### PR TITLE
Removing class select from cards of Card View.

### DIFF
--- a/less/card-view.less
+++ b/less/card-view.less
@@ -69,7 +69,7 @@
   }
   .card-pf-view-checkbox {
     position: absolute;
-    top: 15px;
+    top: 11px;
     left: 15px;
     input[type=checkbox] { display: none; }
   }

--- a/tests/pages/_includes/widgets/cards/object-status.html
+++ b/tests/pages/_includes/widgets/cards/object-status.html
@@ -1,4 +1,4 @@
-<div class="card-pf card-pf-view card-pf-view-select {{include.class1}}">
+<div class="card-pf card-pf-view {{include.class1}}">
   <div class="card-pf-body">
     <div class="card-pf-top-element">
       <span class="fa fa-birthday-cake card-pf-icon-circle"></span>

--- a/tests/pages/_includes/widgets/layouts/card-view-multi-select.html
+++ b/tests/pages/_includes/widgets/layouts/card-view-multi-select.html
@@ -3,52 +3,52 @@
 <div class="container-fluid container-cards-pf">
   <div class="row row-cards-pf">
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-{% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
     </div>
   </div>
 </div>

--- a/tests/pages/_includes/widgets/layouts/card-view-single-select.html
+++ b/tests/pages/_includes/widgets/layouts/card-view-single-select.html
@@ -3,22 +3,22 @@
 <div class="container-fluid container-cards-pf">
   <div class="row row-cards-pf">
     <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
-{% include widgets/cards/object-status.html class1="card-pf-view-single-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-single-select" %}
     </div>
     <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
-{% include widgets/cards/object-status.html class1="card-pf-view-single-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-single-select" %}
     </div>
     <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
-{% include widgets/cards/object-status.html class1="card-pf-view-single-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-single-select" %}
     </div>
     <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
-{% include widgets/cards/object-status.html class1="card-pf-view-single-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-single-select" %}
     </div>
     <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
-{% include widgets/cards/object-status.html class1="card-pf-view-single-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-single-select" %}
     </div>
     <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
-{% include widgets/cards/object-status.html class1="card-pf-view-single-select" %}
+{% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-single-select" %}
     </div>
   </div>
 </div>

--- a/tests/pages/card-view-card-variations.html
+++ b/tests/pages/card-view-card-variations.html
@@ -5,23 +5,23 @@ title: Card View - Card Variations
 resource: true
 ---
 
-<h2>Large, Single Select</h2>
+<h2>Large Card</h2>
 <div class="cards-pf">
   <div class="row row-cards-pf">
     <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
-{% include widgets/cards/object-status.html class1="card-pf-view-single-select" %}
+{% include widgets/cards/object-status.html %}
     </div>
   </div>
 </div>
-<h2>Small, Multi Select</h2>
+<h2>Small Card</h2>
 <div class="cards-pf">
   <div class="row row-cards-pf">
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
-  {% include widgets/cards/object-status.html class1="card-pf-view-multi-select" %}
+  {% include widgets/cards/object-status.html %}
     </div>
   </div><!-- /row -->
 </div>
-<h2>Mini, Status</h2>
+<h2>Mini Card with status</h2>
 <div class="cards-pf">
   <div class="row row-cards-pf">
     <div class="col-xs-12 col-sm-3 col-md-2">
@@ -29,7 +29,7 @@ resource: true
     </div>
   </div><!-- /row -->
 </div>
-<h2>Mini, Summary</h2>
+<h2>Mini Card with text</h2>
 <div class="cards-pf">
   <div class="row row-cards-pf">
     <div class="col-xs-12 col-sm-3 col-md-2">


### PR DESCRIPTION
## Description

To support cards that are selectable or NOT selectable, I removed the class card-pf-view-select from the card widget. Now, this class should be declared in the view that consumes the widget.

This change is to support the Card View Page in patternfly-org: https://patternfly.atlassian.net/browse/PTNFLY-1586
