### PR TITLE
Add Code of Conduct info

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+This project is governed by the [Contributor Covenant version 1.4][1]. All contributors and participants agree to abide by its terms. To report violations, send an email to [covenant@idolhands.com][2].
+
+ [1]: http://contributor-covenant.org/version/1/4/code_of_conduct.md
+ [2]: mailto:covenant@idolhands.com


### PR DESCRIPTION
Add Code of Conduct info to repo, per Contributor Covenant's request for inclusion in their adopters page.
