### PR TITLE
Hide vertical navigation menu during intiialization

### DIFF
--- a/src/js/patternfly.js
+++ b/src/js/patternfly.js
@@ -1568,6 +1568,10 @@
       },
 
       init = function (handleItemSelections) {
+        // Hide the nav menus during initialization
+        navElement.addClass('hide-nav-pf');
+        bodyContentElement.addClass('hide-nav-pf');
+
         //Set correct state on load
         checkNavState();
 

--- a/src/less/vertical-nav.less
+++ b/src/less/vertical-nav.less
@@ -52,7 +52,7 @@
     box-shadow: 0 0 3px fade(@color-pf-black, 15%);
     display: block !important;
   }
-  .hide-nav-pf {  // Used to hide navigation initially to avoid startup flicker
+  &.hide-nav-pf {  // Used to hide navigation initially to avoid startup flicker
     visibility: hidden !important;
   }
   .list-group {

--- a/tests/pages/_includes/widgets/navigation/vertical-navigation.html
+++ b/tests/pages/_includes/widgets/navigation/vertical-navigation.html
@@ -4,7 +4,7 @@
   {% include widgets/layouts/navbar-vertical.html %}
 {% endif %}
 <div class="nav-pf-vertical
-     {% if page.submenus %}nav-pf-vertical-with-sub-menus hide-nav-pf{% endif %}
+     {% if page.submenus %}nav-pf-vertical-with-sub-menus{% endif %}
      {% if page.persistent-secondary %}nav-pf-persistent-secondary{% endif %}
      {% if page.collapsible-menus %}nav-pf-vertical-collapsible-menus{% endif %}
      {% if page.hide-icons %}hidden-icons-pf{% endif %}


### PR DESCRIPTION
Automatically add the .hide-nav-pf class to the navigation menu and body content element during the initialization of the vertical navigation menu to prevent flicker while determining if there is a pinned sub-menu.

http://rawgit.com/jeff-phillips-18/patternfly/navigation-dist/dist/tests/vertical-navigation-with-tertiary-pins.html

Fixes issue #517
