### PR TITLE
Ensure dist branch is not redeployed

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -12,6 +12,11 @@ then
   fi
 fi
 
+# Ensure dist branch is not redeployed.
+case $TRAVIS_BRANCH in
+  *-dist$* ) echo "This commit was made against the dist branch. Do not deploy!"; exit 1;;
+esac
+
 # User info
 git config user.name "patternfly-build"
 git config user.email "patternfly-build@redhat.com"


### PR DESCRIPTION
## Description

Apparently, multiple dist branches are being created for some forks. I was not able to reproduce, but it's possible if there is an existing dist directory and a merge is performed.  
## Changes:
- Added simple test to ensure the dist branch is not redeployed. If the branch name ends in "-dist", we exit the publish.sh script.
