### PR TITLE
Moved javascript from the toolbar include to the page to fix issue #293 of patternfly-org.

### DIFF
--- a/tests/pages/_includes/widgets/layouts/toolbar.html
+++ b/tests/pages/_includes/widgets/layouts/toolbar.html
@@ -96,18 +96,3 @@
           </div><!-- /col -->
         </div><!-- /row -->
       </div><!-- /container -->
-      <script>
-      (function($) {
-        $(document).ready(function() {
-          // Upon clicking the find button, show the find dropdown content
-          $(".btn-find").click(function () {
-            $(".find-pf-dropdown-container").toggle();
-          });
-          // Upon clicking the find close button, hide the find dropdown content
-          $(".btn-find-close").click(function () {
-            $(".find-pf-dropdown-container").hide();
-          });
-
-        });
-      })(jQuery);
-    </script>

--- a/tests/pages/toolbar.html
+++ b/tests/pages/toolbar.html
@@ -7,3 +7,18 @@ resource: true
       <h2>Toolbar with Horizontal Navigation</h2>
 {% include widgets/layouts/navbar-primary.html %}
 {% include widgets/layouts/toolbar.html %}
+      <script>
+      (function($) {
+        $(document).ready(function() {
+          // Upon clicking the find button, show the find dropdown content
+          $(".btn-find").click(function () {
+            $(this).parent().find(".find-pf-dropdown-container").toggle();
+          });
+          // Upon clicking the find close button, hide the find dropdown content
+          $(".btn-find-close").click(function () {
+            $(".find-pf-dropdown-container").hide();
+          });
+
+        });
+      })(jQuery);
+    </script>


### PR DESCRIPTION
## Description

Moved javascript from the toolbar include to the toolbar page, to fix the issue #293 of patternfly-org. The fact that the javascript was inside the include caused caused malfunction in the toolbar, since it was being imported twice. The toolbar was not opening the find pop-up.
## Changes

Moved javascript from the toolbar include to the toolbar page.
## Link to rawgit and/or image

Here is a [link to Toolbar on rawgit](http://rawgit.com/cardosogabriel/patternfly/patternfly-org/issue-293-dist/dist/tests/toolbar.html).
## PR checklist (if relevant)
- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
