### PR TITLE
Fix for vertical navigation showing primary item when secondary pinned

### DIFF
--- a/src/less/vertical-nav.less
+++ b/src/less/vertical-nav.less
@@ -354,10 +354,10 @@
         right: 21px;
       }
       .collapsed-secondary-nav-pf & {
-        z-index: @zindex-navbar-fixed;
+        z-index: 0;
       }
       .collapsed-tertiary-nav-pf & {
-        z-index: @zindex-navbar-fixed;
+        z-index: 0;
       }
     }
   }
@@ -417,7 +417,7 @@
     &.active,
     &.hover {
       > a {
-        z-index: @zindex-navbar-fixed;
+        z-index: 0;
       }
     }
   }


### PR DESCRIPTION
Fixes issue #517

This only occurs on a reload if the user happens to be hovering on an
area where the primary item would be drawn if nothing was pinned.
