### PR TITLE
Add style for selected items in dropdown to match bootstrap-select

### DIFF
--- a/src/less/dropdowns.less
+++ b/src/less/dropdowns.less
@@ -78,6 +78,17 @@
     border-color: transparent;
   }
 }
+
+// Selected state
+.dropdown-menu > .selected > a {
+  background-color: @dropdown-link-active-bg;
+  border-color: @dropdown-link-active-border-color;
+  color: @color-pf-white;
+  small {
+    color: fade(@color-pf-white, 50%);
+  }
+}
+
 // Nuke hover/focus effects
 .dropdown-menu > .disabled > a {
   &:hover,

--- a/tests/pages/_includes/widgets/cards/dashboard-timeframe-footer.html
+++ b/tests/pages/_includes/widgets/cards/dashboard-timeframe-footer.html
@@ -11,6 +11,7 @@
         Last 30 Days <span class="caret"></span>
       </button>
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
+        <li class="selected"><a href="#">Last 30 Days</a></li>
         <li><a href="#">Last 60 Days</a></li>
         <li><a href="#">Last 90 Days</a></li>
       </ul>

--- a/tests/pages/_includes/widgets/cards/dashboard-timeframe-header.html
+++ b/tests/pages/_includes/widgets/cards/dashboard-timeframe-header.html
@@ -5,6 +5,7 @@
         Last 30 Days <span class="caret"></span>
       </button>
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
+        <li class="selected"><a href="#">Last 30 Days</a></li>
         <li><a href="#">Last 60 Days</a></li>
         <li><a href="#">Last 90 Days</a></li>
       </ul>

--- a/tests/pages/_includes/widgets/layouts/cards-alt.html
+++ b/tests/pages/_includes/widgets/layouts/cards-alt.html
@@ -93,6 +93,7 @@
                   Last 30 Days <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-right" role="menu">
+                  <li class="selected"><a href="#">Last 30 Days</a></li>
                   <li><a href="#">Last 60 Days</a></li>
                   <li><a href="#">Last 90 Days</a></li>
                 </ul>

--- a/tests/pages/_includes/widgets/layouts/cards.html
+++ b/tests/pages/_includes/widgets/layouts/cards.html
@@ -206,6 +206,7 @@
                   Last 30 Days <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-right" role="menu">
+                  <li class="selected"><a href="#">Last 30 Days</a></li>
                   <li><a href="#">Last 60 Days</a></li>
                   <li><a href="#">Last 90 Days</a></li>
                 </ul>

--- a/tests/pages/_includes/widgets/layouts/toolbar.html
+++ b/tests/pages/_includes/widgets/layouts/toolbar.html
@@ -8,11 +8,9 @@
                   <div class="input-group-btn">
                     <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Name <span class="caret"></span></button>
                     <ul class="dropdown-menu">
-                      <li><a href="#">Action</a></li>
-                      <li><a href="#">Another action</a></li>
-                      <li><a href="#">Something else here</a></li>
-                      <li role="separator" class="divider"></li>
-                      <li><a href="#">Separated link</a></li>
+                      <li class="selected"><a href="#">Name</a></li>
+                      <li><a href="#">Type</a></li>
+                      <li><a href="#">Color</a></li>
                     </ul>
                   </div><!-- /btn-group -->
                   <input type="text" class="form-control" id="filter" placeholder="Filter By Name...">
@@ -22,11 +20,9 @@
                 <div class="dropdown btn-group">
                   <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Name <span class="caret"></span></button>
                   <ul class="dropdown-menu">
-                    <li><a href="#">Action</a></li>
-                    <li><a href="#">Another action</a></li>
-                    <li><a href="#">Something else here</a></li>
-                    <li role="separator" class="divider"></li>
-                    <li><a href="#">Separated link</a></li>
+                    <li class="selected"><a href="#">Name</a></li>
+                    <li><a href="#">Type</a></li>
+                    <li><a href="#">Last Modified</a></li>
                   </ul>
                 </div>
                 <button class="btn btn-link" type="button">


### PR DESCRIPTION
This PR adds the selected styling for dropdowns to match the styling set for bootstrap-select objects. Updated test pages to set the selected state on dropdowns where selection is applicable.

This fixes issue https://github.com/patternfly/angular-patternfly/issues/318

See the filter and sort dropdowns at http://rawgit.com/jeff-phillips-18/patternfly/fixes-dist/dist/tests/toolbar.html

@andresgalante @srambach 
