### PR TITLE
Node LTS4 - Travis upgrade and README note

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '0.10'
+  - '4'
 
 before_install:
   - 'git checkout -B $TRAVIS_BRANCH' # Reconcile detached HEAD

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ PatternFly can be installed and managed through [NPM](https://www.npmjs.com/). T
 npm install patternfly --save
 ```
 
+Patternfly stays up to date with the Node LTS [Release Schedule](https://github.com/nodejs/LTS#lts_schedule). If you're using Patternfly downstream, we suggest the use of an actively supported version of Node/NPM, although prior versions of Node may work. 
+
 ### Install with Bower
 
 PatternFly can be installed and managed through [Bower](http://bower.io/). To do so, either add `patternfly` as a dependency in your `bower.json` or run the following:


### PR DESCRIPTION
## Travis Node 4 Upgrade

The goal of this PR is to satisfy requirements of [PTNFLY-1767](https://patternfly.atlassian.net/browse/PTNFLY-1767) and [PTNFLY-1766](https://patternfly.atlassian.net/browse/PTNFLY-1766), and ensure Core P.F. builds properly with Node 4 LTS.
## Changes

Surprisingly, there is very little code changes. I have attempted to run our build/unit tests in my fork with Travis [here](https://travis-ci.org/priley86/patternfly/builds/164984186) with Node 4. It appears all unit tests and build steps pass.
## PR checklist (if relevant)
- [x] **Cross browser**: works in IE9
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [x] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
