### PR TITLE
PTNFLY-1780 Making Tree View hover and selected state optional.

### DIFF
--- a/src/less/bootstrap-treeview.less
+++ b/src/less/bootstrap-treeview.less
@@ -10,20 +10,19 @@
     background: transparent;
     border-bottom: 1px solid transparent !important;
     border-top: 1px solid transparent !important;
+    cursor: default !important;
     margin-bottom: 0;
     overflow: hidden;
     padding: 0 10px;
     text-overflow: ellipsis;
     white-space: nowrap;
-
     &:hover {
-      background: @dropdown-link-hover-bg !important;
-      border-color: @dropdown-link-hover-border-color !important;
+      background: none !important;
     }
     &.node-selected {
-      background: @dropdown-link-active-bg !important;
-      border-color: @dropdown-link-active-border-color !important;
-      color: @dropdown-link-active-color !important;
+      background: none !important;
+      border-color: transparent !important;
+      color: inherit !important;
     }
     &.node-check-changed {
       span.node-icon,
@@ -43,6 +42,9 @@
     &.check-icon {
       margin-right: 10px;
     }
+    &.expand-icon {
+      cursor: pointer !important;
+    }
   }
   span.image {
     background-repeat: no-repeat;
@@ -60,8 +62,28 @@
   .node-disabled {
     color: @color-pf-black-300;
     cursor: not-allowed;
+    span.expand-icon {
+      cursor: default !important;
+    }
   }
   .node-hidden {
     display:none;
+  }
+}
+
+.treeview-pf-hover .list-group-item {
+  cursor: pointer !important;
+  &:hover {
+    background-color: @dropdown-link-hover-bg !important;
+    border-color: @dropdown-link-hover-border-color !important;
+  }
+}
+
+.treeview-pf-select .list-group-item {
+  cursor: pointer !important;
+  &.node-selected {
+    background: @dropdown-link-active-bg !important;
+    border-color: @dropdown-link-active-border-color !important;
+    color: @dropdown-link-active-color !important;
   }
 }

--- a/tests/pages/bootstrap-treeview.html
+++ b/tests/pages/bootstrap-treeview.html
@@ -58,11 +58,15 @@ url-js-extra: '//rawgit.com/patternfly/patternfly-bootstrap-treeview/patternfly/
           <div id="treeview10"></div>
         </div><!--/col-->
         <div class="col-sm-4">
-          <h2>Prevent Unselection</h2>
-          <div id="treeview11"></div>
+          <h2>Hover and Select</h2>
+          <div id="treeview13" class="treeview-pf-hover treeview-pf-select"></div>
         </div><!--/col-->
       </div>
       <div class="row">
+        <div class="col-sm-4">
+          <h2>Prevent Unselection</h2>
+          <div id="treeview11" class="treeview-pf-select"></div>
+        </div><!--/col-->
         <div class="col-sm-4">
           <h2>Disabled Nodes</h2>
           <div id="treeview12"></div>
@@ -325,6 +329,15 @@ url-js-extra: '//rawgit.com/patternfly/patternfly-bootstrap-treeview/patternfly/
             showBorder: false
           });
           tree12.treeview('disableAll');
+
+          //Hover and Select
+          $('#treeview13').treeview({
+            collapseIcon: collapseIcon,
+            data: defaultData,
+            expandIcon: expandIcon,
+            nodeIcon: nodeIcon,
+            showBorder: false
+          });
 
         });
       </script>


### PR DESCRIPTION
## Description

Removed the hover and selected visual styling from treeviews. It is possible to display such styles, but the classes `treeview-pf-hover` and `treeview-pf-select` need to be added to the `treeview` component.

Issue: https://patternfly.atlassian.net/browse/PTNFLY-1780
## Improvements
- Added cursor pointer for the expand arrow of treeview items, except in case of treeview Disabled.
## Link to rawgit and/or image

http://rawgit.com/cardosogabriel/patternfly/PTNFLY-1780-dist/dist/tests/bootstrap-treeview.html

Added the option "Hover and Select" in the tests page.
## PR checklist (if relevant)
- [x] **Cross browser**: works in IE9
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [x] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Code guidelines**: Follows [PatternFly Code Guide](http://codeguide.patternfly.org/)
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
