### PR TITLE
update google-code-prettify

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "datatables.net-colreorder": "~1.3.2",
     "drmonty-datatables-colvis": "~1.1.2",
     "eonasdan-bootstrap-datetimepicker": "~4.15.35",
-    "google-code-prettify": "~1.0.1",
+    "google-code-prettify": "~1.0.4",
     "jquery-match-height": "~0.7.0",
     "moment": "~2.14.1",
     "patternfly-bootstrap-combobox": "~1.1.7",


### PR DESCRIPTION
- after [request](https://github.com/tcollard/google-code-prettify/pull/11), they have republished google-code-prettify upstream to make the npm version match the bower version. 
