### PR TITLE
Removing package.json and Gruntfile.js from Bower.json ignore

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,13 +13,10 @@
     "**/.*",
     "node_modules",
     "bower_components",
-    "app/components",
     "test",
     "tests",
-    "package.json",
-    "Gruntfile.js",
-    "PatternFlyIcons-webfont.json",
     "Makefile",
+    "PatternFlyIcons-webfont.json",
     "patternfly.spec.in"
   ],
   "devDependencies": {


### PR DESCRIPTION
So that they are included in the package distributed via Bower

@erundle, review and merge, please?
