### PR TITLE
Fix specificity on setting collapsed items width for vertical nav.

### DIFF
--- a/less/vertical-nav.less
+++ b/less/vertical-nav.less
@@ -227,7 +227,7 @@
     }
   }
 }
-.collapsed {
+.nav-pf-vertical.collapsed {
   width: @nav-pf-vertical-collapsed-width;
   &.collapsed-secondary-nav-pf { // collapsed state with secondary menu pinned
     width: @nav-pf-vertical-width;
@@ -248,7 +248,7 @@
     }
   }
   &.hover-tertiary-nav-pf {
-    width: calc(@nav-pf-vertical-collapsed-width + (@nav-pf-vertical-badges-width * 2));
+    width: calc(@nav-pf-vertical-collapsed-width + (@nav-pf-vertical-width * 2));
     &.nav-pf-vertical-with-badges {
       width: calc(@nav-pf-vertical-collapsed-width + (@nav-pf-vertical-badges-width * 2));
     }


### PR DESCRIPTION
## Description

Adds specificity to vertical navigations settings to set the width for collapsed items to only effect those in vertical navigation

http://rawgit.com/jeff-phillips-18/patternfly/fixes-dist/dist/tests/index.html

Fixes issue in patternfly-org: https://github.com/patternfly/patternfly-org/issues/281
