### PR TITLE
Fixed errors with capitalization in the login sample page.

### DIFF
--- a/tests-src/login.html
+++ b/tests-src/login.html
@@ -33,10 +33,10 @@ resource: true
               <div class="col-xs-8 col-sm-offset-2 col-sm-6 col-md-offset-2 col-md-6">
                 <div class="checkbox">
                   <label>
-                    <input type="checkbox" tabindex="3"> Remember Username
+                    <input type="checkbox" tabindex="3"> Remember username
                   </label>
                 </div>
-                <span class="help-block"> Forgot <a href="#" tabindex="5">Username</a> or <a href="#" tabindex="6">Password</a>?</span>
+                <span class="help-block"> Forgot <a href="#" tabindex="5">username</a> or <a href="#" tabindex="6">password</a>?</span>
               </div>
               <div class="col-xs-4 col-sm-4 col-md-4 submit">
                 <button type="submit" class="btn btn-primary btn-lg" tabindex="4">Log In</button>

--- a/tests/login.html
+++ b/tests/login.html
@@ -53,10 +53,10 @@
               <div class="col-xs-8 col-sm-offset-2 col-sm-6 col-md-offset-2 col-md-6">
                 <div class="checkbox">
                   <label>
-                    <input type="checkbox" tabindex="3"> Remember Username
+                    <input type="checkbox" tabindex="3"> Remember username
                   </label>
                 </div>
-                <span class="help-block"> Forgot <a href="#" tabindex="5">Username</a> or <a href="#" tabindex="6">Password</a>?</span>
+                <span class="help-block"> Forgot <a href="#" tabindex="5">username</a> or <a href="#" tabindex="6">password</a>?</span>
               </div>
               <div class="col-xs-4 col-sm-4 col-md-4 submit">
                 <button type="submit" class="btn btn-primary btn-lg" tabindex="4">Log In</button>


### PR DESCRIPTION
Bug Text:

Sentence style capitalization for "Forgot Username or Password?" therefore it should be "Forgot username or password?"

Should use sentence style capitalization for checkbox labels therefore it should be "Remember username" vs "Remember Username". See: https://docs.google.com/a/redhat.com/document/d/155JhZ5UvOAUBPE1Ryl0PK0L8vLXOsz_CeLJLtDnOixY/edit#heading=h.yqkqzbmhvgms
