### PR TITLE
add spec file for building rpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ npm
 npm.cmd
 
 # Ignore generated files
-patternfly.spec
 build
 
 # Ignore Desktop Services Store

--- a/patternfly.spec
+++ b/patternfly.spec
@@ -1,0 +1,30 @@
+Name:		patternfly3
+Summary:	PatternFly open interface project
+Version:	3.7.0
+Release:	1%{?release_suffix}%{?dist}
+License:	ASL 2.0
+URL:		https://github.com/patternfly/patternfly
+Source:		patternfly-3.7.0.tar.gz
+
+BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch:	noarch
+
+%description
+PatternFly open interface project
+
+%prep
+%setup -q -n patternfly-3.7.0
+
+%install
+rm -rf "%{buildroot}"
+mkdir -p "%{buildroot}/%{_datadir}/%{name}"
+cp -ar dist/* "%{buildroot}/%{_datadir}/%{name}/"
+rm -rf "%{buildroot}/%{_datadir}/%{name}/tests" || /bin/true
+
+%files
+%{_datadir}/%{name}/
+
+%changelog
+* Fri Jul 29 2016 Greg Sheremeta <gshereme@redhat.com> - 3.7.0-1
+- Initial version.
+


### PR DESCRIPTION
In PatternFly v1, we were using a complex rpm setup that
build the dist folder from source. For PatternFly v3,
this spec file simply packages the dist/ folder contents
into the rpm. When the rpm is installed, web applications
can access PatternFly at /usr/share/patternfly3.

Note one directory between v3 and v1 -- v1 had an intermediate
'resources' directory. This has been removed. E.g. patternfly.css
is now available at '/usr/share/patternfly3/css/patternfly.css'.

I'll maintain the rpm on copr. Current URL:
https://copr.fedorainfracloud.org/coprs/patternfly/patternfly3/

To use the rpm:
    sudo dnf copr enable patternfly/patternfly3
    sudo dnf install patternfly3
