### PR TITLE
Reordered $panel-primary-text in variables.less for SASS compatibility

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -161,6 +161,7 @@
 @tooltip-bg:                                                        #434343;
 @tooltip-max-width:                                                 220px;
 // References variable declared in blocks above
+@panel-primary-text:                                                @body-bg;
 @alert-danger-bg:                                                   @body-bg;
 @alert-danger-border:                                               @brand-danger;
 @alert-danger-text:                                                 @gray-dark;
@@ -200,7 +201,6 @@
 @panel-info-border:                                                 @brand-info;
 @panel-info-heading-bg:                                             @brand-info;
 @panel-info-text:                                                   @panel-primary-text;
-@panel-primary-text:                                                @body-bg;
 @panel-success-border:                                              @brand-success;
 @panel-success-heading-bg:                                          @brand-success;
 @panel-success-text:                                                @panel-primary-text;


### PR DESCRIPTION
I'm working on the [sass version](https://github.com/patternfly/patternfly-sass) of Patternfly and I have some issues with the variable order. Reordering the variables in the LESS version is an easier solution than doing this algorithmically with a parser. Also Bootstrap uses variables ordered by declarations first.
