### PR TITLE
Fix @navbar-pf-alt-bg-img variable

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -60,7 +60,7 @@
 @navbar-pf-active-color:                                            @color-pf-black-150;
 @navbar-pf-alt-active-color:                                        @color-pf-white;
 @navbar-pf-alt-bg-color:                                            @color-pf-black;
-@navbar-pf-alt-bg-img:                                              url("../img/bg-navbar-pf-alt.svg");
+@navbar-pf-alt-bg-img:                                              "bg-navbar-pf-alt.svg";
 @navbar-pf-bg-color:                                                @color-pf-black;
 @navbar-pf-border-color:                                            @color-pf-blue-300;
 @navbar-pf-color:                                                   @color-pf-black-300;


### PR DESCRIPTION
This change makes the @navbar-pf-alt-bg-img align to other image variables. Without this change, the url to this image is incorrect when @img-path is overriden.
