### PR TITLE
Typo in class name

### DIFF
--- a/less/vertical-nav.less
+++ b/less/vertical-nav.less
@@ -1,7 +1,7 @@
 //
 //  Vertical navigation
 // --------------------------------------------------
-.layout-pf-fixedafdaf.transitions .nav-pf-vertical {
+.layout-pf-fixed.transitions .nav-pf-vertical {
   transition: @flyout-transition-pf;
   &.collapsed .list-group-item .list-group-item-value {
     transition: opacity 0s .1s, opacity .1s linear;


### PR DESCRIPTION
Looks like a typo in .layout-pf-fixed**afdaf**.transitions. I am unsure how to test this because I'm not sure if anything had previously by it broken.
