### PR TITLE
update google-code-prettify once more

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "datatables-colreorder": "~1.3.2",
     "datatables-colvis": "~1.1.2",
     "font-awesome": "~4.6.3",
-    "google-code-prettify": "~1.0.4",
+    "google-code-prettify": "~1.0.5",
     "jquery": "~2.1.4",
     "matchHeight": "~0.7.0",
     "eonasdan-bootstrap-datetimepicker": "~4.17.37",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "datatables.net-colreorder": "~1.3.2",
     "drmonty-datatables-colvis": "~1.1.2",
     "eonasdan-bootstrap-datetimepicker": "~4.15.35",
-    "google-code-prettify": "~1.0.4",
+    "google-code-prettify": "~1.0.5",
     "jquery-match-height": "~0.7.0",
     "moment": "~2.14.1",
     "patternfly-bootstrap-combobox": "~1.1.7",


### PR DESCRIPTION
They have now published to npm with versions in sync, so this should be safe to update now.
https://github.com/tcollard/google-code-prettify/pull/12
