### PR TITLE
Fixes Issues#492 - List View: Find widget gets cut off page

### DIFF
--- a/src/less/toolbar.less
+++ b/src/less/toolbar.less
@@ -71,7 +71,7 @@
   background: @color-pf-white;
   border: solid 1px @color-pf-black-400;
   display: none;
-  left: -200px;
+  right: -20px;
   padding: 5px;
   position: absolute;
   top: 35px;
@@ -91,13 +91,17 @@
     border-bottom:11px solid @color-pf-black-400;
     border-left:11px solid transparent;
     border-right:11px solid transparent;
-    left: 215px;
+    right: 35px;
+    .toolbar-pf-find:last-child & {
+      right: 15px;
+    }
     top: -12px;
     @media (max-width: @grid-float-breakpoint) {
       border-bottom:11px solid transparent;
       border-right:11px solid @color-pf-black-400;
       border-top:11px solid transparent;
       left: -22px;
+      right: initial;
       top: 8px;
     }
   }
@@ -105,13 +109,17 @@
     border-bottom:10px solid @color-pf-white;
     border-left:10px solid transparent;
     border-right:10px solid transparent;
-    left: 216px;
+    right: 36px;
+    .toolbar-pf-find:last-child & {
+      right: 16px;
+    }
     top: -10px;
     @media (max-width: @grid-float-breakpoint) {
       border-bottom:10px solid transparent;
       border-right:10px solid @color-pf-white;
       border-top:10px solid transparent;
       left: -20px;
+      right: initial;
       top: 9px;
     }
   }


### PR DESCRIPTION
## Description

If the content view type selection is removed, the find widget falls off of the page when clicked
### Issue

https://github.com/patternfly/patternfly/issues/492  - List View: Find widget gets cut off page if content view selection isn't present
## Changes
- As before, the container used left value to set position, but the best way is to use right value. So update left to right. As the row padding is 20px, so set the right value is 20px.
- When the find button is the last-child, the right margin is 0, but if find button beside Selection buttons, the right margin is 20px. So add a judgement when it is the last-child, the right value of the triangle icons will 20px less than others.
## Link to image

Find button beside the selection buttons
<img width="456" alt="screen shot 2016-09-22 at 2 36 29 pm" src="https://cloud.githubusercontent.com/assets/701009/18738865/04cbc70a-80d2-11e6-8fb8-0d1f4bf18628.png">

Only Find Button
<img width="444" alt="screen shot 2016-09-22 at 2 10 09 pm" src="https://cloud.githubusercontent.com/assets/701009/18738873/11c6aa2e-80d2-11e6-9cbd-2163c344fa44.png">
## PR checklist (if relevant)
- [x] **Cross browser**: works in IE9
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
