### PR TITLE
Removing css that caused issue with borders displaying in secondary a…

### DIFF
--- a/less/list-group.less
+++ b/less/list-group.less
@@ -9,26 +9,10 @@
   }
 }
 .list-group-item {
-	border-top: 0;
   border-left: 0;
   border-right: 0;
-  margin-bottom: 0;
 }
 
 .list-group-item-heading {
   font-weight: 600;
-}
-
-.list-group-item {
-  &.active,
-  &.active:hover,
-  &.active:focus {
-    border-top: solid 1px @list-group-active-border;
-    margin-top: -1px;
-    z-index: auto;
-  }
-  &.active:first-child{
-    border-top: 1px solid @list-group-active-border !important;
-    margin-top: -1px;
-  }
 }

--- a/less/list-view.less
+++ b/less/list-view.less
@@ -14,6 +14,7 @@
     &.active {
       color: @list-group-link-color;
       background-color: @list-view-active-bg;
+      z-index:auto;
     }
     &:hover {
       background-color: @list-view-hover-bg;


### PR DESCRIPTION
## Description

A previous update, #400, to list-group.less resulted in unwanted borders displaying for list group items in the secondary and tertiary nav panels. To fix the issue I removed the css that resulted in these borders displaying. 

**NOTE,** the border style updates in #400 modified the display of borders in the list view, so that when a row was selected, a top AND bottom blue border displayed. With this CSS removed, only a top blue border will display for selected items (for any row except first). In the design document, blue borders do not display at all so I'm not sure what the actual expected look is. If further updates are needed for this, please let me know. 

I also moved the css that fixed the original issue addressed by #400 from list-group.less to list-view.less as suggested by Andres.
## Examples of updates

Navigation Before
![screen shot 2016-08-24 at 12 36 43 pm](https://cloud.githubusercontent.com/assets/21063328/17939191/7246f86e-69f7-11e6-8342-0a3e5d70f7f9.png)

Navigation After
![After](https://cloud.githubusercontent.com/assets/21063328/17939123/0cc37594-69f7-11e6-99d9-6d6139ff12a0.png)

List View Before
![screen shot 2016-08-24 at 12 37 24 pm](https://cloud.githubusercontent.com/assets/21063328/17939210/8c515c4a-69f7-11e6-86fa-2b7329f046d3.png)

List View After
![After](https://cloud.githubusercontent.com/assets/21063328/17939137/1aab55b4-69f7-11e6-893a-b3ae0ea191f7.png)
