### PR TITLE
Updated CSS for inline actions in data tables.

### DIFF
--- a/src/less/datatables.less
+++ b/src/less/datatables.less
@@ -185,10 +185,12 @@
   }
   // Override table styles -- child selectors are due to specificity
   table {
+    height: 100%;
     margin-bottom: 0;
     max-width: none !important;
     > tbody {
       > tr {
+        height: 100%;
         > td {
           // Styling for inline actions
           &.datatable-pf-actions {
@@ -333,18 +335,24 @@
   }
 }
 
-// Inline action button and kebab
-.datatable-pf-actions.btn-default {
+//Inline action button and kebab
+// Sets button height to 100% of td height in firefox and chrome, but not in IE when wrapping occurs. 
+// Button height must be set dynamically in IE to be equal to td height.
+.datatable-pf-actions {
+  background-color: @btn-default-bg; // included just in case there are gaps between the edges of the buttons and the table cell
+  height: 100%;
   .btn,
-  .open .dropdown-toggle {
-    background-color: transparent;
-    background-image: none;
+  .dropdown-toggle {
     border: none;
     box-shadow: none;
     height: 100%;
     width: 100%;
   }
+  .dropdown, .table-btn-pf {
+    height: 100%;
+  }
 }
+
 
 // Selection column
 .datatable-pf-select {

--- a/tests/pages/_includes/widgets/datatables/datatable.html
+++ b/tests/pages/_includes/widgets/datatables/datatable.html
@@ -25,14 +25,14 @@
           { data: "version" },
           { data: "grade"},
           { data: null,
-            className: "datatable-pf-actions btn-default",
+            className: "datatable-pf-actions",
             render: function (data, type, full, meta) {
               // Inline action button renderer
-              return '<button class="btn" type="button">Actions</button>';
+              return '<div class="table-btn-pf"><button class="btn btn-default" type="button">Actions</button></div>';
             }
           }, {
             data: null,
-            className: "datatable-pf-actions btn-default",
+            className: "datatable-pf-actions",
             render: function (data, type, full, meta) {
               // Inline action kebab renderer
               return '<div class="dropdown dropdown-kebab-pf">' +


### PR DESCRIPTION
## Description

Updated the css for buttons that display in data tables. This css works for FireFox and Chrome, but in IE the height of the button is not equal to the height of the table row when text wrapping occurs in the table row. Height of buttons in IE will need to be set dynamically.

https://patternfly.atlassian.net/browse/PTNFLY-1897
## Changes
- modified where the btn-default class is applied (i.e. moved it back to the button).
- included a wrapper class around buttons (this was needed to avoid extra css changes to the styles defined for btn-default that affected width, like box-sizing and padding)
## Link to rawgit and/or image

https://rawgit.com/jgiardino/patternfly/table-view-dist/dist/tests/datatables.html

Example of buttons in IE
<img width="323" alt="screen shot 2016-10-14 at 4 08 15 pm" src="https://cloud.githubusercontent.com/assets/21063328/19568813/1b253d06-96c1-11e6-8242-afca1f209f2d.png">
## PR checklist (if relevant)
- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [ ] **Cross browser**: works in Chrome
- [ ] **Cross browser**: works in Firefox
- [ ] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [ ] **Responsive**: works in extra small, small, medium and large view ports.
- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
