### PR TITLE
Removing unnecessary inline styles from card examples

### DIFF
--- a/tests-src/_includes/cards.html
+++ b/tests-src/_includes/cards.html
@@ -822,14 +822,14 @@
       <div class="row row-cards-pf">
       <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
         <div class="col-xs-12 col-sm-5 col-md-5">
-          <div class="card-pf" style="height: 180px;">
-            <h2 class="card-pf-title" style="height: 17px;">
+          <div class="card-pf">
+            <h2 class="card-pf-title">
               Card Title
             </h2>
-            <div class="card-pf-body" style="height: 40px;">
+            <div class="card-pf-body">
               <p>[card contents]</p>
             </div>
-            <div class="card-pf-footer" style="">
+            <div class="card-pf-footer">
               <div class="dropdown card-pf-time-frame-filter">
                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                   Last 30 Days <span class="caret"></span>
@@ -848,11 +848,11 @@
           </div>
         </div>
         <div class="col-xs-12 col-sm-7 col-md-7">
-          <div class="card-pf" style="height: 180px;">
-            <h2 class="card-pf-title" style="height: 17px;">
+          <div class="card-pf">
+            <h2 class="card-pf-title">
               Card Title
             </h2>
-            <div class="card-pf-body" style="height: 40px;">
+            <div class="card-pf-body">
               <p>[card contents]</p>
             </div>
           </div>

--- a/tests/cards.html
+++ b/tests/cards.html
@@ -944,14 +944,14 @@
       <div class="row row-cards-pf">
       <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
         <div class="col-xs-12 col-sm-5 col-md-5">
-          <div class="card-pf" style="height: 180px;">
-            <h2 class="card-pf-title" style="height: 17px;">
+          <div class="card-pf">
+            <h2 class="card-pf-title">
               Card Title
             </h2>
-            <div class="card-pf-body" style="height: 40px;">
+            <div class="card-pf-body">
               <p>[card contents]</p>
             </div>
-            <div class="card-pf-footer" style="">
+            <div class="card-pf-footer">
               <div class="dropdown card-pf-time-frame-filter">
                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                   Last 30 Days <span class="caret"></span>
@@ -970,11 +970,11 @@
           </div>
         </div>
         <div class="col-xs-12 col-sm-7 col-md-7">
-          <div class="card-pf" style="height: 180px;">
-            <h2 class="card-pf-title" style="height: 17px;">
+          <div class="card-pf">
+            <h2 class="card-pf-title">
               Card Title
             </h2>
-            <div class="card-pf-body" style="height: 40px;">
+            <div class="card-pf-body">
               <p>[card contents]</p>
             </div>
           </div>

--- a/tests/layout-alt-fixed-inner-scroll.html
+++ b/tests/layout-alt-fixed-inner-scroll.html
@@ -985,14 +985,14 @@
       <div class="row row-cards-pf">
       <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
         <div class="col-xs-12 col-sm-5 col-md-5">
-          <div class="card-pf" style="height: 180px;">
-            <h2 class="card-pf-title" style="height: 17px;">
+          <div class="card-pf">
+            <h2 class="card-pf-title">
               Card Title
             </h2>
-            <div class="card-pf-body" style="height: 40px;">
+            <div class="card-pf-body">
               <p>[card contents]</p>
             </div>
-            <div class="card-pf-footer" style="">
+            <div class="card-pf-footer">
               <div class="dropdown card-pf-time-frame-filter">
                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                   Last 30 Days <span class="caret"></span>
@@ -1011,11 +1011,11 @@
           </div>
         </div>
         <div class="col-xs-12 col-sm-7 col-md-7">
-          <div class="card-pf" style="height: 180px;">
-            <h2 class="card-pf-title" style="height: 17px;">
+          <div class="card-pf">
+            <h2 class="card-pf-title">
               Card Title
             </h2>
-            <div class="card-pf-body" style="height: 40px;">
+            <div class="card-pf-body">
               <p>[card contents]</p>
             </div>
           </div>

