### PR TITLE
packaging: add make and spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ node_modules/
 nodevars.bat
 npm
 npm.cmd
+
+# Ignore generated files
+patternfly.spec
+build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+PACKAGE_NAME=patternfly
+VERSION=1.0.3
+MILESTONE=master
+ifneq ($(MILESTONE),)
+SUFFIX:=_$(MILESTONE)
+endif
+PACKAGE_VERSION=$(VERSION)$(SUFFIX)
+PACKAGE_RPM_VERSION=$(VERSION)
+PACKAGE_RPM_RELEASE=0.0.$(MILESTONE)
+ABI=1
+
+PREFIX=/usr/local
+DATAROOT_DIR=$(PREFIX)/share
+PKG_DATA_DIR=$(DATAROOT_DIR)/$(PACKAGE_NAME)
+RESOURCES_DIR=$(DATAROOT_DIR)/patternfly$(ABI)/resources
+
+.SUFFIXES:
+.SUFFIXES: .in
+
+all:	patternfly.spec
+	rm -fr build
+	mkdir -p build/components
+	cp -r dist/* build
+	cp -r components/* build/components/
+	sed -i "s#../../components#../components#g" \
+		build/css/patternfly*.css \
+		$(NULL)
+
+clean:
+	rm -rf build
+
+install:	all
+	install -d -m 0755 "$(DESTDIR)$(RESOURCES_DIR)"
+	cp -r build/* "$(DESTDIR)$(RESOURCES_DIR)"
+	find "$(DESTDIR)$(RESOURCES_DIR)" -type d -exec chmod 0755 {} +
+	find "$(DESTDIR)$(RESOURCES_DIR)" -type f -exec chmod 0644 {} +
+
+.PHONY:	patternfly.spec.in
+dist:	patternfly.spec
+	git ls-files | tar --files-from /proc/self/fd/0 \
+		--xform 's#^#$(PACKAGE_NAME)-$(PACKAGE_VERSION)/#' \
+		-czf "$(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz" \
+		patternfly.spec \
+		$(NULL)
+
+.in:
+	sed \
+		-e 's/@PACKAGE_NAME@/$(PACKAGE_NAME)/g' \
+		-e 's/@PACKAGE_VERSION@/$(PACKAGE_VERSION)/g' \
+		-e 's/@PACKAGE_RPM_VERSION@/$(PACKAGE_RPM_VERSION)/g' \
+		-e 's/@PACKAGE_RPM_RELEASE@/$(PACKAGE_RPM_RELEASE)/g' \
+		$< > $@

--- a/patternfly.spec.in
+++ b/patternfly.spec.in
@@ -1,0 +1,41 @@
+%global make_common_opts \\\
+	PACKAGE_NAME=%{name} \\\
+	RPM_VERSION=%{version} \\\
+	RPM_RELEASE=%{release} \\\
+	DISPLAY_VERSION=%{version}-%{release} \\\
+	PREFIX=%{_prefix} \\\
+	DATAROOT_DIR=%{_datadir} \\\
+	PKG_DATA_DIR=%{_datadir}/%{name} \\\
+	%{nil}
+
+Name:		patternfly1
+Summary:	PatternFly open interface project and its dependencies
+Version:	@PACKAGE_RPM_VERSION@
+Release:	@PACKAGE_RPM_RELEASE@%{?release_suffix}%{?dist}
+License:	ASL 2.0
+URL:		https://github.com/patternfly/patternfly
+Source:		@PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz
+
+BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch:	noarch
+
+%description
+PatternFly open interface project, with dependencies bundled
+
+%prep
+%setup -q -n patternfly-@PACKAGE_VERSION@
+
+%build
+make %{?_smp_mflags} %{make_common_opts}
+
+%install
+rm -rf "%{buildroot}"
+make %{?_smp_mflags} %{make_common_opts} install DESTDIR="%{buildroot}"
+
+%files
+%{_datadir}/%{name}/
+
+%changelog
+* Fri Jun 20 2014 Greg Sheremeta <gshereme@redhat.com> - 1.0.3-1
+- Initial version.
+


### PR DESCRIPTION
make is the core of packaging, may be used by different distributions to
avoid logic duplication.

spec is for rpm based systems.

Signed-off-by: Alon Bar-Lev alon.barlev@gmail.com
