### PR TITLE
PTNFLY-1334 Migrate all "Forms and Controls" Content Over to the Site

### DIFF
--- a/tests-src/_includes/cards.html
+++ b/tests-src/_includes/cards.html
@@ -182,13 +182,13 @@
       <div class="row row-cards-pf">
         <div class="col-md-12">
           <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
-          {% include widgets/cards/utilization-trend-multiple-metrics.html chart3="chart-pf-donut-1" chart4="chart-pf-sparkline-1" chart5="chart-pf-donut-2" chart6="chart-pf-sparkline-2" chart7="chart-pf-donut-3" chart8="chart-pf-sparkline-3" %}
+          {% include widgets/cards/utilization-trend-multiple-metrics.html id3="chart-pf-donut-1" id4="chart-pf-sparkline-1" id5="chart-pf-donut-2" id6="chart-pf-sparkline-2" id7="chart-pf-donut-3" id8="chart-pf-sparkline-3" %}
         </div>
       </div><!-- /row -->
       <div class="row row-cards-pf">
         <div class="col-xs-12 col-sm-4 col-md-4">
           <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
-          {% include widgets/cards/utilization-trend-single-metric.html chart1="chart-pf-donut-4" chart2="chart-pf-sparkline-4" %}
+          {% include widgets/cards/utilization-trend-single-metric.html id1="chart-pf-donut-4" id2="chart-pf-sparkline-4" %}
         </div>
       </div><!-- /row -->
       <div class="row row-cards-pf">

--- a/tests-src/_includes/widgets/cards/utilization-trend-multiple-metrics.html
+++ b/tests-src/_includes/widgets/cards/utilization-trend-multiple-metrics.html
@@ -16,11 +16,11 @@
               <span class="card-pf-utilization-card-details-line-2">of 1000 MHz</span>
             </span>
         </p>
-        <div id="{{ include.chart3 }}"></div>
-        <div class="chart-pf-sparkline" id="{{ include.chart4 }}"></div>
+        <div id="{{include.id3}}"></div>
+        <div class="chart-pf-sparkline" id="{{include.id4}}"></div>
         <script>
           var donutConfig = $().c3ChartDefaults().getDefaultDonutConfig('A');
-          donutConfig.bindto = '#{{ include.chart3 }}';
+          donutConfig.bindto = '#{{include.id3}}';
           donutConfig.color =  {
             pattern: ["#cc0000","#D1D1D1"]
           };
@@ -44,13 +44,13 @@
           };
 
           var chart1 = c3.generate(donutConfig);
-          var donutChartTitle = d3.select("#{{ include.chart3 }}").select('text.c3-chart-arcs-title');
+          var donutChartTitle = d3.select("#{{include.id3}}").select('text.c3-chart-arcs-title');
           donutChartTitle.text("");
           donutChartTitle.insert('tspan').text("950").classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
           donutChartTitle.insert('tspan').text("MHz Used").classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
 
           var sparklineConfig = $().c3ChartDefaults().getDefaultSparklineConfig();
