### PR TITLE
Implemented expand-collapse section in forms

### DIFF
--- a/src/less/forms.less
+++ b/src/less/forms.less
@@ -73,3 +73,23 @@ label {
 span.required-pf {
   color: @brand-danger;
 }
+
+.fields-section-pf {
+  border-color: @color-pf-black-200;
+  border-style: solid;
+  border-width: 1px 0 0;
+  margin-top: 25px;
+  padding: 15px 0 0;
+}
+.fields-section-header-pf {
+  border: none;
+  font-size: @font-size-base;
+  margin: 0;
+  padding-right: @padding-large-horizontal;
+  width: auto;
+  .fa-angle-right {
+    cursor: pointer;
+    font-size: @font-size-large;
+    width: @font-size-large;
+  }
+}

--- a/tests/pages/_includes/widgets/forms/expand-collapse-section.html
+++ b/tests/pages/_includes/widgets/forms/expand-collapse-section.html
@@ -1,0 +1,80 @@
+<form class="form-horizontal">
+  <div class="form-group">
+    <label class="col-sm-{{include.col-size-label}} control-label" for="{{include.id-blueprintname}}">Blueprint Name</label>
+    <div class="col-sm-{{include.col-size-field}}">
+      <input type="text" id="{{include.id-blueprintname}}" class="form-control">
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="col-sm-{{include.col-size-label}} control-label" for="{{include.id-catalog}}">Catalog</label>
+    <div class="col-sm-{{include.col-size-field}}">
+      <input type="text" id="{{include.id-catalog}}" class="form-control"></div>
+  </div>
+  <div class="form-group">
+    <label class="col-sm-{{include.col-size-label}} control-label" for="{{include.id-number}}">Number</label>
+    <div class="col-sm-{{include.col-size-field}}">
+      <input type="text" id="{{include.id-number}}" class="form-control"></div>
+  </div>
+
+  <fieldset class="fields-section-pf" id="{{include.id-fieldsection}}">
+    <legend class="fields-section-header-pf">
+      <span class="fa fa-angle-right fa-angle-down field-section-toggle-pf"></span>
+      <a href="#{{include.id-fieldsection}}" class="field-section-toggle-pf">Advanced Options</a>
+    </legend>
+    <div class="form-group">
+      <label class="col-sm-{{include.col-size-label}} control-label" for="{{include.id-entry1}}">Entry Point 1</label>
+      <div class="col-sm-{{include.col-size-field}}">
+        <input type="text" id="{{include.id-entry1}}" class="form-control"></div>
+    </div>
+    <div class="form-group">
+      <label class="col-sm-{{include.col-size-label}} control-label" for="{{include.id-entry2}}">Entry Point 2</label>
+      <div class="col-sm-{{include.col-size-field}}">
+        <input type="text" id="{{include.id-entry2}}" class="form-control"></div>
+    </div>
+    <div class="form-group">
+      <label class="col-sm-{{include.col-size-label}} control-label" for="{{include.id-entry3}}">Entry Point 3</label>
+      <div class="col-sm-{{include.col-size-field}}">
+        <input type="text" id="{{include.id-entry3}}" class="form-control"></div>
+    </div>
+  </fieldset>
+
+  {% if include.is-modal == false %}
+  <div class="form-group">
+    <div class="col-sm-offset-{{include.col-size-label}} col-sm-{{include.col-size-field}}">
+      <button type="submit" class="btn btn-primary">Save</button>
+      <button type="submit" class="btn btn-default">Cancel</button>
+    </div>
+  </div>
+  {% endif %}
+  {% if include.is-modal == true %}
+  <div class="modal-footer">
+    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+    <button type="button" class="btn btn-primary">Save</button>
+  </div>
+  {% endif %}
+
+
+</form>
+
+<script>
+  // Initialize form
+  $(document).ready(function() {
+    // set default state to collapsed for expandable field section
+    $('.fields-section-header-pf').attr('aria-expanded', 'false');
+    $('.fields-section-pf .form-group').addClass('hidden');
+    $('.fa.field-section-toggle-pf').removeClass('fa-angle-down');
+
+    // click the field section heading to expand the section
+    $("#{{include.id-fieldsection}} .field-section-toggle-pf").click(function(event){
+      $(this).parents(".fields-section-pf").find(".fa").toggleClass("fa-angle-down");
+      $(this).parents(".fields-section-pf").find(".form-group").toggleClass("hidden");
+      if ($(this).parent().attr('aria-expanded') == 'false') {
+        $(this).parent().attr('aria-expanded', 'true');
+      } else {
+        $(this).parent().attr('aria-expanded', 'false');
+      }
+    })
+
+  });
+
+</script>

--- a/tests/pages/forms.html
+++ b/tests/pages/forms.html
@@ -240,6 +240,32 @@ resource: true
         {% include widgets/forms/input-validation-modal.html id-default="modalInput" id-disabled="modalInputDisabled" id-error="modalInputError" has-error=true %}
       </div>
 
+      <h2>Expand-Collapse Section</h2>
+      <div class="example-pf">
+        {% include widgets/forms/expand-collapse-section.html id-blueprintname="AdvOptBlueprintName" id-catalog="AdvOptCatalog" id-number="AdvOptNumber" id-entry1="AdvOptEntry1" id-entry2="AdvOptEntry2" id-entry3="AdvOptEntry3" id-fieldsection="AdvOptSection" is-modal=false col-size-label="2" col-size-field="10" %}
+      </div>
+
+      <h2>Expand-Collapse Section inside a modal</h2>
+
+      <button class="btn btn-default" data-toggle="modal" data-target="#myModal">Launch demo modal</button>
+      <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
+                <span class="pficon pficon-close"></span>
+              </button>
+              <h4 class="modal-title" id="myModalLabel">Edit Blueprint Details</h4>
+            </div>
+            <div class="modal-body">
+              <div class="example-pf">
+                {% include widgets/forms/expand-collapse-section.html id-blueprintname="AdvOptBlueprintNameMod" id-catalog="AdvOptCatalogMod" id-number="AdvOptNumberMod" id-entry1="AdvOptEntry1Mod" id-entry2="AdvOptEntry2Mod" id-entry3="AdvOptEntry3Mod" id-fieldsection="AdvOptSectionMod" is-modal=true col-size-label="3" col-size-field="9" %}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <h2>Controls</h2>
 
       <input type="text" class="form-control" placeholder="Text input">


### PR DESCRIPTION
## Description

Included an example of an expand-collapse section in a form.
https://patternfly.atlassian.net/browse/PTNFLY-1683
## Changes
- Implemented the section using fieldset and legend and added new css for these elements
- Included javascript to enable the toggle feature
- Included two examples of the form on the forms.html test page:
  - One form is inline - under header "Expand-Collapse Section"
  - One form is in a modal - under header "Expand-Collapse Section inside a modal"
## Questions

I included an href on the anchor link inside the legend so that it would be keyboard accessible. The alternative would be to remove the href and include tabindex="0" if the behavior of the anchor link is awkward (it's a little weird on the forms.html page, but I'm not sure it would be so weird on a normal form page). Any thoughts?
## Link to rawgit and/or image

Here is a [link to Forms on rawgit](https://rawgit.com/jgiardino/patternfly/form-expand-collapse-3-dist/dist/tests/forms.html). Scroll down to the section labeled “Expand-Collapse Section”

This is an image:
<img width="776" alt="screen shot 2016-10-21 at 11 26 26 am" src="https://cloud.githubusercontent.com/assets/21063328/19603978/4baaa34c-9781-11e6-938d-407f4624cf22.png">
## PR checklist (if relevant)
- [x] **Cross browser**: works in IE9
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [x] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
