### PR TITLE
Removed global email.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,3 @@ script:
 
 after_success:
   - sh -x ./scripts/publish.sh
-
-notifications:
-  email:
-    - patternfly-build@redhat.com

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -13,7 +13,7 @@ then
 fi
 
 # User info
-git config user.name "Admin"
+git config user.name "patternfly-build"
 git config user.email "patternfly-build@redhat.com"
 git config --global push.default simple
 
@@ -36,5 +36,3 @@ then
 else
   git push upstream $TRAVIS_BRANCH:$TRAVIS_BRANCH-dist --force -v
 fi
-
-exit $?


### PR DESCRIPTION
## Description

Now that developers are building their own dist directories via Travis, we no longer want the email property set in travis.yml. Currently, all build notifications are being sent to patternfly-build@redhat.com, even for personal forks. The committer/author should be notified when building their own repos, not patternfly-build@redhat.com.
- Removed global email
- Created a valid user in GitHub for committing dist changes. 

Now GitHub shows dist commits by a valid user patternfly-build with email patternfly-build@redhat.com.

![screen shot 2016-08-23 at 11 21 44 pm](https://cloud.githubusercontent.com/assets/17481322/17917234/6d8492ec-6988-11e6-8de7-856770636aec.png)