--- a/tests/layout-alt-fixed-with-footer-inner-scroll.html
+++ b/tests/layout-alt-fixed-with-footer-inner-scroll.html
@@ -985,14 +985,14 @@
       <div class="row row-cards-pf">
       <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
         <div class="col-xs-12 col-sm-5 col-md-5">
-          <div class="card-pf" style="height: 180px;">
-            <h2 class="card-pf-title" style="height: 17px;">
+          <div class="card-pf">
+            <h2 class="card-pf-title">
               Card Title
             </h2>
-            <div class="card-pf-body" style="height: 40px;">
+            <div class="card-pf-body">
               <p>[card contents]</p>
             </div>
-            <div class="card-pf-footer" style="">
+            <div class="card-pf-footer">
               <div class="dropdown card-pf-time-frame-filter">
                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                   Last 30 Days <span class="caret"></span>
@@ -1011,11 +1011,11 @@
           </div>
         </div>
         <div class="col-xs-12 col-sm-7 col-md-7">
-          <div class="card-pf" style="height: 180px;">
-            <h2 class="card-pf-title" style="height: 17px;">
+          <div class="card-pf">
+            <h2 class="card-pf-title">
               Card Title
             </h2>
-            <div class="card-pf-body" style="height: 40px;">
+            <div class="card-pf-body">
               <p>[card contents]</p>
             </div>
           </div>

--- a/tests/layout-alt-fixed-with-footer.html
+++ b/tests/layout-alt-fixed-with-footer.html
@@ -985,14 +985,14 @@
       <div class="row row-cards-pf">
       <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
         <div class="col-xs-12 col-sm-5 col-md-5">
-          <div class="card-pf" style="height: 180px;">
-            <h2 class="card-pf-title" style="height: 17px;">
+          <div class="card-pf">
+            <h2 class="card-pf-title">
               Card Title
             </h2>
-            <div class="card-pf-body" style="height: 40px;">
+            <div class="card-pf-body">
               <p>[card contents]</p>
             </div>
-            <div class="card-pf-footer" style="">
+            <div class="card-pf-footer">
               <div class="dropdown card-pf-time-frame-filter">
                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                   Last 30 Days <span class="caret"></span>
@@ -1011,11 +1011,11 @@
           </div>
         </div>
         <div class="col-xs-12 col-sm-7 col-md-7">
-          <div class="card-pf" style="height: 180px;">
-            <h2 class="card-pf-title" style="height: 17px;">
+          <div class="card-pf">
+            <h2 class="card-pf-title">
               Card Title
             </h2>
-            <div class="card-pf-body" style="height: 40px;">
+            <div class="card-pf-body">
               <p>[card contents]</p>
             </div>
           </div>

--- a/tests/layout-alt-fixed.html
+++ b/tests/layout-alt-fixed.html
@@ -985,14 +985,14 @@
       <div class="row row-cards-pf">
       <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
         <div class="col-xs-12 col-sm-5 col-md-5">
-          <div class="card-pf" style="height: 180px;">
-            <h2 class="card-pf-title" style="height: 17px;">
+          <div class="card-pf">
+            <h2 class="card-pf-title">
               Card Title
             </h2>
-            <div class="card-pf-body" style="height: 40px;">
+            <div class="card-pf-body">
               <p>[card contents]</p>
             </div>
-            <div class="card-pf-footer" style="">
+            <div class="card-pf-footer">
               <div class="dropdown card-pf-time-frame-filter">
                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                   Last 30 Days <span class="caret"></span>
@@ -1011,11 +1011,11 @@
           </div>
         </div>
         <div class="col-xs-12 col-sm-7 col-md-7">
-          <div class="card-pf" style="height: 180px;">
-            <h2 class="card-pf-title" style="height: 17px;">
+          <div class="card-pf">
+            <h2 class="card-pf-title">
               Card Title
             </h2>
-            <div class="card-pf-body" style="height: 40px;">
+            <div class="card-pf-body">
               <p>[card contents]</p>
             </div>
           </div>


### PR DESCRIPTION
Some unnecessary inline styles snuck in to the card examples.

@andresgalante or @erundle, review and merge, please?
