### PR TITLE
Fix for dispatching resize event for vertical nav on IE11

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -176,7 +176,7 @@ module.exports = function (grunt) {
       },
       js: {
         files: ['src/js/*.js'],
-        tasks: ['eslint', 'concat":js', 'copy:js', 'uglify']
+        tasks: ['eslint', 'concat:js', 'copy:js', 'uglify']
       },
       livereload: {
         files: ['dist/css/*.css', 'dist/js/*.js', 'dist/tests/*.html', '!tests/pages/*.html']

--- a/src/js/patternfly-functions.js
+++ b/src/js/patternfly-functions.js
@@ -613,13 +613,7 @@
 
       forceResize = function (delay) {
         setTimeout(function () {
-          if (window.dispatchEvent) {
-            window.dispatchEvent(new Event('resize'));
-          }
-          // Special case for IE
-          if ($(document).fireEvent) {
-            $(document).fireEvent('onresize');
-          }
+          $(window).trigger('resize');
         }, delay);
       },
 


### PR DESCRIPTION
## Description

Fixes issue #457

Use the jQuery method to dispatch the event since we only need the
jQuery added handler to respond.

## PR checklist

- [x] **Cross browser**: works in IE9
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
