### PR TITLE
Adding bootstrap-datetimepicker.min.css to Wiredep exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ exclude: [
   "bower_components/datatables/media/css/jquery.dataTables.css",
   "bower_components/datatables-colreorder/css/dataTables.colReorder.css",
   "bower_components/datatables-colvis/css/dataTables.colVis.css",
+  "bower_components/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css",
   "bower_components/font-awesome/css/font-awesome.css",
   "bower_components/google-code-prettify/bin/prettify.min.css"
 ],


### PR DESCRIPTION
Since Bootstrap Date Time Picker CSS is already included in PatternFly, the Wiredep exclude needs to be updated to include bootstrap-datetimepicker.min.css
