### PR TITLE
Allow navigation item labels to use all available space

### DIFF
--- a/src/less/vertical-nav.less
+++ b/src/less/vertical-nav.less
@@ -77,6 +77,7 @@
       position: relative;
       white-space: nowrap;
       width: @nav-pf-vertical-width;
+      // When flexbox is supported nav item names take up all available space
       @supports (display: flex) {
         display: flex;
         padding-right: 0;
@@ -128,6 +129,7 @@
       display: block;
       line-height: 25px;
       max-width: 120px;
+      // If flexbox is supported, do not set max-width, take all space with just some right padding
       @supports (display: flex) {
         flex: 1;
         max-width: none;
@@ -172,6 +174,8 @@
     position: absolute;
     right: 15px;
     top: 20px;
+    // If flexbox is supported, use relative positioning to place to the right of the label
+    // and adjust the top position so that the secondary and tertiary nav items don't need to change
     @supports (display: flex) {
       padding-left: 0;
       padding-right: 15px;
@@ -335,6 +339,7 @@
       top: 0;
     }
     .list-group-item-value {
+      // If flex box is supported add some padding to account for the submenu indicator
       @supports (display: flex) {
         padding-right: 35px;
       }
@@ -618,6 +623,7 @@
           right: 20px;
           top: 4px;
         }
+        // If flex box is supported add some padding to account for the submenu indicator
         .list-group-item-value {
           @supports (display: flex) {
             padding-right: 35px;

--- a/src/less/vertical-nav.less
+++ b/src/less/vertical-nav.less
@@ -77,6 +77,10 @@
       position: relative;
       white-space: nowrap;
       width: @nav-pf-vertical-width;
+      @supports (display: flex) {
+        display: flex;
+        padding-right: 0;
+      }
       .fa,
       .glyphicon,
       .pficon {
@@ -124,6 +128,11 @@
       display: block;
       line-height: 25px;
       max-width: 120px;
+      @supports (display: flex) {
+        flex: 1;
+        max-width: none;
+        padding-right: 15px;
+      }
       overflow: hidden;
       text-overflow: ellipsis;
     }
@@ -163,6 +172,14 @@
     position: absolute;
     right: 15px;
     top: 20px;
+    @supports (display: flex) {
+      padding-left: 0;
+      padding-right: 15px;
+      position: relative;
+      right: 0;
+      margin-top: -3px;
+      top: 5px;
+    }
     .badge {
       background: @nav-pf-vertical-badge-bg-color;
       color: @nav-pf-vertical-badge-color;
@@ -316,6 +333,11 @@
       position: absolute;
       right: 20px;
       top: 0;
+    }
+    .list-group-item-value {
+      @supports (display: flex) {
+        padding-right: 35px;
+      }
     }
   }
   &.active,
@@ -595,6 +617,11 @@
           position: absolute;
           right: 20px;
           top: 4px;
+        }
+        .list-group-item-value {
+          @supports (display: flex) {
+            padding-right: 35px;
+          }
         }
       }
       &.active,

--- a/tests/pages/_includes/widgets/navigation/secondary-nav-amet.html
+++ b/tests/pages/_includes/widgets/navigation/secondary-nav-amet.html
@@ -6,7 +6,7 @@
   <ul class="list-group">
     <li class="list-group-item {% if page.nav-tertiary %}tertiary-nav-item-pf{% endif %}" data-target="#amet-detracto-tertiary">
       <a>
-        <span class="list-group-item-value">Detracto</span>
+        <span class="list-group-item-value">Detracto Suscipiantur</span>
         {% if page.nav-tertiary %}{% else %}
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -46,7 +46,7 @@
     </li>
     <li class="list-group-item {% if page.nav-tertiary %}tertiary-nav-item-pf{% endif %}" data-target="#amet-corrumpit-tertiary">
       <a>
-        <span class="list-group-item-value">Corrumpit</span>
+        <span class="list-group-item-value">Corrumpit Cupidatat Proident Deserunt</span>
         {% if page.nav-tertiary %}{% else %}
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -68,9 +68,11 @@
     {% if page.nav-tertiary %}
     <li class="list-group-item">
       <a>
-        <span class="list-group-item-value">urbanitas</span>
+        <span class="list-group-item-value">Urbanitas Habitant Morbi Tristique</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">
+          <span class="badge">5</span>
+          <span class="badge">5</span>
           <span class="badge">5</span>
         </div>
         {% endif %}


### PR DESCRIPTION
Rather than using a max-width for the item labels, use flex box display to allow the name to take up whatever space is available so as not to truncate the name unless necessary.

This only effects browsers supporting Flex box.

Examples can be see on the following pages, the "Amet" secondary menu has been updated to use really long menu item names to show these changes.

http://rawgit.com/jeff-phillips-18/patternfly/fixes-dist/dist/tests/vertical-navigation-with-badges.html

http://rawgit.com/jeff-phillips-18/patternfly/fixes-dist/dist/tests/vertical-navigation-with-tertiary-pins.html
