### PR TITLE
Implicitly specify `opacity: 1` for input placeholders in Firefox

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -77,7 +77,7 @@
 // Placeholder text
 .placeholder(@color: @input-color-placeholder) {
   &:-moz-placeholder            { color: @color; font-style: italic; } // Firefox 4-18
-  &::-moz-placeholder           { color: @color; font-style: italic;} // Firefox 19+
+  &::-moz-placeholder           { color: @color; font-style: italic; opacity: 1; } // Firefox 19+
   &:-ms-input-placeholder       { color: @color; font-style: italic; } // Internet Explorer 10+
   &::-webkit-input-placeholder  { color: @color; font-style: italic; } // Safari and Chrome
 }


### PR DESCRIPTION
When overriding a mixin in SASS, the original rules aren't copied.
This caused issues with the color of input placeholders in FF.

https://github.com/twbs/bootstrap/blob/10606a73bcbfc6c723d60e2a1069c921afff0d2a/less/mixins/vendor-prefixes.less#L105
