### PR TITLE
Replaced the "bootstrap-combobox" bower dependency with one for the p…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,6 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.7",
-    "bootstrap-combobox": "~1.1.7",
     "bootstrap-datepicker": "~1.6.4",
     "bootstrap-select": "~1.10.0",
     "bootstrap-switch": "~3.3.2",
@@ -37,6 +36,7 @@
     "matchHeight": "~0.7.0",
     "eonasdan-bootstrap-datetimepicker": "~4.17.37",
     "moment": "~2.14.1",
+    "patternfly-bootstrap-combobox": "~1.1.7",
     "patternfly-bootstrap-treeview": "~2.1.0"
   }
 }


### PR DESCRIPTION
## Description
This PR fixes a bug (PTNFLY-1933) where the less build fails for projects that consume patternfly via bower rather than via npm.

## Changes
This PR replaces the "bootstrap-combobox" bower dependency with one for the patternfly fork "patternfly-bootstrap-combobox".