### PR TITLE
Fix for Fixed Accordions when no parent selector is given.

### DIFF
--- a/src/js/patternfly.js
+++ b/src/js/patternfly.js
@@ -937,7 +937,7 @@
       setTimeout(function () {
         // Set the max-height for the collapse panels
         parentElement.find('[data-toggle="collapse"]').each($.proxy(function (i, element) {
-          var $element, selector, $target, scrollElement, innerHeight;
+          var $element, selector, $target, scrollElement, innerHeight = 0;
           $element = $(element);
 
           // Determine the selector to find the target


### PR DESCRIPTION
The inner height variable was not initialized when no parent selector is given so the body's max height value was not being set.
