### PR TITLE
Add input-border-focus to match border shadow color.

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -47,6 +47,7 @@
 @img-spinner-xs:                                                    "spinner-xs.gif";
 @input-border-disabled:                                             @color-pf-black-300;
 @input-border-hover:                                                @color-pf-blue-200;
+@input-border-focus:                                                @color-pf-blue-400;
 @list-view-accented-border:                                         @color-pf-blue-300;
 @list-view-active-bg:                                               @color-pf-blue-50;
 @list-view-divider:                                                 @color-pf-black-300;


### PR DESCRIPTION
This merge will fix the focus color of the form inputs.
Otherwise the bootstrap color is used.
