### PR TITLE
Fix-bug: there are repeated dropdown menus of datepicker

### DIFF
--- a/dist/tests/bootstrap-datepicker.html
+++ b/dist/tests/bootstrap-datepicker.html
@@ -87,21 +87,21 @@
       <h3>Validation States</h3>
       <div class="form-group has-success">
         <label class="control-label" for="boostrap-datepicker-success-readonly">With success</label>
-        <input type="text" class="form-control bootstrap-datepicker" id="boostrap-datepicker-success-readonly" readonly>
+        <input type="text" class="form-control bootstrap-datepicker input-datepicker" id="boostrap-datepicker-success-readonly" readonly>
       </div>
       <div class="form-group has-warning">
         <label class="control-label" for="boostrap-datepicker-warning-readonly">With warning</label>
-        <input type="text" class="form-control bootstrap-datepicker" id="boostrap-datepicker-warning-readonly" readonly>
+        <input type="text" class="form-control bootstrap-datepicker input-datepicker" id="boostrap-datepicker-warning-readonly" readonly>
       </div>
       <div class="form-group has-error">
         <label class="control-label" for="boostrap-datepicker-error-readonly">With error</label>
-        <input type="text" class="form-control bootstrap-datepicker" id="boostrap-datepicker-error-readonly" readonly>
+        <input type="text" class="form-control bootstrap-datepicker input-datepicker" id="boostrap-datepicker-error-readonly" readonly>
       </div>
       <hr>
       <h2>Normal Inputs</h2>
       <p><span class="text-warning">Not recommended.</span>  For comparison only.</p>
       <h3>Text Input</h3>
-      <input type="text" class="form-control bootstrap-datepicker">
+      <input type="text" class="form-control bootstrap-datepicker input-datepicker">
       <h3>Component</h3>
       <div class="input-group date">
         <input type="text" class="form-control bootstrap-datepicker"><span class="input-group-addon"><span class="fa fa-calendar"></span></span>
@@ -117,19 +117,19 @@
       <h3>Validation States</h3>
       <div class="form-group has-success">
         <label class="control-label" for="boostrap-datepicker-success">With success</label>
-        <input type="text" class="form-control bootstrap-datepicker" id="boostrap-datepicker-success">
+        <input type="text" class="form-control bootstrap-datepicker input-datepicker" id="boostrap-datepicker-success">
       </div>
       <div class="form-group has-warning">
         <label class="control-label" for="boostrap-datepicker-warning">With warning</label>
-        <input type="text" class="form-control bootstrap-datepicker" id="boostrap-datepicker-warning">
+        <input type="text" class="form-control bootstrap-datepicker input-datepicker" id="boostrap-datepicker-warning">
       </div>
       <div class="form-group has-error">
         <label class="control-label" for="boostrap-datepicker-error">With error</label>
-        <input type="text" class="form-control bootstrap-datepicker" id="boostrap-datepicker-error">
+        <input type="text" class="form-control bootstrap-datepicker input-datepicker" id="boostrap-datepicker-error">
       </div>
       <script>
         // Initialize Boostrap-Datepicker
-        $('.bootstrap-datepicker, .input-group.date, .bootstrap-datepicker-inline').datepicker({
+        $('.input-datepicker, .input-group.date, .bootstrap-datepicker-inline').datepicker({
           autoclose: true,
           orientation: "top auto",
           todayBtn: "linked",

--- a/tests/pages/bootstrap-datepicker.html
+++ b/tests/pages/bootstrap-datepicker.html
@@ -23,21 +23,21 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.4.0/js/bo
       <h3>Validation States</h3>
       <div class="form-group has-success">
         <label class="control-label" for="boostrap-datepicker-success-readonly">With success</label>
-        <input type="text" class="form-control bootstrap-datepicker" id="boostrap-datepicker-success-readonly" readonly>
+        <input type="text" class="form-control bootstrap-datepicker input-datepicker" id="boostrap-datepicker-success-readonly" readonly>
       </div>
       <div class="form-group has-warning">
         <label class="control-label" for="boostrap-datepicker-warning-readonly">With warning</label>
-        <input type="text" class="form-control bootstrap-datepicker" id="boostrap-datepicker-warning-readonly" readonly>
+        <input type="text" class="form-control bootstrap-datepicker input-datepicker" id="boostrap-datepicker-warning-readonly" readonly>
       </div>
       <div class="form-group has-error">
         <label class="control-label" for="boostrap-datepicker-error-readonly">With error</label>
-        <input type="text" class="form-control bootstrap-datepicker" id="boostrap-datepicker-error-readonly" readonly>
+        <input type="text" class="form-control bootstrap-datepicker input-datepicker" id="boostrap-datepicker-error-readonly" readonly>
       </div>
       <hr>
       <h2>Normal Inputs</h2>
       <p><span class="text-warning">Not recommended.</span>  For comparison only.</p>
       <h3>Text Input</h3>
-      <input type="text" class="form-control bootstrap-datepicker">
+      <input type="text" class="form-control bootstrap-datepicker input-datepicker">
       <h3>Component</h3>
       <div class="input-group date">
         <input type="text" class="form-control bootstrap-datepicker"><span class="input-group-addon"><span class="fa fa-calendar"></span></span>
@@ -53,19 +53,19 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.4.0/js/bo
       <h3>Validation States</h3>
       <div class="form-group has-success">
         <label class="control-label" for="boostrap-datepicker-success">With success</label>
-        <input type="text" class="form-control bootstrap-datepicker" id="boostrap-datepicker-success">
+        <input type="text" class="form-control bootstrap-datepicker input-datepicker" id="boostrap-datepicker-success">
       </div>
       <div class="form-group has-warning">
         <label class="control-label" for="boostrap-datepicker-warning">With warning</label>
-        <input type="text" class="form-control bootstrap-datepicker" id="boostrap-datepicker-warning">
+        <input type="text" class="form-control bootstrap-datepicker input-datepicker" id="boostrap-datepicker-warning">
       </div>
       <div class="form-group has-error">
         <label class="control-label" for="boostrap-datepicker-error">With error</label>
-        <input type="text" class="form-control bootstrap-datepicker" id="boostrap-datepicker-error">
+        <input type="text" class="form-control bootstrap-datepicker input-datepicker" id="boostrap-datepicker-error">
       </div>
       <script>
         // Initialize Boostrap-Datepicker
-        $('.bootstrap-datepicker, .input-group.date, .bootstrap-datepicker-inline').datepicker({
+        $('.input-datepicker, .input-group.date, .bootstrap-datepicker-inline').datepicker({
           autoclose: true,
           orientation: "top auto",
           todayBtn: "linked",


### PR DESCRIPTION
The [issue](https://github.com/patternfly/patternfly/issues/333) is caused by repeated instantiation of datepicker controls. Now the datepicker with icon no longer pops up two dropdown menus.
