### PR TITLE
PTNFLY-1462 Making the Horizontal Nav and Notification Drawer for horizontal nav use the same include.

### DIFF
--- a/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar-page.html
+++ b/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar-page.html
@@ -1,4 +1,8 @@
-{% include widgets/navigation/horizontal-primary-nav-bar.html %}
+{% if page.notification-drawer %}
+  {% include widgets/layouts/nav-horizontal-notification-drawer.html %}
+{% else %}
+  {% include widgets/navigation/horizontal-primary-nav-bar.html %}
+{% endif %}
 <div class="container-fluid container-cards-pf">
 {% include widgets/layouts/cards-alt.html %}
 </div>

--- a/tests/pages/notification-drawer-horizontal-nav.html
+++ b/tests/pages/notification-drawer-horizontal-nav.html
@@ -4,22 +4,8 @@ css-extra: false
 layout: layout-fixed
 resource: true
 full-page: true
+notification-drawer: true
 title: Notification Drawer for Horizontal Navigation
 url-js-extra: ['//cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js', '//cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.js', '//cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js']
 ---
-{% include widgets/layouts/nav-horizontal-notification-drawer.html %}
-<div class="container-fluid container-cards-pf">
-{% include widgets/layouts/cards-alt.html %}
-</div>
-<script>
-  $(document).ready(function() {
-    // matchHeight the contents of each .card-pf and then the .card-pf itself
-    $(".row-cards-pf > [class*='col'] > .card-pf .card-pf-title").matchHeight();
-    $(".row-cards-pf > [class*='col'] > .card-pf > .card-pf-body").matchHeight();
-    $(".row-cards-pf > [class*='col'] > .card-pf > .card-pf-footer").matchHeight();
-    $(".row-cards-pf > [class*='col'] > .card-pf").matchHeight();
-
-    // initialize tooltips
-    $('[data-toggle="tooltip"]').tooltip();
-  });
-</script>
+{% include widgets/navigation/horizontal-primary-nav-bar-page.html %}


### PR DESCRIPTION
## Description

The same way it was done for Vertical Navigation / Notification Drawer for vertical nav, the include for horizontal navigation was adjusted to be able to be consumed by both Horizontal Nav and Notification Drawer for horizontal nav pages.

The pages continue working the same. This was an adjustment to allow patternfly-org to consume this include.
