### PR TITLE
Donut tooltip label fix

### DIFF
--- a/tests-src/_includes/cards.html
+++ b/tests-src/_includes/cards.html
@@ -487,7 +487,7 @@
                       tooltip: {
                         contents: function (d) {
                           return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                                  Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                                  Math.round(d[0].ratio * 100) + '%' + ' GB ' + d[0].name +
                                   '</span>';
                         }
                       },
@@ -587,7 +587,7 @@
                       tooltip: {
                         contents: function (d) {
                           return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                                  Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                                  Math.round(d[0].ratio * 100) + '%' + ' Gbps ' + d[0].name +
                                   '</span>';
                         }
                       },
@@ -698,7 +698,7 @@
                   tooltip: {
                     contents: function (d) {
                       return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                              Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                              Math.round(d[0].ratio * 100) + '%' + ' Gbps ' + d[0].name +
                               '</span>';
                     }
                   },

--- a/tests/cards.html
+++ b/tests/cards.html
@@ -609,7 +609,7 @@
                       tooltip: {
                         contents: function (d) {
                           return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                                  Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                                  Math.round(d[0].ratio * 100) + '%' + ' GB ' + d[0].name +
                                   '</span>';
                         }
                       },
@@ -709,7 +709,7 @@
                       tooltip: {
                         contents: function (d) {
                           return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                                  Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                                  Math.round(d[0].ratio * 100) + '%' + ' Gbps ' + d[0].name +
                                   '</span>';
                         }
                       },
@@ -820,7 +820,7 @@
                   tooltip: {
                     contents: function (d) {
                       return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                              Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                              Math.round(d[0].ratio * 100) + '%' + ' Gbps ' + d[0].name +
                               '</span>';
                     }
                   },

--- a/tests/layout-alt-fixed-inner-scroll.html
+++ b/tests/layout-alt-fixed-inner-scroll.html
@@ -650,7 +650,7 @@
                       tooltip: {
                         contents: function (d) {
                           return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                                  Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                                  Math.round(d[0].ratio * 100) + '%' + ' GB ' + d[0].name +
                                   '</span>';
                         }
                       },
@@ -750,7 +750,7 @@
                       tooltip: {
                         contents: function (d) {
                           return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                                  Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                                  Math.round(d[0].ratio * 100) + '%' + ' Gbps ' + d[0].name +
                                   '</span>';
                         }
                       },
@@ -861,7 +861,7 @@
                   tooltip: {
                     contents: function (d) {
                       return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                              Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                              Math.round(d[0].ratio * 100) + '%' + ' Gbps ' + d[0].name +
                               '</span>';
                     }
                   },

--- a/tests/layout-alt-fixed-with-footer-inner-scroll.html
+++ b/tests/layout-alt-fixed-with-footer-inner-scroll.html
@@ -650,7 +650,7 @@
                       tooltip: {
                         contents: function (d) {
                           return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                                  Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                                  Math.round(d[0].ratio * 100) + '%' + ' GB ' + d[0].name +
                                   '</span>';
                         }
                       },
@@ -750,7 +750,7 @@
                       tooltip: {
                         contents: function (d) {
                           return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                                  Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                                  Math.round(d[0].ratio * 100) + '%' + ' Gbps ' + d[0].name +
                                   '</span>';
                         }
                       },
@@ -861,7 +861,7 @@
                   tooltip: {
                     contents: function (d) {
                       return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                              Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                              Math.round(d[0].ratio * 100) + '%' + ' Gbps ' + d[0].name +
                               '</span>';
                     }
                   },

--- a/tests/layout-alt-fixed-with-footer.html
+++ b/tests/layout-alt-fixed-with-footer.html
@@ -650,7 +650,7 @@
                       tooltip: {
                         contents: function (d) {
                           return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                                  Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                                  Math.round(d[0].ratio * 100) + '%' + ' GB ' + d[0].name +
                                   '</span>';
                         }
                       },
@@ -750,7 +750,7 @@
                       tooltip: {
                         contents: function (d) {
                           return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                                  Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                                  Math.round(d[0].ratio * 100) + '%' + ' Gbps ' + d[0].name +
                                   '</span>';
                         }
                       },
@@ -861,7 +861,7 @@
                   tooltip: {
                     contents: function (d) {
                       return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                              Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                              Math.round(d[0].ratio * 100) + '%' + ' Gbps ' + d[0].name +
                               '</span>';
                     }
                   },

--- a/tests/layout-alt-fixed.html
+++ b/tests/layout-alt-fixed.html
@@ -650,7 +650,7 @@
                       tooltip: {
                         contents: function (d) {
                           return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                                  Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                                  Math.round(d[0].ratio * 100) + '%' + ' GB ' + d[0].name +
                                   '</span>';
                         }
                       },
@@ -750,7 +750,7 @@
                       tooltip: {
                         contents: function (d) {
                           return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                                  Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                                  Math.round(d[0].ratio * 100) + '%' + ' Gbps ' + d[0].name +
                                   '</span>';
                         }
                       },
@@ -861,7 +861,7 @@
                   tooltip: {
                     contents: function (d) {
                       return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
-                              Math.round(d[0].ratio * 100) + '%' + ' MHz ' + d[0].name +
+                              Math.round(d[0].ratio * 100) + '%' + ' Gbps ' + d[0].name +
                               '</span>';
                     }
                   },


### PR DESCRIPTION
Three of the four donut chart tooltips had the incorrect unit specified.
