### PR TITLE
PNTLY-1829 Required fields for forms.

### DIFF
--- a/src/less/forms.less
+++ b/src/less/forms.less
@@ -10,6 +10,11 @@
   color: @brand-danger;
 }
 
+.fields-status-pf {
+  color: @color-pf-black-500;
+  margin-bottom: 15px;
+}
+
 .form-control {
   &[disabled],
   &[readonly],
@@ -58,4 +63,13 @@
 
 label {
   font-weight: 600;
+  &.required-pf:after {
+    color: @brand-danger;
+    content: "*";
+    margin-left: 3px;
+  }
+}
+
+span.required-pf {
+  color: @brand-danger;
 }

--- a/tests/pages/forms.html
+++ b/tests/pages/forms.html
@@ -4,67 +4,136 @@ layout: page
 title: Forms
 resource: true
 ---
-      <h2>PatternFly Example</h2>
-      <form class="form-horizontal">
+      <h2>Right-aligned labels</h2>
+
+      <h3>Basic Form</h3>
+      <form class="form-horizontal" role="form">
         <div class="form-group">
-          <label class="col-sm-2 control-label" for="textInput">Default</label>
+          <label for="inputEmail1" class="col-sm-2 control-label">Email</label>
           <div class="col-sm-10">
-            <input type="text" id="textInput" class="form-control"></div>
+            <input type="email" class="form-control" id="inputEmail1">
+          </div>
         </div>
         <div class="form-group">
-          <label class="col-sm-2 control-label" for="textInputDisabled">Disabled</label>
+          <label for="inputPassword1" class="col-sm-2 control-label">Password</label>
           <div class="col-sm-10">
-            <input type="text" id="textInputDisabled" class="form-control" disabled></div>
+            <input type="password" class="form-control" id="inputPassword1">
+          </div>
         </div>
-        <div class="form-group has-error">
-          <label class="col-sm-2 control-label" for="inputError">With error</label>
-          <div class="col-sm-10">
-            <input type="text" id="inputError1" class="form-control">
-            <span class="help-block">Please correct the error</span>
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-10">
+            <div class="checkbox">
+              <label>
+                <input type="checkbox"> Remember me
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-10">
+            <button type="submit" class="btn btn-default">Sign in</button>
           </div>
         </div>
       </form>
-      <h2>Count Remaining Characters Control</h2>
-      <form>
+
+      <h3>All Fields Required</h3>
+      <form class="form-horizontal" role="form">
+        <p class="fields-status-pf">All fields are required.</p>
         <div class="form-group">
-          <label for="messageArea"></label>
-          <textarea class="form-control" id="messageArea" name="text" placeholder="Type in your message" rows="5"></textarea>
+          <label for="input1" class="col-sm-2 control-label">Field One</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="input1" required>
+          </div>
         </div>
-          <span class="pull-right chars-remaining-pf">
-            <span id="charRemainingCntFld"></span>
-            <button id="postBtn" type="submit" class="btn btn-default">Post New Message</button>
-          </span>
+        <div class="form-group">
+          <label for="input2" class="col-sm-2 control-label">Field Two</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="input2" required>
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="input3" class="col-sm-2 control-label">Field Three</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="input3" required>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-10">
+            <button type="submit" class="btn btn-default" disabled>Action</button>
+          </div>
+        </div>
       </form>
-      <script>
-        // countFld is the id of the field where you want the 'remaining chars. count' number
-        // to be displayed.
-        $('#messageArea').countRemainingChars( {countFld: 'charRemainingCntFld'} );
 
-        // all settings/options
-        // $('#messageArea').countRemainingChars( {countFld: 'charRemainingCntFld',
-        //                                         charsMaxLimit: 20,
-        //                                         charsWarnRemaining: 5,
-        //                                         blockInputAtMaxLimit: true} );
+      <h3>Required and Optional Fields</h3>
+      <form class="form-horizontal" role="form">
+        <p class="fields-status-pf">The fields marked with <span class="required-pf">*</span> are required.</p>
+        <div class="form-group">
+          <label for="input4" class="col-sm-2 control-label required-pf">Field One</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="input4" required>
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="input5" class="col-sm-2 control-label">Field Two</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="input5">
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="input6" class="col-sm-2 control-label required-pf">Field Three</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="input6" required>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-10">
+            <button type="submit" class="btn btn-default" disabled>Action</button>
+          </div>
+        </div>
+      </form>
 
+      <h3>All Fields Optional</h3>
+      <form class="form-horizontal" role="form">
+        <p class="fields-status-pf">All fields are optional.</p>
+        <div class="form-group">
+          <label for="input7" class="col-sm-2 control-label">Field One</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="input7">
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="input8" class="col-sm-2 control-label">Field Two</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="input8">
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="input9" class="col-sm-2 control-label">Field Three</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="input9">
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-10">
+            <button type="submit" class="btn btn-default">Action</button>
+          </div>
+        </div>
+      </form>
 
-        // taId is the id of the textArea field which triggered the event
-        // Helpful if counting remaining chars on multiple TAs
-        $('#messageArea').on("overCharsMaxLimitEvent", function( event, taId ) {
-          $('#postBtn').prop("disabled",true);
-        });
-        $('#messageArea').on("underCharsMaxLimitEvent", function( event, taId) {
-          $('#postBtn').prop("disabled",false);
-        });
-      </script><br>
-      <h2>Basic Example</h2>
+      <h3>Error Feedback</h3>
+      {% include widgets/forms/input-validation-form.html id-default="exampleInput" id-disabled="exampleInputDisabled" id-error="exampleInputError" has-error=true %}
+
+      <h2>Top-aligned labels</h2>
+
+      <h3>Basic Form</h3>
       <form role="form">
         <div class="form-group">
           <label for="exampleInputEmail1">Email address</label>
-          <input type="email" class="form-control" id="exampleInputEmail1" placeholder="Enter email">
+          <input type="email" class="form-control" id="exampleInputEmail1">
         </div>
         <div class="form-group">
           <label for="exampleInputPassword1">Password</label>
-          <input type="password" class="form-control" id="exampleInputPassword1" placeholder="Password">
+          <input type="password" class="form-control" id="exampleInputPassword1">
         </div>
         <div class="form-group">
           <label for="exampleInputFile">File input</label>
@@ -78,6 +147,61 @@ resource: true
         </div>
         <button type="submit" class="btn btn-default">Submit</button>
       </form>
+
+      <h3>All Fields Required</h3>
+      <form role="form">
+        <p class="fields-status-pf">All fields are required.</p>
+        <div class="form-group">
+          <label for="input10">Field One</label>
+          <input type="text" class="form-control" id="input10" required>
+        </div>
+        <div class="form-group">
+          <label for="input11">Field Two</label>
+          <input type="text" class="form-control" id="input11" required>
+        </div>
+        <div class="form-group">
+          <label for="input12">Field Three</label>
+          <input type="text" class="form-control" id="input12" required>
+        </div>
+        <button type="submit" class="btn btn-default" disabled>Action</button>
+      </form>
+
+      <h3>Required and Optional Fields</h3>
+      <form role="form">
+        <p class="fields-status-pf">The fields marked with <span class="required-pf">*</span> are required.</p>
+        <div class="form-group">
+          <label for="input13" class="required-pf">Field One</label>
+          <input type="text" class="form-control" id="input13" required>
+        </div>
+        <div class="form-group">
+          <label for="input14">Field Two</label>
+          <input type="text" class="form-control" id="input14">
+        </div>
+        <div class="form-group">
+          <label for="input15" class="required-pf">Field Three</label>
+          <input type="text" class="form-control" id="input15" required>
+        </div>
+        <button type="submit" class="btn btn-default" disabled>Action</button>
+      </form>
+
+      <h3>All Fields Optional</h3>
+      <form role="form">
+        <p class="fields-status-pf">All fields are optional.</p>
+        <div class="form-group">
+          <label for="input16">Field One</label>
+          <input type="text" class="form-control" id="input16">
+        </div>
+        <div class="form-group">
+          <label for="input17">Field Two</label>
+          <input type="text" class="form-control" id="input17">
+        </div>
+        <div class="form-group">
+          <label for="input18">Field Three</label>
+          <input type="text" class="form-control" id="input18">
+        </div>
+        <button type="submit" class="btn btn-default">Action</button>
+      </form>
+
       <h2>Inline Form</h2>
       <form class="form-inline" role="form">
         <div class="form-group">
@@ -95,36 +219,29 @@ resource: true
         </div>
         <button type="submit" class="btn btn-default">Sign in</button>
       </form>
-      <h2>Horizontal Form</h2>
-      <form class="form-horizontal" role="form">
-        <div class="form-group">
-          <label for="inputEmail1" class="col-lg-2 control-label">Email</label>
-          <div class="col-lg-10">
-            <input type="email" class="form-control" id="inputEmail1" placeholder="Email">
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="inputPassword1" class="col-lg-2 control-label">Password</label>
-          <div class="col-lg-10">
-            <input type="password" class="form-control" id="inputPassword1" placeholder="Password">
-          </div>
-        </div>
-        <div class="form-group">
-          <div class="col-lg-offset-2 col-lg-10">
-            <div class="checkbox">
-              <label>
-                <input type="checkbox"> Remember me
-              </label>
-            </div>
-          </div>
-        </div>
-        <div class="form-group">
-          <div class="col-lg-offset-2 col-lg-10">
-            <button type="submit" class="btn btn-default">Sign in</button>
-          </div>
-        </div>
-      </form>
-      <h2>Supported Controls</h2>
+
+      <h2>Inside a modal</h2>
+      <!--
+        Styles and example-pf div makes modal visible and posistion relative. It's intended for docs page.
+        *Do not use in production*
+      -->
+      <style>
+        .example-pf .modal{
+          position: relative;
+          top: auto;
+          right: auto;
+          bottom: auto;
+          left: auto;
+          z-index: 1;
+          display: block;
+        }
+      </style>
+      <div class="example-pf">
+        {% include widgets/forms/input-validation-modal.html id-default="modalInput" id-disabled="modalInputDisabled" id-error="modalInputError" has-error=true %}
+      </div>
+
+      <h2>Controls</h2>
+
       <input type="text" class="form-control" placeholder="Text input">
       <input type="password" class="form-control" placeholder="Text input">
       <input type="datetime" class="form-control" placeholder="Text input">
@@ -181,7 +298,41 @@ resource: true
         <option>4</option>
         <option>5</option>
       </select>
-      <h2>Static Control</h2>
+
+      <h3>Count Remaining Characters Control</h3>
+      <form>
+        <div class="form-group">
+          <label for="messageArea"></label>
+          <textarea class="form-control" id="messageArea" name="text" placeholder="Type in your message" rows="5"></textarea>
+        </div>
+          <span class="pull-right chars-remaining-pf">
+            <span id="charRemainingCntFld"></span>
+            <button id="postBtn" type="submit" class="btn btn-default">Post New Message</button>
+          </span>
+      </form>
+      <script>
+        // countFld is the id of the field where you want the 'remaining chars. count' number
+        // to be displayed.
+        $('#messageArea').countRemainingChars( {countFld: 'charRemainingCntFld'} );
+
+        // all settings/options
+        // $('#messageArea').countRemainingChars( {countFld: 'charRemainingCntFld',
+        //                                         charsMaxLimit: 20,
+        //                                         charsWarnRemaining: 5,
+        //                                         blockInputAtMaxLimit: true} );
+
+
+        // taId is the id of the textArea field which triggered the event
+        // Helpful if counting remaining chars on multiple TAs
+        $('#messageArea').on("overCharsMaxLimitEvent", function( event, taId ) {
+          $('#postBtn').prop("disabled",true);
+        });
+        $('#messageArea').on("underCharsMaxLimitEvent", function( event, taId) {
+          $('#postBtn').prop("disabled",false);
+        });
+      </script><br>
+
+      <h3>Static Control</h3>
       <form class="form-horizontal" role="form">
         <div class="form-group">
           <label class="col-lg-2 control-label">Email</label>
@@ -196,6 +347,176 @@ resource: true
           </div>
         </div>
       </form>
+
+      <h3>Help Text</h3>
+      <span class="help-block">A block of help text that breaks onto a new line and may extend beyond one line.</span>
+      <div class="input-group">
+        <span class="input-group-addon">@</span>
+        <input type="text" class="form-control" placeholder="Username">
+      </div>
+
+      <h3>Control Sizing</h3>
+      <input class="form-control input-lg" type="text" placeholder=".input-lg">
+      <input class="form-control" type="text" placeholder="Default input">
+      <input class="form-control input-sm" type="text" placeholder=".input-sm">
+      <select class="form-control input-lg">...</select>
+      <select class="form-control">...</select>
+      <select class="form-control input-sm">...</select>
+      <div class="row">
+        <div class="col-lg-2">
+          <input type="text" class="form-control" placeholder=".col-lg-2">
+        </div>
+        <div class="col-lg-3">
+          <input type="text" class="form-control" placeholder=".col-lg-3">
+        </div>
+        <div class="col-lg-4">
+          <input type="text" class="form-control" placeholder=".col-lg-4">
+        </div>
+      </div>
+
+      <h2>Input Groups</h2>
+
+      <h3>Basic Example</h3>
+      <div class="input-group">
+        <input type="text" class="form-control">
+        <span class="input-group-addon">.00</span>
+      </div>
+      <div class="input-group">
+        <span class="input-group-addon">$</span>
+        <input type="text" class="form-control">
+        <span class="input-group-addon">.00</span>
+      </div>
+
+      <h3>Sizing</h3>
+      <div class="input-group input-group-lg">
+        <span class="input-group-addon">@</span>
+        <input type="text" class="form-control input-lg" placeholder="Username">
+      </div>
+      <div class="input-group">
+        <span class="input-group-addon">@</span>
+        <input type="text" class="form-control" placeholder="Username">
+      </div>
+      <div class="input-group input-group-sm">
+        <span class="input-group-addon">@</span>
+        <input type="text" class="form-control" placeholder="Username">
+      </div>
+
+      <h3>Checkboxes and radio addons</h3>
+      <div class="row">
+        <div class="col-lg-6">
+          <div class="input-group">
+            <span class="input-group-addon">
+              <input type="checkbox">
+            </span>
+            <input type="text" class="form-control">
+          </div><!-- /input-group -->
+        </div><!-- /.col-lg-6 -->
+        <div class="col-lg-6">
+          <div class="input-group">
+            <span class="input-group-addon">
+              <input type="radio">
+            </span>
+            <input type="text" class="form-control">
+          </div><!-- /input-group -->
+        </div><!-- /.col-lg-6 -->
+      </div><!-- /.row -->
+
+      <h3>Button addons</h3>
+      <div class="row">
+        <div class="col-lg-6">
+          <div class="input-group">
+            <span class="input-group-btn">
+              <button class="btn btn-default" type="button">Go!</button>
+            </span>
+            <input type="text" class="form-control">
+          </div><!-- /input-group -->
+        </div><!-- /.col-lg-6 -->
+        <div class="col-lg-6">
+          <div class="input-group">
+            <input type="text" class="form-control">
+            <span class="input-group-btn">
+              <button class="btn btn-default" type="button">Go!</button>
+            </span>
+          </div><!-- /input-group -->
+        </div><!-- /.col-lg-6 -->
+      </div><!-- /.row -->
+
+      <h3>Buttons with dropdowns</h3>
+      <div class="row">
+        <div class="col-lg-6">
+          <div class="input-group">
+            <div class="input-group-btn">
+              <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">Action <span class="caret"></span></button>
+              <ul class="dropdown-menu">
+                <li><a href="#">Action</a></li>
+                <li><a href="#">Another action</a></li>
+                <li><a href="#">Something else here</a></li>
+                <li class="divider"></li>
+                <li><a href="#">Separated link</a></li>
+              </ul>
+            </div><!-- /btn-group -->
+            <input type="text" class="form-control">
+          </div><!-- /input-group -->
+        </div><!-- /.col-lg-6 -->
+        <div class="col-lg-6">
+          <div class="input-group">
+            <input type="text" class="form-control">
+            <div class="input-group-btn">
+              <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">Action <span class="caret"></span></button>
+              <ul class="dropdown-menu pull-right">
+                <li><a href="#">Action</a></li>
+                <li><a href="#">Another action</a></li>
+                <li><a href="#">Something else here</a></li>
+                <li class="divider"></li>
+                <li><a href="#">Separated link</a></li>
+              </ul>
+            </div><!-- /btn-group -->
+          </div><!-- /input-group -->
+        </div><!-- /.col-lg-6 -->
+      </div><!-- /.row -->
+
+      <h3>Segmented buttons</h3>
+      <form class="bs-example bs-example-form" role="form">
+        <div class="row">
+          <div class="col-lg-6">
+            <div class="input-group">
+              <div class="input-group-btn">
+                <button type="button" class="btn btn-default" tabindex="-1">Action</button>
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" tabindex="-1">
+                  <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" role="menu">
+                  <li><a href="#">Action</a></li>
+                  <li><a href="#">Another action</a></li>
+                  <li><a href="#">Something else here</a></li>
+                  <li class="divider"></li>
+                  <li><a href="#">Separated link</a></li>
+                </ul>
+              </div>
+              <input type="text" class="form-control">
+            </div><!-- /.input-group -->
+          </div><!-- /.col-lg-6 -->
+          <div class="col-lg-6">
+            <div class="input-group">
+              <input type="text" class="form-control">
+              <div class="input-group-btn">
+                <button type="button" class="btn btn-default" tabindex="-1">Action</button>
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" tabindex="-1">
+                  <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu pull-right" role="menu">
+                  <li><a href="#">Action</a></li>
+                  <li><a href="#">Another action</a></li>
+                  <li><a href="#">Something else here</a></li>
+                  <li class="divider"></li>
+                  <li><a href="#">Separated link</a></li>
+                </ul>
+              </div>
+            </div><!-- /.input-group -->
+          </div><!-- /.col-lg-6 -->
+        </div><!-- /.row -->
+      </form>
+
       <h2>Form States</h2>
       <input class="form-control" id="focusedInput" type="text" value="This is focused...">
       <input class="form-control" id="disabledInput" type="text" placeholder="Disabled input here..." disabled>
@@ -260,186 +581,4 @@ resource: true
           <option>4</option>
           <option>5</option>
         </select>
-      </div>
-      <h2>Control Sizing</h2>
-      <input class="form-control input-lg" type="text" placeholder=".input-lg">
-      <input class="form-control" type="text" placeholder="Default input">
-      <input class="form-control input-sm" type="text" placeholder=".input-sm">
-      <select class="form-control input-lg">...</select>
-      <select class="form-control">...</select>
-      <select class="form-control input-sm">...</select>
-      <div class="row">
-        <div class="col-lg-2">
-          <input type="text" class="form-control" placeholder=".col-lg-2">
-        </div>
-        <div class="col-lg-3">
-          <input type="text" class="form-control" placeholder=".col-lg-3">
-        </div>
-        <div class="col-lg-4">
-          <input type="text" class="form-control" placeholder=".col-lg-4">
-        </div>
-      </div>
-      <h2>Help Text</h2>
-      <span class="help-block">A block of help text that breaks onto a new line and may extend beyond one line.</span>
-      <div class="input-group">
-        <span class="input-group-addon">@</span>
-        <input type="text" class="form-control" placeholder="Username">
-      </div>
-      <h2>Input Groups</h2>
-      <h3>Basic Example</h3>
-      <div class="input-group">
-        <input type="text" class="form-control">
-        <span class="input-group-addon">.00</span>
-      </div>
-      <div class="input-group">
-        <span class="input-group-addon">$</span>
-        <input type="text" class="form-control">
-        <span class="input-group-addon">.00</span>
-      </div>
-      <h3>Sizing</h3>
-      <div class="input-group input-group-lg">
-        <span class="input-group-addon">@</span>
-        <input type="text" class="form-control input-lg" placeholder="Username">
-      </div>
-      <div class="input-group">
-        <span class="input-group-addon">@</span>
-        <input type="text" class="form-control" placeholder="Username">
-      </div>
-      <div class="input-group input-group-sm">
-        <span class="input-group-addon">@</span>
-        <input type="text" class="form-control" placeholder="Username">
-      </div>
-      <h3>Checkboxes and radio addons</h3>
-      <div class="row">
-        <div class="col-lg-6">
-          <div class="input-group">
-            <span class="input-group-addon">
-              <input type="checkbox">
-            </span>
-            <input type="text" class="form-control">
-          </div><!-- /input-group -->
-        </div><!-- /.col-lg-6 -->
-        <div class="col-lg-6">
-          <div class="input-group">
-            <span class="input-group-addon">
-              <input type="radio">
-            </span>
-            <input type="text" class="form-control">
-          </div><!-- /input-group -->
-        </div><!-- /.col-lg-6 -->
-      </div><!-- /.row -->
-      <h3>Button addons</h3>
-      <div class="row">
-        <div class="col-lg-6">
-          <div class="input-group">
-            <span class="input-group-btn">
-              <button class="btn btn-default" type="button">Go!</button>
-            </span>
-            <input type="text" class="form-control">
-          </div><!-- /input-group -->
-        </div><!-- /.col-lg-6 -->
-        <div class="col-lg-6">
-          <div class="input-group">
-            <input type="text" class="form-control">
-            <span class="input-group-btn">
-              <button class="btn btn-default" type="button">Go!</button>
-            </span>
-          </div><!-- /input-group -->
-        </div><!-- /.col-lg-6 -->
-      </div><!-- /.row -->
-      <h3>Buttons with dropdowns</h3>
-      <div class="row">
-        <div class="col-lg-6">
-          <div class="input-group">
-            <div class="input-group-btn">
-              <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">Action <span class="caret"></span></button>
-              <ul class="dropdown-menu">
-                <li><a href="#">Action</a></li>
-                <li><a href="#">Another action</a></li>
-                <li><a href="#">Something else here</a></li>
-                <li class="divider"></li>
-                <li><a href="#">Separated link</a></li>
-              </ul>
-            </div><!-- /btn-group -->
-            <input type="text" class="form-control">
-          </div><!-- /input-group -->
-        </div><!-- /.col-lg-6 -->
-        <div class="col-lg-6">
-          <div class="input-group">
-            <input type="text" class="form-control">
-            <div class="input-group-btn">
-              <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">Action <span class="caret"></span></button>
-              <ul class="dropdown-menu pull-right">
-                <li><a href="#">Action</a></li>
-                <li><a href="#">Another action</a></li>
-                <li><a href="#">Something else here</a></li>
-                <li class="divider"></li>
-                <li><a href="#">Separated link</a></li>
-              </ul>
-            </div><!-- /btn-group -->
-          </div><!-- /input-group -->
-        </div><!-- /.col-lg-6 -->
-      </div><!-- /.row -->
-      <h3>Segmented buttons</h3>
-      <form class="bs-example bs-example-form" role="form">
-        <div class="row">
-          <div class="col-lg-6">
-            <div class="input-group">
-              <div class="input-group-btn">
-                <button type="button" class="btn btn-default" tabindex="-1">Action</button>
-                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" tabindex="-1">
-                  <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu" role="menu">
-                  <li><a href="#">Action</a></li>
-                  <li><a href="#">Another action</a></li>
-                  <li><a href="#">Something else here</a></li>
-                  <li class="divider"></li>
-                  <li><a href="#">Separated link</a></li>
-                </ul>
-              </div>
-              <input type="text" class="form-control">
-            </div><!-- /.input-group -->
-          </div><!-- /.col-lg-6 -->
-          <div class="col-lg-6">
-            <div class="input-group">
-              <input type="text" class="form-control">
-              <div class="input-group-btn">
-                <button type="button" class="btn btn-default" tabindex="-1">Action</button>
-                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" tabindex="-1">
-                  <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu pull-right" role="menu">
-                  <li><a href="#">Action</a></li>
-                  <li><a href="#">Another action</a></li>
-                  <li><a href="#">Something else here</a></li>
-                  <li class="divider"></li>
-                  <li><a href="#">Separated link</a></li>
-                </ul>
-              </div>
-            </div><!-- /.input-group -->
-          </div><!-- /.col-lg-6 -->
-        </div><!-- /.row -->
-      </form>
-      <h2>Sample form for documentation</h2>
-      <h3>In page</h3>
-        {% include widgets/forms/input-validation-form.html id-default="exampleInput" id-disabled="exampleInputDisabled" id-error="exampleInputError" has-error=true %}
-      <h3>Inside a modal</h3>
-      <!--
-        Styles and example-pf div makes modal visible and posistion relative. It's intended for docs page.
-        *Do not use in production*
-      -->
-      <style>
-        .example-pf .modal{
-          position: relative;
-          top: auto;
-          right: auto;
-          bottom: auto;
-          left: auto;
-          z-index: 1;
-          display: block;
-        }
-      </style>
-      <div class="example-pf">
-        {% include widgets/forms/input-validation-modal.html id-default="modalInput" id-disabled="modalInputDisabled" id-error="modalInputError" has-error=true %}
       </div>


### PR DESCRIPTION
## Description

Initial implementation for Forms: required fields.
https://patternfly.atlassian.net/browse/PTNFLY-1829
## Changes
- This PR proposes a reorganisation of the forms test page. With the addition of 6 more different forms, there was a need to better place all the elements of the page. Please give feedback.
- Introduced 6 new forms: 3 form variations for right-aligned labels and 3 more for top-aligned labels.
## Link to rawgit and/or image

[link to Forms on rawgit](http://rawgit.com/cardosogabriel/patternfly/PTNFLY-1829-dist/dist/tests/forms.html)
## Considerations about the solution for right-aligned labels
- Since the optional needs to be in a new line, it has a display: block. Given that we don't know what is the breakpoint set by the developer using patternfly, I cannot specify when this element should go inline, which is the desirable behavior for when the label go above the input. So the result is that even when the label is above the input, the optional appears in a new line, and without the ().
- Placing the optional below the label generates a bigger vertical space between the inputs, breaking the rhythm of the design. I could set a negative margin in case of having optional, that would help specially when the label fills only one line, keeping the rhythm between the inputs but having less space between optional and next label.

![negative margin](https://snag.gy/kL8lo2.jpg)
## PR checklist (if relevant)

Will still test.
- [x] **Cross browser**: works in IE9
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [x] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
