### PR TITLE
Add missing style definitions for treeview node images

### DIFF
--- a/less/bootstrap-treeview.less
+++ b/less/bootstrap-treeview.less
@@ -44,6 +44,16 @@
       margin-right: 10px;
     }
   }
+  span.image {
+    background-repeat: no-repeat;
+    background-size: contain;
+    display: inline-block;
+    height: 1.19em;
+    line-height: 1em;
+    margin-right: 5px;
+    vertical-align: middle;
+    width: 12px;
+  }
   span.indent {
     margin-right: 5px;
   }


### PR DESCRIPTION
Node icons are working properly, but 5daf134 introduced optional
node image support. For this it is necessary to have some extra
style definitions.

![screenshot from 2016-09-02 09-07-06](https://cloud.githubusercontent.com/assets/649130/18195665/09e8809c-70ed-11e6-9964-996b4175fd28.png)

Maybe this PR is wrong and the bootstrap-treeview.css file needs
to be included in our codebase under the lib folder and loaded
from the top level less file...
