### PR TITLE
PTNFLY-1647 - Horizontal Navigation - Make it sticky

### DIFF
--- a/less/layouts.less
+++ b/less/layouts.less
@@ -106,3 +106,25 @@
     }
   }
 }
+// when nav is fixed, set padding-top to the main container
+.navbar-fixed-top + .container-fluid{
+  padding-top: 72px;
+  @media (max-width: @grid-float-breakpoint){
+    padding-top: 38px;
+  }
+}
+.navbar-fixed-top + .nav-pf-vertical + .container-fluid{
+  padding-top: @navbar-pf-height;
+  padding-left: ( @nav-pf-vertical-width + 20px );
+  @media (max-width: @grid-float-breakpoint){
+    padding-left: 20px;
+  }
+}
+
+// move the transitions out of layout-pf-fixed
+.transitions .container-pf-nav-pf-vertical {
+  transition: @flyout-transition-pf;
+  -webkit-transition: margin-left @nav-pf-container-transition-period;
+  -moz-transition: margin-left @nav-pf-container-transition-period;
+  -o-transition: margin-left @nav-pf-container-transition-period;
+}

--- a/tests/pages/_includes/widgets/layouts/nav-horizontal-notification-drawer.html
+++ b/tests/pages/_includes/widgets/layouts/nav-horizontal-notification-drawer.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-default navbar-pf" role="navigation">
+<nav class="navbar navbar-default navbar-pf navbar-fixed-top" role="navigation">
   <div class="navbar-header">
     <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
       <span class="sr-only">Toggle navigation</span>

--- a/tests/pages/_includes/widgets/layouts/nav-vertical-notification-drawer.html
+++ b/tests/pages/_includes/widgets/layouts/nav-vertical-notification-drawer.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-pf-vertical">
+<nav class="navbar navbar-pf-vertical navbar-fixed-top">
   <div class="navbar-header">
     <button type="button" class="navbar-toggle">
       <span class="sr-only">Toggle navigation</span>

--- a/tests/pages/_includes/widgets/layouts/navbar-primary.html
+++ b/tests/pages/_includes/widgets/layouts/navbar-primary.html
@@ -1,4 +1,4 @@
-    {% strip %}<nav class="navbar navbar-default navbar-pf" role="navigation">
+    {% strip %}<nav class="navbar navbar-default navbar-pf navbar-fixed-top" role="navigation">
       <div class="navbar-header">
         <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
           <span class="sr-only">Toggle navigation</span>

--- a/tests/pages/_includes/widgets/layouts/navbar-vertical.html
+++ b/tests/pages/_includes/widgets/layouts/navbar-vertical.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-pf-vertical">
+<nav class="navbar navbar-pf-vertical navbar-fixed-top">
   <div class="navbar-header">
     <button type="button" class="navbar-toggle">
       <span class="sr-only">Toggle navigation</span>

--- a/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar.html
+++ b/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-default navbar-pf" role="navigation">
+<nav class="navbar navbar-default navbar-pf navbar-fixed-top" role="navigation">
   <div class="navbar-header">
     <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
       <span class="sr-only">Toggle navigation</span>

--- a/tests/pages/notification-drawer-vertical-nav.html
+++ b/tests/pages/notification-drawer-vertical-nav.html
@@ -1,7 +1,7 @@
 ---
 categories: [Layouts]
 css-extra: false
-layout: layout-fixed
+layout: layout-static
 resource: true
 full-page: true
 notification-drawer: true

--- a/tests/pages/vertical-navigation-primary-only.html
+++ b/tests/pages/vertical-navigation-primary-only.html
@@ -1,7 +1,7 @@
 ---
 categories: [Navigation]
 css-extra: false
-layout: layout-fixed
+layout: layout-static
 resource: true
 full-page: true
 hide-icons: false

--- a/tests/pages/vertical-navigation-with-secondary.html
+++ b/tests/pages/vertical-navigation-with-secondary.html
@@ -1,7 +1,7 @@
 ---
 categories: [Navigation]
 css-extra: false
-layout: layout-fixed
+layout: layout-static
 resource: true
 full-page: true
 hide-icons: false

--- a/tests/pages/vertical-navigation-with-tertiary-no-icons.html
+++ b/tests/pages/vertical-navigation-with-tertiary-no-icons.html
@@ -1,7 +1,7 @@
 ---
 categories: [Navigation]
 css-extra: false
-layout: layout-fixed
+layout: layout-static
 resource: true
 full-page: true
 hide-icons: true

--- a/tests/pages/vertical-navigation-with-tertiary-pins.html
+++ b/tests/pages/vertical-navigation-with-tertiary-pins.html
@@ -1,7 +1,7 @@
 ---
 categories: [Navigation]
 css-extra: false
-layout: layout-fixed
+layout: layout-static
 resource: true
 full-page: true
 hide-icons: false


### PR DESCRIPTION
https://patternfly.atlassian.net/browse/PTNFLY-1647

Add class '.nav-fixed-top' to the navigation horizontal html
Add padding top to the container-fuild

Changed files
less/layouts.less
tests/pages/_includes/widgets/layouts/nav-horizontal-notification-drawer.html

I don't know how to get the demo link, let you see the demo page.
So I add the html page to my sever. 
Please check the demo page here: https://devops-ucd.rhcloud.com/June/patternfly/dist/tests/notification-drawer-horizontal-nav.html
