### PR TITLE
PTNFLY-1790 adds checklist to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,11 @@
 ## Description
 Write a few sentences describing the overall goals of the pull request's commits.
 
-(optional) Include related PRs or Issues
+(optional) Include related PRs, Issues and or Jira stories.
 
-(optional) Include a list of changes:
+## Changes
+
+Write a list of changes the PR introduces
 
 * Change 01
 * Change 02
@@ -16,3 +18,17 @@ For example: Here is a [link to Alerts on rawgit](https://rawgit.com/patternfly/
 This is an image:
 
 ![Image description](http://placehold.it/350x150)
+
+## PR checklist (if relevant)
+
+- [ ] **Cross browser**: works in IE9
+- [ ] **Cross browser**: works in IE10
+- [ ] **Cross browser**: works in IE11
+- [ ] **Cross browser**: works in Edge
+- [ ] **Cross browser**: works in Chrome
+- [ ] **Cross browser**: works in Firefox
+- [ ] **Cross browser**: works in Safari
+- [ ] **Cross browser**: works in Opera
+- [ ] **Responsive**: works in extra small, small, medium and large view ports.
+- [ ] **Code guidelines**: Follows [PatternFly Code Guide](http://codeguide.patternfly.org/)
+- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.


### PR DESCRIPTION
## Description

The goal is to make contributors aware that contribution should follow some standards, for example been responsive and cross browser compatible.

Thats why I've added a checklist to the PR template. This doesn't apply to all PRs, thats why I've marked it as optional. If the PR is relevant to a UI change, then it should follow the standards.

[Link to Jira issue](https://patternfly.atlassian.net/browse/PTNFLY-1790)
## Link to a preview

https://github.com/andresgalante/patternfly/blob/PTNFLY-1790-PR-template/.github/PULL_REQUEST_TEMPLATE.md

@dlabrecq @cardosogabriel @LHinson @bleathem can you please review this one?  👀  
