### PR TITLE
Specified a specific dependency on "table" to avoid es6 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "karma-phantomjs-launcher": "^1.0.1",
     "matchdep": "~1.0.1",
     "nsp": "^2.6.1",
-    "pixrem": "^3.0.1"
+    "pixrem": "^3.0.1",
+    "table": "3.7.9"
   },
   "optionalDependencies": {
     "bootstrap-datepicker": "~1.6.4",


### PR DESCRIPTION
## Description

The `grunt stylelint:src` task started failing as the `table` transient dependency started using es6 syntax.  This caused the build to fail in node 0.10 with the error:

```
Running "stylelint:src" (stylelint) task

/home/bleathem/workspace/patternfly/patternfly/node_modules/table/dist/table.js:112
  let userConfig = arguments.length <= 1 || arguments[1] === undefined ? {} : 
  ^^^
Warning: Unexpected strict mode reserved word Use --force to continue.

Aborted due to warnings.
```

We have an outstanding story to move to node 4 ([PTNFLY-1756](https://patternfly.atlassian.net/browse/PTNFLY-1756)), but until that story is addressed we will continue to build with node 0.10.  To resolve this issue I introduced a hard dependency on an older version of the table module.
## Changes
- Introduce a hard dependency on an older version of the table module to fix the build in node 0.10
