### PR TITLE
Added patternfly-build@redhat.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,7 @@ script:
 
 after_success:
   - sh -x ./scripts/publish.sh
+
+notifications:
+  email:
+    - patternfly-build@redhat.com

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -14,7 +14,7 @@ fi
 
 # User info
 git config user.name "Admin"
-git config user.email "patternfly@redhat.com"
+git config user.email "patternfly-build@redhat.com"
 git config --global push.default simple
 
 # Add upstream authentication token


### PR DESCRIPTION
Created a patternfly-build@redhat.com mailing list for Travis build notifications. The thought is to have folks subscribe to this ML instead of blasting everyone on the patternfly and angular-patternfly mailing lists.

Currently, everyone on these mailing lists receive notification whenever the Travis build fails and again when it succeeds. This happens for the patternfly, angular-patternfly and patternfly-org repos.

Thoughts?