-          sparklineConfig.bindto = '#{{ include.chart4 }}';
+          sparklineConfig.bindto = '#{{include.id4}}';
           sparklineConfig.data = {
             columns: [
               ['%', 10, 50, 28, 20, 31, 27, 60, 36, 52, 55, 62, 68, 69, 88, 74, 88, 95],
@@ -69,11 +69,11 @@
               <span class="card-pf-utilization-card-details-line-2">of 432 GB</span>
             </span>
         </p>
-        <div id="{{ include.chart5}}"></div>
-        <div class="chart-pf-sparkline" id="{{ include.chart6 }}"></div>
+        <div id="{{include.id5}}"></div>
+        <div class="chart-pf-sparkline" id="{{include.id6}}"></div>
         <script>
           var donutConfig = $().c3ChartDefaults().getDefaultDonutConfig('A');
-          donutConfig.bindto = '#{{ include.chart5 }}';
+          donutConfig.bindto = '#{{include.id5}}';
           donutConfig.color =  {
             pattern: ["#3f9c35","#D1D1D1"]
           };
@@ -97,13 +97,13 @@
           };
 
           var chart3 = c3.generate(donutConfig);
-          var donutChartTitle = d3.select("#{{ include.chart5}}").select('text.c3-chart-arcs-title');
+          var donutChartTitle = d3.select("#{{include.id5}}").select('text.c3-chart-arcs-title');
           donutChartTitle.text("");
           donutChartTitle.insert('tspan').text("176").classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
           donutChartTitle.insert('tspan').text("GB Used").classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
 
           var sparklineConfig = $().c3ChartDefaults().getDefaultSparklineConfig();
-          sparklineConfig.bindto = '#{{ include.chart6 }}';
+          sparklineConfig.bindto = '#{{include.id6}}';
           sparklineConfig.data = {
             columns: [
               ['%', 35, 36, 20, 30, 31, 22, 44, 36, 40, 41, 55, 52, 48, 48, 50, 40, 41],
@@ -122,11 +122,11 @@
               <span class="card-pf-utilization-card-details-line-2">of 1300 Gbps</span>
             </span>
         </p>
-        <div id="{{ include.chart7 }}"></div>
-        <div class="chart-pf-sparkline" id="{{ include.chart8 }}"></div>
+        <div id="{{include.id7}}"></div>
+        <div class="chart-pf-sparkline" id="{{include.id8}}"></div>
         <script>
           var donutConfig = $().c3ChartDefaults().getDefaultDonutConfig('A');
-          donutConfig.bindto = '#{{ include.chart7 }}';
+          donutConfig.bindto = '#{{include.id7}}';
           donutConfig.color =  {
             pattern: ["#EC7A08","#D1D1D1"]
           };
@@ -150,13 +150,13 @@
           };
 
           var chart5 = c3.generate(donutConfig);
-          var donutChartTitle = d3.select("#{{ include.chart7 }}").select('text.c3-chart-arcs-title');
+          var donutChartTitle = d3.select("#{{include.id7}}").select('text.c3-chart-arcs-title');
           donutChartTitle.text("");
           donutChartTitle.insert('tspan').text("1100").classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
           donutChartTitle.insert('tspan').text("Gbps Used").classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
 
           var sparklineConfig = $().c3ChartDefaults().getDefaultSparklineConfig();
-          sparklineConfig.bindto = '#{{ include.chart8 }}';
+          sparklineConfig.bindto = '#{{include.id8}}';
           sparklineConfig.data = {
             columns: [
               ['%', 60, 55, 70, 44, 31, 67, 54, 46, 58, 75, 62, 68, 69, 88, 74, 88, 85],

--- a/tests-src/_includes/widgets/cards/utilization-trend-single-metric.html
+++ b/tests-src/_includes/widgets/cards/utilization-trend-single-metric.html
@@ -10,13 +10,13 @@
           <span class="card-pf-utilization-card-details-line-2">of 1300 Gbps</span>
         </span>
     </p>
-    <div id="{{ include.chart1 }}"></div>
-    <div class="chart-pf-sparkline" id="{{ include.chart2 }}"></div>
+    <div id="{{include.id1}}"></div>
+    <div class="chart-pf-sparkline" id="{{include.id2}}"></div>
     <script>
       var c3ChartDefaults = $().c3ChartDefaults();
 
       var donutConfig = c3ChartDefaults.getDefaultDonutConfig('A');
-      donutConfig.bindto = '#{{ include.chart1 }}';
+      donutConfig.bindto = '#{{include.id1}}';
       donutConfig.color =  {
         pattern: ["#EC7A08","#D1D1D1"]
       };
@@ -40,13 +40,13 @@
       };
 
       var chart1 = c3.generate(donutConfig);
-      var donutChartTitle = d3.select("#{{ include.chart1 }}").select('text.c3-chart-arcs-title');
+      var donutChartTitle = d3.select("#{{include.id1}}").select('text.c3-chart-arcs-title');
       donutChartTitle.text("");
       donutChartTitle.insert('tspan').text("1100").classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
       donutChartTitle.insert('tspan').text("Gpbs Used").classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
 
       var sparklineConfig = c3ChartDefaults.getDefaultSparklineConfig();
-      sparklineConfig.bindto = '#{{ include.chart2 }}';
+      sparklineConfig.bindto = '#{{include.id2}}';
       sparklineConfig.data = {
         columns: [
           ['%', 60, 55, 70, 44, 31, 67, 54, 46, 58, 75, 62, 68, 69, 88, 74, 88, 85],

--- a/tests-src/_includes/widgets/charts/area-multiple.html
+++ b/tests-src/_includes/widgets/charts/area-multiple.html
@@ -1,4 +1,4 @@
-<div id="{{ include.chart1 }}" class="line-chart-pf"></div>
+<div id="{{include.id}}" class="line-chart-pf"></div>
 <script>
   var areaChartDataColumns = [
     ['data1', 350, 400, 350, 0],
@@ -12,7 +12,7 @@
 
   var c3ChartDefaults = $().c3ChartDefaults();
   var areaChartConfig = c3ChartDefaults.getDefaultAreaConfig();
-  areaChartConfig.bindto = '#{{ include.chart1 }}';
+  areaChartConfig.bindto = '#{{include.id}}';
   areaChartConfig.data = {
     columns: areaChartDataColumns,
     type: 'area-spline'

--- a/tests-src/_includes/widgets/charts/area-single.html
+++ b/tests-src/_includes/widgets/charts/area-single.html
@@ -1,4 +1,4 @@
-<div id="{{ include.chart1 }}" class="line-chart-pf"></div>
+<div id="{{include.id}}" class="line-chart-pf"></div>
 <script>
   var areaChartDataColumns = [
     ['data1', 350, 400, 350, 0],
@@ -12,7 +12,7 @@
 
   var c3ChartDefaults = $().c3ChartDefaults();
   var singleAreaChartConfig = c3ChartDefaults.getDefaultSingleAreaConfig();
-  singleAreaChartConfig.bindto = '#{{ include.chart1 }}';
+  singleAreaChartConfig.bindto = '#{{include.id}}';
   singleAreaChartConfig.data = {
     columns: singleAreaChartDataColumns,
     type: 'area-spline'

--- a/tests-src/_includes/widgets/charts/bar-horizontal-group.html
+++ b/tests-src/_includes/widgets/charts/bar-horizontal-group.html
@@ -1,4 +1,4 @@
-<div id="{{ include.chart1 }}"></div>
+<div id="{{include.id}}"></div>
 <script>
   var c3ChartDefaults = $().c3ChartDefaults();
 
@@ -30,7 +30,7 @@
   };
 
   var groupedHorizontalBarChartConfig = $().c3ChartDefaults().getDefaultGroupedBarConfig();
-  groupedHorizontalBarChartConfig.bindto = '#{{ include.chart1 }}';
+  groupedHorizontalBarChartConfig.bindto = '#{{include.id}}';
   groupedHorizontalBarChartConfig.axis = {
     rotated: true,
     x: {

--- a/tests-src/_includes/widgets/charts/bar-horizontal.html
+++ b/tests-src/_includes/widgets/charts/bar-horizontal.html
@@ -1,4 +1,4 @@
-<div id="{{ include.chart1 }}"></div>
+<div id="{{include.id}}"></div>
 <script>
   var c3ChartDefaults = $().c3ChartDefaults();
 
@@ -14,7 +14,7 @@
   ];
 
   var horizontalBarChartConfig = $().c3ChartDefaults().getDefaultBarConfig(categories);
-  horizontalBarChartConfig.bindto = '#{{ include.chart1 }}';
+  horizontalBarChartConfig.bindto = '#{{include.id}}';
   horizontalBarChartConfig.axis = {
     rotated: true,
     x: {

--- a/tests-src/_includes/widgets/charts/bar-vertical-group.html
+++ b/tests-src/_includes/widgets/charts/bar-vertical-group.html
@@ -1,4 +1,4 @@
-<div id="{{ include.chart1 }}"></div>
+<div id="{{include.id}}"></div>
 <script>
   var c3ChartDefaults = $().c3ChartDefaults();
 
@@ -30,7 +30,7 @@
   };
 
   var groupedVerticalBarChartConfig = $().c3ChartDefaults().getDefaultGroupedBarConfig();
-  groupedVerticalBarChartConfig.bindto = '#{{ include.chart1 }}';
+  groupedVerticalBarChartConfig.bindto = '#{{include.id}}';
   groupedVerticalBarChartConfig.axis = {
     x: {
       categories: groupedcCategories,

--- a/tests-src/_includes/widgets/charts/bar-vertical.html
+++ b/tests-src/_includes/widgets/charts/bar-vertical.html
@@ -1,4 +1,4 @@
-<div id="{{ include.chart1 }}"></div>
+<div id="{{include.id}}"></div>
 <script>
   var c3ChartDefaults = $().c3ChartDefaults();
 
@@ -14,7 +14,7 @@
   ];
 
   var verticalBarChartConfig = $().c3ChartDefaults().getDefaultBarConfig(categories);
-  verticalBarChartConfig.bindto = '#{{ include.chart1 }}';
+  verticalBarChartConfig.bindto = '#{{include.id}}';
   verticalBarChartConfig.axis = {
     x: {
       categories: categories,

--- a/tests-src/_includes/widgets/charts/donut-mini.html
+++ b/tests-src/_includes/widgets/charts/donut-mini.html
@@ -1,4 +1,4 @@
-<div id="{{ include.chart1 }}" class="donut-chart-pf"></div>
+<div id="{{include.id}}" class="donut-chart-pf"></div>
 <div style="text-align: center; width: 160px;">Animals</div>
 <script>
   var c3ChartDefaults = $().c3ChartDefaults();
@@ -24,7 +24,7 @@
 
   // Small Donut Chart
   var donutChartSmallConfig = c3ChartDefaults.getDefaultDonutConfig('8');
-  donutChartSmallConfig.bindto = '#{{ include.chart1 }}';
+  donutChartSmallConfig.bindto = '#{{include.id}}';
   donutChartSmallConfig.tooltip = {show: true};
   donutChartSmallConfig.data = donutData;
   donutChartSmallConfig.legend = {

--- a/tests-src/_includes/widgets/charts/donut-utilization.html
+++ b/tests-src/_includes/widgets/charts/donut-utilization.html
@@ -1,8 +1,8 @@
-<div id="{{ include.chart1 }}"></div>
+<div id="{{include.id}}"></div>
 <script>
   var c3ChartDefaults = $().c3ChartDefaults();
   var utilizationDonutChartConfig = c3ChartDefaults.getDefaultDonutConfig('A');
-  utilizationDonutChartConfig.bindto = '#{{ include.chart1 }}';
+  utilizationDonutChartConfig.bindto = '#{{include.id}}';
   utilizationDonutChartConfig.data = {
     type: "donut",
     columns: [
@@ -19,5 +19,5 @@
     contents: $().pfGetUtilizationDonutTooltipContentsFn('MHz')
   };
   var utilizationDonutChart = c3.generate(utilizationDonutChartConfig);
-  $().pfSetDonutChartTitle("#{{ include.chart1 }}", "60", "MHz Used");
+  $().pfSetDonutChartTitle("#{{include.id}}", "60", "MHz Used");
 </script>

--- a/tests-src/_includes/widgets/charts/donut-whole-relationship.html
+++ b/tests-src/_includes/widgets/charts/donut-whole-relationship.html
@@ -1,12 +1,12 @@
 <div class="row">
   <div class="col-xs-12 col-sm-12 col-md-4">
-    <div id="{{ include.chart1 }}"></div>
+    <div id="{{include.id1}}"></div>
   </div>
   <div class="col-xs-12 col-sm-12 col-md-4">
-    <div id="{{ include.chart2 }}"></div>
+    <div id="{{include.id2}}"></div>
   </div>
   <div class="col-xs-12 col-sm-12 col-md-4">
-    <div id="{{ include.chart3 }}"></div>
+    <div id="{{include.id3}}"></div>
   </div>
 </div>
 <script>
@@ -33,7 +33,7 @@
 
   // Donut Chart without Legend
   var donutChartConfig = c3ChartDefaults.getDefaultDonutConfig();
-  donutChartConfig.bindto = '#{{ include.chart1 }}';
+  donutChartConfig.bindto = '#{{include.id1}}';
   donutChartConfig.tooltip = {show: true};
   donutChartConfig.data = donutData;
   donutChartConfig.tooltip = {
@@ -41,11 +41,11 @@
   };
 
   var donutChartNoLegend = c3.generate(donutChartConfig);
-  $().pfSetDonutChartTitle("#{{ include.chart1 }}", "8", "Animals");
+  $().pfSetDonutChartTitle("#{{include.id1}}", "8", "Animals");
 
   // Right Legend
   var donutChartRightConfig = c3ChartDefaults.getDefaultDonutConfig();
-  donutChartRightConfig.bindto = '#{{ include.chart2 }}';
+  donutChartRightConfig.bindto = '#{{include.id2}}';
   donutChartRightConfig.tooltip = {show: true};
   donutChartRightConfig.data = donutData;
   donutChartRightConfig.legend = {
@@ -61,11 +61,11 @@
   };
 
   var donutChartRightLegend = c3.generate(donutChartRightConfig);
-  $().pfSetDonutChartTitle("#{{ include.chart2 }}", "8", "Animals");
+  $().pfSetDonutChartTitle("#{{include.id2}}", "8", "Animals");
 
   // Donut Chart Bottom Legend
   var donutChartBottomConfig = c3ChartDefaults.getDefaultDonutConfig();
-  donutChartBottomConfig.bindto = '#{{ include.chart3 }}';
+  donutChartBottomConfig.bindto = '#{{include.id3}}';
   donutChartBottomConfig.tooltip = {show: true};
   donutChartBottomConfig.data = donutData;
   donutChartBottomConfig.legend = {
@@ -81,5 +81,5 @@
   };
 
   var donutChartBottomLegend = c3.generate(donutChartBottomConfig);
-  $().pfSetDonutChartTitle("#{{ include.chart3 }}", "8", "Animals");
+  $().pfSetDonutChartTitle("#{{include.id3}}", "8", "Animals");
 </script>

--- a/tests-src/_includes/widgets/charts/line-multiple.html
+++ b/tests-src/_includes/widgets/charts/line-multiple.html
@@ -1,4 +1,4 @@
-<div id="{{ include.chart1 }}" class="line-chart-pf"></div>
+<div id="{{include.id}}" class="line-chart-pf"></div>
 <script>
   var lineChartDataColumns = [
     ['data1', 30, 200, 100, 400, 150, 250],
@@ -13,7 +13,7 @@
 
   var c3ChartDefaults = $().c3ChartDefaults();
   var lineChartConfig = c3ChartDefaults.getDefaultLineConfig();
-  lineChartConfig.bindto = '#{{ include.chart1 }}';
+  lineChartConfig.bindto = '#{{include.id}}';
   lineChartConfig.data = {
     columns: lineChartDataColumns,
     type: 'line'

--- a/tests-src/_includes/widgets/charts/line-single.html
+++ b/tests-src/_includes/widgets/charts/line-single.html
@@ -1,4 +1,4 @@
-<div id="{{ include.chart1 }}" class="line-chart-pf"></div>
+<div id="{{include.id}}" class="line-chart-pf"></div>
 <script>
   var lineChartDataColumns = [
     ['data1', 30, 200, 100, 400, 150, 250],
@@ -12,7 +12,7 @@
   ];
 
   var singleLineChartConfig = c3ChartDefaults.getDefaultSingleLineConfig();
-  singleLineChartConfig.bindto = '#{{ include.chart1 }}';
+  singleLineChartConfig.bindto = '#{{include.id}}';
   singleLineChartConfig.data = {
     columns: singleLineChartDataColumns,
     type: 'line'

--- a/tests-src/_includes/widgets/charts/pie-mini.html
+++ b/tests-src/_includes/widgets/charts/pie-mini.html
@@ -1,4 +1,4 @@
-<div id="{{ include.chart1 }}" class="pie-chart-pf"></div>
+<div id="{{include.id}}" class="pie-chart-pf"></div>
 <div style="text-align: center; width: 160px;">Animals</div>
 <script>
   var pieData = {
@@ -22,7 +22,7 @@
 
   var c3ChartDefaults = $().c3ChartDefaults();
   var pieChartSmallConfig = c3ChartDefaults.getDefaultPieConfig();
-  pieChartSmallConfig.bindto = '#{{ include.chart1 }}';
+  pieChartSmallConfig.bindto = '#{{include.id}}';
   pieChartSmallConfig.data = pieData;
   pieChartSmallConfig.legend = {
     show: true,

--- a/tests-src/_includes/widgets/charts/pie-whole-relationship.html
+++ b/tests-src/_includes/widgets/charts/pie-whole-relationship.html
@@ -1,12 +1,12 @@
 <div class="row">
   <div class="col-xs-12 col-sm-12 col-md-4">
-    <div id="{{ include.chart1 }}"></div>
+    <div id="{{include.id1}}"></div>
   </div>
   <div class="col-xs-12 col-sm-12 col-md-4">
-    <div id="{{ include.chart2 }}"></div>
+    <div id="{{include.id2}}"></div>
   </div>
   <div class="col-xs-12 col-sm-12 col-md-4">
-    <div id="{{ include.chart3 }}"></div>
+    <div id="{{include.id3}}"></div>
   </div>
 </div>
 <script>
@@ -33,13 +33,13 @@
 
   // Pie Chart without Legend
   var pieChartConfig = c3ChartDefaults.getDefaultPieConfig();
-  pieChartConfig.bindto = '#{{ include.chart1 }}';
+  pieChartConfig.bindto = '#{{ include.id1 }}';
   pieChartConfig.data = pieData;
   var pieChartNoLegend = c3.generate(pieChartConfig);
 
   // Right Legend
   var pieChartRightConfig = c3ChartDefaults.getDefaultPieConfig();
-  pieChartRightConfig.bindto = '#{{ include.chart2 }}';
+  pieChartRightConfig.bindto = '#{{include.id2}}';
   pieChartRightConfig.data = pieData;
   pieChartRightConfig.legend = {
     show: true,
@@ -53,7 +53,7 @@
 
   // Pie Chart Bottom Legend
   var pieChartBottomConfig = c3ChartDefaults.getDefaultPieConfig();
-  pieChartBottomConfig.bindto = '#{{ include.chart3 }}';
+  pieChartBottomConfig.bindto = '#{{include.id3}}';
   pieChartBottomConfig.data = pieData;
   pieChartBottomConfig.legend = {
     show: true,

--- a/tests-src/_includes/widgets/charts/sparkline.html
+++ b/tests-src/_includes/widgets/charts/sparkline.html
@@ -1,9 +1,9 @@
-<div id="{{ include.chart1 }}" class="chart-pf-sparkline"></div>
+<div id="{{include.id}}" class="chart-pf-sparkline"></div>
 <div>Less than one year remaining</div>
 <script>
   var c3ChartDefaults = $().c3ChartDefaults();
   var sparklineChartConfig = c3ChartDefaults.getDefaultSparklineConfig();
-  sparklineChartConfig.bindto = '#{{ include.chart1 }}';
+  sparklineChartConfig.bindto = '#{{include.id}}';
   sparklineChartConfig.data = {
     columns: [
       ['%', 10, 14, 12, 20, 31, 27, 44, 36, 52, 55, 62, 68, 69, 88, 74, 88, 91],

--- a/tests-src/_includes/widgets/charts/spline-multiple.html
+++ b/tests-src/_includes/widgets/charts/spline-multiple.html
@@ -1,4 +1,4 @@
-<div id="{{ include.chart1 }}" class="line-chart-pf"></div>
+<div id="{{include.id}}" class="line-chart-pf"></div>
 <script>
   var lineChartDataColumns = [
     ['data1', 30, 200, 100, 400, 150, 250],
@@ -12,7 +12,7 @@
   ];
 
   var splineChartConfig = c3ChartDefaults.getDefaultLineConfig();
-  splineChartConfig.bindto = '#{{ include.chart1 }}';
+  splineChartConfig.bindto = '#{{include.id}}';
   splineChartConfig.data = {
     columns: lineChartDataColumns,
     type: 'spline'

--- a/tests-src/_includes/widgets/charts/spline-single.html
+++ b/tests-src/_includes/widgets/charts/spline-single.html
@@ -1,4 +1,4 @@
-<div id="{{ include.chart1 }}" class="line-chart-pf"></div>
+<div id="{{include.id}}" class="line-chart-pf"></div>
 <script>
   var lineChartDataColumns = [
     ['data1', 30, 200, 100, 400, 150, 250],
@@ -12,7 +12,7 @@
   ];
 
   var singleSplineChartConfig = c3ChartDefaults.getDefaultSingleLineConfig();
-  singleSplineChartConfig.bindto = '#{{ include.chart1 }}';
+  singleSplineChartConfig.bindto = '#{{include.id}}';
   singleSplineChartConfig.data = {
     columns: singleLineChartDataColumns,
     type: 'spline'

--- a/tests-src/_includes/widgets/dashboard.html
+++ b/tests-src/_includes/widgets/dashboard.html
@@ -232,13 +232,13 @@
       <div class="row row-cards-pf">
         <div class="col-md-12">
           <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
-          {% include widgets/cards/utilization-trend-multiple-metrics.html chart3="chart-pf-donut-1" chart4="chart-pf-sparkline-1" chart5="chart-pf-donut-2" chart6="chart-pf-sparkline-2" chart7="chart-pf-donut-3" chart8="chart-pf-sparkline-3" %}
+          {% include widgets/cards/utilization-trend-multiple-metrics.html id3="chart-pf-donut-1" id4="chart-pf-sparkline-1" id5="chart-pf-donut-2" id6="chart-pf-sparkline-2" id7="chart-pf-donut-3" id8="chart-pf-sparkline-3" %}
         </div>
       </div><!-- /row -->
       <div class="row row-cards-pf">
         <div class="col-xs-12 col-sm-4 col-md-4">
           <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
-          {% include widgets/cards/utilization-trend-single-metric.html chart1="chart-pf-donut-4" chart2="chart-pf-sparkline-4" %}
+          {% include widgets/cards/utilization-trend-single-metric.html id1="chart-pf-donut-4" id2="chart-pf-sparkline-4" %}
         </div>
       </div><!-- /row -->
       <div class="row row-cards-pf">

--- a/tests-src/_includes/widgets/forms/bootstrap-datepicker-inline.html
+++ b/tests-src/_includes/widgets/forms/bootstrap-datepicker-inline.html
@@ -1,0 +1,9 @@
+<div id="{{include.id}}" class="bootstrap-datepicker-inline"></div>
+<script>
+  $('#{{include.id}}').datepicker({
+    autoclose: true,
+    orientation: "top auto",
+    todayBtn: "linked",
+    todayHighlight: true
+  });
+</script>

--- a/tests-src/_includes/widgets/forms/bootstrap-datepicker-text-input.html
+++ b/tests-src/_includes/widgets/forms/bootstrap-datepicker-text-input.html
@@ -1,0 +1,9 @@
+<input id="{{include.id}}" type="text" class="form-control bootstrap-datepicker" readonly>
+<script>
+  $('#{{include.id}}').datepicker({
+    autoclose: true,
+    orientation: "top auto",
+    todayBtn: "linked",
+    todayHighlight: true
+  });
+</script>

--- a/tests-src/_includes/widgets/forms/bootstrap-datepicker.html
+++ b/tests-src/_includes/widgets/forms/bootstrap-datepicker.html
@@ -1,0 +1,11 @@
+<div id="{{include.id}}" class="input-group date">
+  <input type="text" class="form-control bootstrap-datepicker" readonly><span class="input-group-addon"><span class="fa fa-calendar"></span></span>
+</div>
+<script>
+  $('#{{include.id}}').datepicker({
+    autoclose: true,
+    orientation: "top auto",
+    todayBtn: "linked",
+    todayHighlight: true
+  });
+</script>

--- a/tests-src/_includes/widgets/forms/field-level-help.html
+++ b/tests-src/_includes/widgets/forms/field-level-help.html
@@ -1,0 +1,14 @@
+<form class="form-horizontal">
+  <div class="form-group">
+    <label class="col-sm-3 control-label" for="{{include.id}}">Default <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-html="true" title="" data-content="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et <a href='#'>dolore magna aliqua</a>." data-placement="top"><span class="fa fa-info-circle"></span></a></label>
+    <div class="col-sm-9">
+      <input type="text" id="{{include.id}}" class="form-control">
+    </div>
+  </div>
+</form>
+<script>
+  // Initialize Popovers
+  $(document).ready(function() {
+    $('[data-toggle=popover]').popovers()
+  });
+</script>

--- a/tests-src/_includes/widgets/forms/time-picker.html
+++ b/tests-src/_includes/widgets/forms/time-picker.html
@@ -1,0 +1,20 @@
+<div class="input-group time-picker-pf" id="{{include.id}}">
+  <input type="text" class="form-control">
+      <span class="input-group-addon btn btn-default">
+        <span class="fa fa-clock-o"></span>
+      </span>
+</div>
+<script>
+  $(function () {
+    $('#{{include.id}}').datetimepicker({
+      format: 'LT',
+      keyBinds: {
+        enter: function () {
+          $('#{{include.id}}').find('input').trigger('change');
+          this.hide();
+        }
+      }
+    });
+    $('#{{include.id}}').data('DateTimePicker').clear();
+  });
+</script>

--- a/tests-src/area-charts.html
+++ b/tests-src/area-charts.html
@@ -9,12 +9,12 @@ url-js-extra: ['//cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.min.js', '//cdnjs.
 <h2>Area Chart</h2>
 <div class="row">
   <div class="col-lg-6 col-sm-12">
-    {% include widgets/charts/area-multiple.html chart1="areaChart" %}
+    {% include widgets/charts/area-multiple.html id="areaChart" %}
   </div>
 </div>
 <h2>Single Area Chart</h2>
 <div class="row">
   <div class="col-lg-6 col-sm-12">
-    {% include widgets/charts/area-single.html chart1="singleAreaChart" %}
+    {% include widgets/charts/area-single.html id="singleAreaChart" %}
   </div>
 </div>

--- a/tests-src/bar-charts.html
+++ b/tests-src/bar-charts.html
@@ -9,24 +9,24 @@ url-js-extra: ['//cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.min.js', '//cdnjs.
 <h2>Vertical Bar Chart</h2>
 <div class="row">
   <div class="col-lg-4 col-sm-6 col-xs-12">
-    {% include widgets/charts/bar-vertical.html chart1="verticalBarChart" %}
+    {% include widgets/charts/bar-vertical.html id="verticalBarChart" %}
   </div>
 </div>
 <h2>Grouped Vertical Bar Chart</h2>
 <div class="row">
   <div class="col-lg-4 col-sm-6 col-xs-12">
-    {% include widgets/charts/bar-vertical-group.html chart1="groupedVerticalBarChart" %}
+    {% include widgets/charts/bar-vertical-group.html id="groupedVerticalBarChart" %}
   </div>
 </div>
 <h2>Horizontal Bar Chart</h2>
 <div class="row">
   <div class="col-lg-4 col-sm-6 col-xs-12">
-    {% include widgets/charts/bar-horizontal.html chart1="horizontalBarChart" %}
+    {% include widgets/charts/bar-horizontal.html id="horizontalBarChart" %}
   </div>
 </div>
 <h2>Grouped Horizontal Bar Chart</h2>
 <div class="row">
   <div class="col-lg-4 col-sm-6 col-xs-12">
-    {% include widgets/charts/bar-horizontal-group.html chart1="groupedHorizontalBarChart" %}
+    {% include widgets/charts/bar-horizontal-group.html id="groupedHorizontalBarChart" %}
   </div>
 </div>

--- a/tests-src/bootstrap-datepicker.html
+++ b/tests-src/bootstrap-datepicker.html
@@ -9,13 +9,11 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.4.0/js/bo
       <h2>Readonly Inputs</h2>
       <p><span class="text-success">Recommended.</span>  To prevent invalid dates, setting the inputs to readonly only allows a date to be input via the date picker widget.</p>
       <h3>Text Input</h3>
-      <input type="text" class="form-control bootstrap-datepicker" readonly>
+        {% include widgets/forms/bootstrap-datepicker-text-input.html id="datepicker1" %}
       <h3>Component</h3>
-      <div class="input-group date">
-        <input type="text" class="form-control bootstrap-datepicker" readonly><span class="input-group-addon"><span class="fa fa-calendar"></span></span>
-      </div>
+        {% include widgets/forms/bootstrap-datepicker.html id="datepicker2" %}
       <h3>Inline</h3>
-      <div class="bootstrap-datepicker-inline"></div>
+        {% include widgets/forms/bootstrap-datepicker-inline.html id="datepicker3" %}
       <h3>Range <small>Do not use.  PatternFly-approved design coming in a future update.</small></h3>
       <div class="input-daterange input-group">
         <input type="text" class="form-control bootstrap-datepicker" name="start" readonly>

--- a/tests-src/donut-charts.html
+++ b/tests-src/donut-charts.html
@@ -9,14 +9,14 @@ url-js-extra: ['//cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.min.js', '//cdnjs.
 <div>
   <h2>Donut Chart - Utilization</h2>
   <div style="width: 220px;">
-    {% include widgets/charts/donut-utilization.html chart1="utilizationDonutChart" %}
+    {% include widgets/charts/donut-utilization.html id="utilizationDonutChart" %}
   </div>
   <h2>Donut Chart - Relationship to a Whole</h2>
   <div style="width: 700px;">
-    {% include widgets/charts/donut-whole-relationship.html chart1="donut-chart-no-legend" chart2="donut-chart-right-legend" chart3="donut-chart-bottom-legend" %}
+    {% include widgets/charts/donut-whole-relationship.html id1="donut-chart-no-legend" id2="donut-chart-right-legend" id3="donut-chart-bottom-legend" %}
   </div>
   <h2>Donut Chart - Small</h2>
   <div>
-    {% include widgets/charts/donut-mini.html chart1="smallDonutChart" %}
+    {% include widgets/charts/donut-mini.html id="smallDonutChart" %}
   </div>
 </div>

--- a/tests-src/line-charts.html
+++ b/tests-src/line-charts.html
@@ -9,30 +9,30 @@ url-js-extra: ['//cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.min.js', '//cdnjs.
 <h2>Sparkline</h2>
 <div class="row">
   <div class="col-md-4">
-    {% include widgets/charts/sparkline.html chart1="sparklineChart" %}
+    {% include widgets/charts/sparkline.html id="sparklineChart" %}
   </div>
 </div>
 <h2>Line Chart</h2>
 <div class="row">
   <div class="col-lg-6 col-sm-12">
-    {% include widgets/charts/line-multiple.html chart1="lineChart" %}
+    {% include widgets/charts/line-multiple.html id="lineChart" %}
   </div>
 </div>
 <h2>Single Line Chart</h2>
 <div class="row">
   <div class="col-lg-6 col-sm-12">
-    {% include widgets/charts/line-single.html chart1="singleLineChart" %}
+    {% include widgets/charts/line-single.html id="singleLineChart" %}
   </div>
 </div>
 <h2>Spline Chart</h2>
 <div class="row">
   <div class="col-lg-6 col-sm-12">
-    {% include widgets/charts/spline-multiple.html chart1="splineChart" %}
+    {% include widgets/charts/spline-multiple.html id="splineChart" %}
   </div>
 </div>
 <h2>Single Spline Chart</h2>
 <div class="row">
   <div class="col-lg-6 col-sm-12">
-    {% include widgets/charts/spline-single.html chart1="singleSplineChart" %}
+    {% include widgets/charts/spline-single.html id="singleSplineChart" %}
   </div>
 </div>

--- a/tests-src/pie-charts.html
+++ b/tests-src/pie-charts.html
@@ -9,10 +9,10 @@ url-js-extra: ['//cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.min.js', '//cdnjs.
 <div>
   <h2>Donut Chart - Relationship to a Whole</h2>
   <div style="width: 700px;">
-    {% include widgets/charts/pie-whole-relationship.html chart1="donut-chart-no-legend" chart2="donut-chart-right-legend" chart3="donut-chart-bottom-legend" %}
+    {% include widgets/charts/pie-whole-relationship.html id1="donut-chart-no-legend" id2="donut-chart-right-legend" id3="donut-chart-bottom-legend" %}
   </div>
   <h2>Pie Chart - Small</h2>
   <div>
-    {% include widgets/charts/pie-mini.html chart1="smallDonutChart" %}
+    {% include widgets/charts/pie-mini.html id="smallDonutChart" %}
   </div>
 </div>

--- a/tests-src/popovers.html
+++ b/tests-src/popovers.html
@@ -57,17 +57,4 @@ resource: true
         <a href="#" class="btn btn-default" data-toggle="popover" data-html="true" title="" data-content="Empty Title example.<br>This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy." data-placement="bottom">Popover on bottom</a>
       </div>
       <hr>
-      <form class="form-horizontal">
-        <div class="form-group">
-          <label class="col-sm-2 control-label" for="textInput">Default <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-html="true" title="" data-content="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et <a href='#'>dolore magna aliqua</a>." data-placement="top"><span class="fa fa-info-circle"></span></a></label>
-          <div class="col-sm-10">
-            <input type="text" id="textInput" class="form-control">
-          </div>
-        </div>
-      </form>
-      <script>
-        // Initialize Popovers
-        $(document).ready(function() {
-          $('[data-toggle=popover]').popovers()
-        });
-      </script>
+      {% include widgets/forms/field-level-help.html id="fieldlevelhelp" %}

--- a/tests-src/time-picker.html
+++ b/tests-src/time-picker.html
@@ -10,25 +10,6 @@ url-js-extra: ['https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.11.2/moment.m
 <h3>Component</h3>
 <div class="row">
   <div class="col-lg-4 col-md-5 col-sm-6">
-    <div class="input-group time-picker-pf" id="datetimepicker3">
-      <input type="text" class="form-control">
-      <span class="input-group-addon btn btn-default">
-        <span class="fa fa-clock-o"></span>
-      </span>
-    </div>
-    <script>
-      $(function () {
-        $('#datetimepicker3').datetimepicker({
-          format: 'LT',
-          keyBinds: {
-            enter: function () {
-              $('#datetimepicker3').find('input').trigger('change');
-              this.hide();
-            }
-          }
-        });
-        $('#datetimepicker3').data('DateTimePicker').clear();
-      });
-    </script>
+    {% include widgets/forms/time-picker.html id="timepicker1" %}
   </div>
 </div>

--- a/tests-src/utilization-bar-charts.html
+++ b/tests-src/utilization-bar-charts.html
@@ -9,6 +9,6 @@ url-js-extra: ['//cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.min.js', '//cdnjs.
 <h2>Utilization Bar Chart</h2>
 <div class="row">
   <div class="col-xs-8 col-sm-6 col-md-6">
-    {% include widgets/charts/utilization-bar.html chart1="utilizationBarChart" %}
+    {% include widgets/charts/utilization-bar.html id="utilizationBarChart" %}
   </div>
 </div>

--- a/tests/bootstrap-datepicker.html
+++ b/tests/bootstrap-datepicker.html
@@ -45,13 +45,40 @@
       <h2>Readonly Inputs</h2>
       <p><span class="text-success">Recommended.</span>  To prevent invalid dates, setting the inputs to readonly only allows a date to be input via the date picker widget.</p>
       <h3>Text Input</h3>
-      <input type="text" class="form-control bootstrap-datepicker" readonly>
+        <input id="datepicker1" type="text" class="form-control bootstrap-datepicker" readonly>
+<script>
+  $('#datepicker1').datepicker({
+    autoclose: true,
+    orientation: "top auto",
+    todayBtn: "linked",
+    todayHighlight: true
+  });
+</script>
+
       <h3>Component</h3>
-      <div class="input-group date">
-        <input type="text" class="form-control bootstrap-datepicker" readonly><span class="input-group-addon"><span class="fa fa-calendar"></span></span>
-      </div>
+        <div id="datepicker2" class="input-group date">
+  <input type="text" class="form-control bootstrap-datepicker" readonly><span class="input-group-addon"><span class="fa fa-calendar"></span></span>
+</div>
+<script>
+  $('#datepicker2').datepicker({
+    autoclose: true,
+    orientation: "top auto",
+    todayBtn: "linked",
+    todayHighlight: true
+  });
+</script>
+
       <h3>Inline</h3>
-      <div class="bootstrap-datepicker-inline"></div>
+        <div id="datepicker3" class="bootstrap-datepicker-inline"></div>
+<script>
+  $('#datepicker3').datepicker({
+    autoclose: true,
+    orientation: "top auto",
+    todayBtn: "linked",
+    todayHighlight: true
+  });
+</script>
+
       <h3>Range <small>Do not use.  PatternFly-approved design coming in a future update.</small></h3>
       <div class="input-daterange input-group">
         <input type="text" class="form-control bootstrap-datepicker" name="start" readonly>
@@ -115,6 +142,7 @@
           todayHighlight: true
         });
       </script>
+
     </div><!-- /container -->
   </body>
 </html>

--- a/tests/popovers.html
+++ b/tests/popovers.html
@@ -95,19 +95,20 @@
       </div>
       <hr>
       <form class="form-horizontal">
-        <div class="form-group">
-          <label class="col-sm-2 control-label" for="textInput">Default <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-html="true" title="" data-content="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et <a href='#'>dolore magna aliqua</a>." data-placement="top"><span class="fa fa-info-circle"></span></a></label>
-          <div class="col-sm-10">
-            <input type="text" id="textInput" class="form-control">
-          </div>
-        </div>
-      </form>
-      <script>
-        // Initialize Popovers
-        $(document).ready(function() {
-          $('[data-toggle=popover]').popovers()
-        });
-      </script>
+  <div class="form-group">
+    <label class="col-sm-3 control-label" for="fieldlevelhelp">Default <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-html="true" title="" data-content="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et <a href='#'>dolore magna aliqua</a>." data-placement="top"><span class="fa fa-info-circle"></span></a></label>
+    <div class="col-sm-9">
+      <input type="text" id="fieldlevelhelp" class="form-control">
+    </div>
+  </div>
+</form>
+<script>
+  // Initialize Popovers
+  $(document).ready(function() {
+    $('[data-toggle=popover]').popovers()
+  });
+</script>
+
 
     </div><!-- /container -->
   </body>

--- a/tests/time-picker.html
+++ b/tests/time-picker.html
@@ -46,28 +46,30 @@
 <h3>Component</h3>
 <div class="row">
   <div class="col-lg-4 col-md-5 col-sm-6">
-    <div class="input-group time-picker-pf" id="datetimepicker3">
-      <input type="text" class="form-control">
+    <div class="input-group time-picker-pf" id="timepicker1">
+  <input type="text" class="form-control">
       <span class="input-group-addon btn btn-default">
         <span class="fa fa-clock-o"></span>
       </span>
-    </div>
-    <script>
-      $(function () {
-        $('#datetimepicker3').datetimepicker({
-          format: 'LT',
-          keyBinds: {
-            enter: function () {
-              $('#datetimepicker3').find('input').trigger('change');
-              this.hide();
-            }
-          }
-        });
-        $('#datetimepicker3').data('DateTimePicker').clear();
-      });
-    </script>
+</div>
+<script>
+  $(function () {
+    $('#timepicker1').datetimepicker({
+      format: 'LT',
+      keyBinds: {
+        enter: function () {
+          $('#timepicker1').find('input').trigger('change');
+          this.hide();
+        }
+      }
+    });
+    $('#timepicker1').data('DateTimePicker').clear();
+  });
+</script>
+
   </div>
 </div>
+
     </div><!-- /container -->
   </body>
 </html>


### PR DESCRIPTION
Created widget templates for datepicker, timepicker, and field help to be used in patternfly-toolkit pages.
Removed spaces from "#{{ include.chart1 }}" statements per code review comments.
Renamed template ids to use a similar naming convention such as "#{{ include.id }}".

@dtaylor113 @jeff-phillips-18 please review.
