### PR TITLE
PTNFLY-236: make all dependencies (but jquery and bootstrap) optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,22 +5,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bootstrap": "3.3.5",
-    "bootstrap-datepicker": "1.4.0",
-    "bootstrap-select": "1.7.3",
-    "bootstrap-switch": "3.3.2",
-    "bootstrap-touchspin": "3.1.1",
-    "bootstrap-treeview": "1.2.0",
-    "c3": "0.4.10",
-    "datatables": "1.10.9",
-    "datatables.net-colreorder": "1.3.1",
-    "drmonty-datatables-colvis": "1.1.2",
-    "font-awesome": "4.3.0",
-    "google-code-prettify": "1.0.1",
-    "jquery": "2.1.4",
-    "jquery-match-height": "0.6.0",
-    "patternfly-bootstrap-combobox": "~1.0.0",
-    "eonasdan-bootstrap-datetimepicker": "4.15.35",
-    "moment": "2.11.2"
+    "jquery": "2.1.4"
   },
   "devDependencies": {
     "connect-livereload": "~0.3.0",
@@ -35,6 +20,23 @@
     "grunt-jekyll": "^0.4.2",
     "grunt-jslint": "^1.1.14",
     "matchdep": "~0.3.0"
+  },
+  "optionalDependencies": {
+    "bootstrap-datepicker": "1.4.0",
+    "bootstrap-select": "1.7.3",
+    "bootstrap-switch": "3.3.2",
+    "bootstrap-touchspin": "3.1.1",
+    "bootstrap-treeview": "1.2.0",
+    "c3": "0.4.10",
+    "datatables": "1.10.9",
+    "datatables.net-colreorder": "1.3.1",
+    "drmonty-datatables-colvis": "1.1.2",
+    "font-awesome": "4.3.0",
+    "google-code-prettify": "1.0.1",
+    "jquery-match-height": "0.6.0",
+    "patternfly-bootstrap-combobox": "~1.0.0",
+    "eonasdan-bootstrap-datetimepicker": "4.15.35",
+    "moment": "2.11.2"
   },
   "description": "This reference implementation of PatternFly is based on [Bootstrap v3](http://getbootstrap.com/).  Think of PatternFly as a \"skinned\" version of Bootstrap with additional components and customizations.",
   "repository": {


### PR DESCRIPTION
Changes that I have suggested in #236.

This solution allows one to install PatternFly without any extra dependencies using `npm install --no-optional` command.
