### PR TITLE
Removing data-original-title from tooltip and popover examples

### DIFF
--- a/tests-src/popovers.html
+++ b/tests-src/popovers.html
@@ -6,52 +6,52 @@ resource: true
 ---
       <p>Note: To display the close (X) icon in popovers, add data attribute <strong>data-close="true"</strong> to the trigger button element.</p>
       <div class="bs-example" style="margin-top: 40px;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on right with title and close button" data-close="true">Popover on right with title and close button</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on right with title and close button" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true">Popover on right with title and close button</a>
       </div>
       <div class="bs-example" style="margin-top: 40px;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Close icon with no Title text. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true">Popover on right with close button</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on right with title">Popover on right with title</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on right with title" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy.">Popover on right with title</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Empty Title example.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy.">Popover on right</a>
       </div>
       <hr>
       <div class="bs-example" style="margin-top: 40px;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on left with title and close button" data-close="true" data-placement="left">Popover on left with title and close button</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on left with title and close button" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true" data-placement="left">Popover on left with title and close button</a>
       </div>
       <div class="bs-example" style="margin-top: 40px;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Close icon with no Title text. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true" data-placement="left">Popover on left with close button</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on left with title" data-placement="left">Popover on left with title</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on left with title" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="left">Popover on left with title</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Empty Title example.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="left">Popover on left</a>
       </div>
       <hr>
       <div class="bs-example" style="margin-top: 40px;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on left with title and close button" data-close="true" data-placement="top">Popover on top with title and close button</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on left with title and close button" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true" data-placement="top">Popover on top with title and close button</a>
       </div>
       <div class="bs-example" style="margin-top: 40px;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Close icon with no Title text. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true" data-placement="top">Popover on top with close button</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on top with title" data-placement="top">Popover on top with title</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on top with title" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="top">Popover on top with title</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Empty Title example.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="top">Popover on top</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Empty Title example.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about dataa smartproxy." data-placement="top">Popover on top</a>
       </div>
       <hr>
       <div class="bs-example" style="margin-top: 40px;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on left with title and close button" data-close="true" data-placement="bottom">Popover on bottom with title and close button</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on left with title and close button" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true" data-placement="bottom">Popover on bottom with title and close button</a>
       </div>
       <div class="bs-example" style="margin-top: 40px;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Close icon with no Title text. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true" data-placement="bottom">Popover on bottom with close button</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on bottom with title" data-placement="bottom">Popover on bottom with title</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on bottom with title" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="bottom">Popover on bottom with title</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Empty Title example.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="bottom">Popover on bottom</a>

--- a/tests-src/tooltip.html
+++ b/tests-src/tooltip.html
@@ -5,17 +5,17 @@ title: Tooltip
 resource: true
 ---
       <div class="tooltip-demo">
-        <a href="#" class="btn btn-default" data-toggle="tooltip" data-original-title="Caribbean Monk Seal, Barbary Lion, Seaside Sparrow">Caribbean Monk Seal, Barbary L...</a>
+        <a href="#" class="btn btn-default" data-toggle="tooltip" title="Caribbean Monk Seal, Barbary Lion, Seaside Sparrow">Caribbean Monk Seal, Barbary L...</a>
       </div>
       <br>
       <h2>Tooltip Directions</h2>
       <div class="tooltip-demo">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis pretium mi at ante luctus dapibus. Fusce in tempus felis. Suspendisse tristique diam vel.</p>
         <div class="bs-example-tooltips">
-          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="left" title="" data-original-title="Tooltip on left">Tooltip on left</button>
+          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="left" title="Tooltip on left">Tooltip on left</button>
           <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Tooltip on top">Tooltip on top</button>
           <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Tooltip on bottom">Tooltip on bottom</button>
-          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" title="" data-original-title="Tooltip on right">Tooltip on right</button>
+          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" title="Tooltip on right">Tooltip on right</button>
         </div>
         <p style="margin-top: 10px;">Suspendisse tristique diam vel hendrerit aliquet. Vestibulum laoreet nisi ac egestas porttitor. Donec tempus elit convallis.</p>
       </div>

