### PR TITLE
Move patternfly back to window to support webpack

### DIFF
--- a/src/js/patternfly-settings.js
+++ b/src/js/patternfly-settings.js
@@ -492,15 +492,6 @@
     'desktop': 1200
   };
 
-  if (typeof define === 'function' && define.amd) {
-    define("patternfly", function () {
-      return patternfly;
-    });
-  } else if ('undefined' !== typeof exports && 'undefined' !== typeof module) {
-    module.exports = patternfly;
-  } else {
-    window.patternfly = patternfly;
-  }
-
+  window.patternfly = patternfly;
 })(window);
 


### PR DESCRIPTION
## Description
This reverts a change earlier to move PatternFly to a module loading system.  It is now just on window (the way it was before 3.14.0.

https://github.com/patternfly/patternfly/issues/535
## Changes
Simplify Patternfly window object until a better module system is chosen.

## PR checklist (if relevant)
- Checked in webpack
- Checked in regular dist (test pages) to make sure script still loads correctly

cc: @lorthirk, @jeff-phillips-18