### PR TITLE
bootstrap-treeview depends on bower and phantomjs #236

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "bootstrap-select": "1.7.3",
     "bootstrap-switch": "3.3.2",
     "bootstrap-touchspin": "3.1.1",
-    "bootstrap-treeview": "1.2.0",
     "c3": "0.4.10",
     "datatables": "1.10.9",
     "datatables.net-colreorder": "1.3.1",
@@ -35,6 +34,9 @@
     "grunt-jekyll": "^0.4.2",
     "grunt-jslint": "^1.1.14",
     "matchdep": "~0.3.0"
+  },
+  "optionalDependencies": {
+    "bootstrap-treeview": "~1.2.0"
   },
   "description": "This reference implementation of PatternFly is based on [Bootstrap v3](http://getbootstrap.com/).  Think of PatternFly as a \"skinned\" version of Bootstrap with additional components and customizations.",
   "repository": {


### PR DESCRIPTION
Moved bootstrap-treeview into 'optionalDependencies' in the package.json file.
Confirmed  bootstrap-treeview is installed in node_modules.
