### PR TITLE
Explicitly set bootstrap-select's variable overrides in our code

### DIFF
--- a/less/bootstrap-datepicker.less
+++ b/less/bootstrap-datepicker.less
@@ -64,5 +64,8 @@
   }
   .input-group-addon {
     padding: @padding-base-vertical @padding-base-horizontal;
+    line-height: @line-height-base;
+    background-color: @input-group-addon-bg;
+    border-color: @input-group-addon-border-color;
   }
 }


### PR DESCRIPTION
It's better to understand what is overridden and the CSS file can be used instead of LESS.
It also fixes an issue in patternfly-sass, where only the CSS can be used.
