### PR TITLE
Added labels for a11y.

### DIFF
--- a/tests/pages/_includes/widgets/datatables/datatable.html
+++ b/tests/pages/_includes/widgets/datatables/datatable.html
@@ -15,7 +15,7 @@
             className: "datatable-pf-select",
             render: function (data, type, full, meta) {
               // Select row checkbox renderer
-              return '<input type="checkbox" name="select" value="' + meta.row + '">';
+              return '<label class="sr-only">Select row ' + meta.row + '</label><input type="checkbox" name="select">';
             },
             sortable: false
           },

--- a/tests/pages/_includes/widgets/datatables/tmpl/datatable.html
+++ b/tests/pages/_includes/widgets/datatables/tmpl/datatable.html
@@ -1,7 +1,7 @@
 <table class="table table-striped table-bordered table-hover" id="table">
   <thead>
     <tr>
-      <th><input type="checkbox" name="selectAll"></th>
+      <th><label class="sr-only">Select all rows</label><input type="checkbox" name="selectAll"></th>
       <th>Rendering engine</th>
       <th>Browser</th>
       <th>Platform(s)</th>


### PR DESCRIPTION
## Description

Added labels for a11y. Note that the labels are positioned off-screen, hidden from view, but still accessible to screen readers.

The approach is documented here: http://webaim.org/techniques/css/invisiblecontent/

This addresses Gabriel's code review comments from:

https://github.com/patternfly/patternfly/pull/500
## Changes

Write a list of changes the PR introduces
- Added labels for a11y
- Added style to position labels off-screen
- Change 03
## Link to rawgit and/or image

https://rawgit.com/dlabrecq/patternfly/table-view-dist/dist/tests/datatables.html

This is an image:

![screen shot 2016-10-11 at 4 22 49 pm](https://cloud.githubusercontent.com/assets/17481322/19287440/bc6456be-8fcf-11e6-9b4b-3269f10835d9.png)
## PR checklist (if relevant)
- [x] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
