### PR TITLE
add example for panel-like list group

### DIFF
--- a/tests/pages/list-group.html
+++ b/tests/pages/list-group.html
@@ -54,6 +54,38 @@ resource: true
         <a href="#" class="list-group-item list-group-item-danger">Vestibulum at eros</a>
       </div>
       <hr>
+      <h2>Panel List</h2>
+      <div class="list-group list-view-pf panel panel-default">
+        <a href="#" class="list-group-item list-view-pf-stacked list-view-pf-top-align">
+            <div class="list-view-pf-main-info">
+                <div class="list-view-pf-body">
+                    <div class="list-view-pf-description">
+                        <div class="list-group-item-heading">
+                            List group item heading
+                        </div>
+                        <div class="list-group-item-text">
+                            Additional text
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </a>
+        <a href="#" class="list-group-item list-view-pf-stacked list-view-pf-top-align">
+            <div class="list-view-pf-main-info">
+                <div class="list-view-pf-body">
+                    <div class="list-view-pf-description">
+                        <div class="list-group-item-heading">
+                            List group item heading
+                        </div>
+                        <div class="list-group-item-text">
+                            Additional text
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </a>
+      </div>
+      <hr>
       <h2>Custom content</h2>
       <div class="list-group">
         <a href="#" class="list-group-item active">


### PR DESCRIPTION
Added panel-like list group example. Line height of .list-group-item-heading was increased, because of
overflowing font character 'g' (characters descender height).