--- a/tests/popovers.html
+++ b/tests/popovers.html
@@ -40,52 +40,52 @@
       <hr>
       <p>Note: To display the close (X) icon in popovers, add data attribute <strong>data-close="true"</strong> to the trigger button element.</p>
       <div class="bs-example" style="margin-top: 40px;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on right with title and close button" data-close="true">Popover on right with title and close button</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on right with title and close button" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true">Popover on right with title and close button</a>
       </div>
       <div class="bs-example" style="margin-top: 40px;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Close icon with no Title text. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true">Popover on right with close button</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on right with title">Popover on right with title</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on right with title" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy.">Popover on right with title</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Empty Title example.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy.">Popover on right</a>
       </div>
       <hr>
       <div class="bs-example" style="margin-top: 40px;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on left with title and close button" data-close="true" data-placement="left">Popover on left with title and close button</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on left with title and close button" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true" data-placement="left">Popover on left with title and close button</a>
       </div>
       <div class="bs-example" style="margin-top: 40px;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Close icon with no Title text. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true" data-placement="left">Popover on left with close button</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on left with title" data-placement="left">Popover on left with title</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on left with title" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="left">Popover on left with title</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Empty Title example.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="left">Popover on left</a>
       </div>
       <hr>
       <div class="bs-example" style="margin-top: 40px;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on left with title and close button" data-close="true" data-placement="top">Popover on top with title and close button</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on left with title and close button" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true" data-placement="top">Popover on top with title and close button</a>
       </div>
       <div class="bs-example" style="margin-top: 40px;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Close icon with no Title text. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true" data-placement="top">Popover on top with close button</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on top with title" data-placement="top">Popover on top with title</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on top with title" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="top">Popover on top with title</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Empty Title example.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="top">Popover on top</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Empty Title example.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about dataa smartproxy." data-placement="top">Popover on top</a>
       </div>
       <hr>
       <div class="bs-example" style="margin-top: 40px;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on left with title and close button" data-close="true" data-placement="bottom">Popover on bottom with title and close button</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on left with title and close button" data-content="This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true" data-placement="bottom">Popover on bottom with title and close button</a>
       </div>
       <div class="bs-example" style="margin-top: 40px;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Close icon with no Title text. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-close="true" data-placement="bottom">Popover on bottom with close button</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
-        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-original-title="Popover on bottom with title" data-placement="bottom">Popover on bottom with title</a>
+        <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="Popover on bottom with title" data-content="Popover with no Close icon.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="bottom">Popover on bottom with title</a>
       </div>
       <div class="bs-example" style="margin: 40px 0;">
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Empty Title example.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="bottom">Popover on bottom</a>
@@ -105,6 +105,7 @@
           $('[data-toggle=popover]').popovers()
         });
       </script>
+
     </div><!-- /container -->
   </body>
 </html>

--- a/tests/tooltip.html
+++ b/tests/tooltip.html
@@ -39,17 +39,17 @@
       </div>
       <hr>
       <div class="tooltip-demo">
-        <a href="#" class="btn btn-default" data-toggle="tooltip" data-original-title="Caribbean Monk Seal, Barbary Lion, Seaside Sparrow">Caribbean Monk Seal, Barbary L...</a>
+        <a href="#" class="btn btn-default" data-toggle="tooltip" title="Caribbean Monk Seal, Barbary Lion, Seaside Sparrow">Caribbean Monk Seal, Barbary L...</a>
       </div>
       <br>
       <h2>Tooltip Directions</h2>
       <div class="tooltip-demo">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis pretium mi at ante luctus dapibus. Fusce in tempus felis. Suspendisse tristique diam vel.</p>
         <div class="bs-example-tooltips">
-          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="left" title="" data-original-title="Tooltip on left">Tooltip on left</button>
+          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="left" title="Tooltip on left">Tooltip on left</button>
           <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Tooltip on top">Tooltip on top</button>
           <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Tooltip on bottom">Tooltip on bottom</button>
-          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" title="" data-original-title="Tooltip on right">Tooltip on right</button>
+          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" title="Tooltip on right">Tooltip on right</button>
         </div>
         <p style="margin-top: 10px;">Suspendisse tristique diam vel hendrerit aliquet. Vestibulum laoreet nisi ac egestas porttitor. Donec tempus elit convallis.</p>
       </div>
@@ -62,6 +62,7 @@
           });
         });
       </script>
+
     </div><!-- /container -->
   </body>
 </html>


### PR DESCRIPTION
Bug fix:  instances of "data-original-title" attribute should be "title" in the markup ("data-original-title" is the javascript-generated attribute).

@andresgalante, @erundle: review and merge, please.
