### PR TITLE
ListView example shows donut charts incorrectly

### DIFF
--- a/tests/pages/_includes/widgets/list-view/list-view-variation-1.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-1.html
@@ -41,6 +41,7 @@
   var c3ChartDefaults = $().c3ChartDefaults();
   var customDonutChartConfig = c3ChartDefaults.getDefaultDonutConfig('34%');
   customDonutChartConfig.size.height = 71;
+  customDonutChartConfig.size.width = 60;
   customDonutChartConfig.donut.width = 5;
   customDonutChartConfig.bindto = '#{{include.id1}}';
   customDonutChartConfig.data = {
@@ -61,6 +62,7 @@
 
   customDonutChartConfig = c3ChartDefaults.getDefaultDonutConfig('21%');
   customDonutChartConfig.size.height = 71;
+  customDonutChartConfig.size.width = 60;
   customDonutChartConfig.donut.width = 5;
   customDonutChartConfig.bindto = '#{{include.id2}}';
   customDonutChartConfig.data = {
@@ -81,6 +83,7 @@
 
   customDonutChartConfig = c3ChartDefaults.getDefaultDonutConfig('14%');
   customDonutChartConfig.size.height = 71;
+  customDonutChartConfig.size.width = 60;
   customDonutChartConfig.donut.width = 5;
   customDonutChartConfig.bindto = '#{{include.id3}}';
   customDonutChartConfig.data = {
@@ -101,6 +104,7 @@
 
   customDonutChartConfig = c3ChartDefaults.getDefaultDonutConfig('25%');
   customDonutChartConfig.size.height = 71;
+  customDonutChartConfig.size.width = 60;
   customDonutChartConfig.donut.width = 5;
   customDonutChartConfig.bindto = '#{{include.id4}}';
   customDonutChartConfig.data = {


### PR DESCRIPTION
## Description

Fix for a bug Liz B. encountered on pf.org, where the ListView code example (variant # 1) show donut charts located off the page.

The problem is that the chart widths are auto-generated incorrectly. We've been setting height, but not width.

There should be no change for the test page itself. The difference will be best seen on pf.org, after this update.
## Changes
- Set the width of donut charts in list view example
## Link to rawgit and/or image

https://rawgit.com/dlabrecq/patternfly/list-view-fix-dist/dist/tests/list-view-rows.html

This is an image from pf.org:

![screen shot 2016-09-15 at 12 46 32 pm](https://cloud.githubusercontent.com/assets/17481322/18558804/7bae4c20-7b42-11e6-8c21-87efb59cd015.png)
