### PR TITLE
change default text color to black

### DIFF
--- a/components/bootstrap/less/variables.less
+++ b/components/bootstrap/less/variables.less
@@ -28,7 +28,7 @@
 //** Background color for `<body>`.
 @body-bg:               #fff;
 //** Global text color on `<body>`.
-@text-color:            @gray-dark;
+@text-color:            @gray-base;
 
 //** Global textual link color.
 @link-color:            @brand-primary;


### PR DESCRIPTION
Makes sites much easier to read due to increased
contrast between backround and foreground.

Signed-off-by: Richard Marko rmarko@fedoraproject.org
