### PR TITLE
Add aria-hidden to pficons

### DIFF
--- a/PFICONS.md
+++ b/PFICONS.md
@@ -43,7 +43,7 @@ Finally, update "tests-src/icons.html" to include the new icons.
 
     Ex:
       <li>
-         <span class="pficon pficon-blueprint"></span>
+         <span class="pficon pficon-blueprint" aria-hidden="true"></span>
          <span class="icon-class">pficon-blueprint</span>
       </li>
 

--- a/src/js/patternfly.dataTables.pfEmpty.js
+++ b/src/js/patternfly.dataTables.pfEmpty.js
@@ -34,7 +34,7 @@
  * </table>
  * <div class="blank-slate-pf table-view-pf-empty hidden" id="emptyState1">
  *   <div class="blank-slate-pf-icon">
- *     <span class="pficon pficon pficon-add-circle-o"></span>
+ *     <span class="pficon pficon-add-circle-o" aria-hidden="true"></span>
  *   </div>
  *   <h1>Empty State Title</h1>
  *   ...

--- a/src/js/patternfly.dataTables.pfFilter.js
+++ b/src/js/patternfly.dataTables.pfFilter.js
@@ -220,7 +220,7 @@
 
     // Append active filter control
     ctx._pfFilter.activeFilterControls.append('<li><span class="label label-info">' + filter.name + ': ' +
-      filter.value + '<a href="#"><span class="pficon pficon-close"/></a></span></li>');
+      filter.value + '<a href="#"><span class="pficon pficon-close" aria-hidden="true"/></a></span></li>');
 
     // Handle click to clear active filter
     $("a", ctx._pfFilter.activeFilterControls).last().on("click", function (e) {

--- a/tests/pages/_includes/head.html
+++ b/tests/pages/_includes/head.html
@@ -39,7 +39,7 @@
       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">
         <span class="pficon pficon-close"></span>
       </button>
-      <span class="pficon pficon-warning-triangle-o"></span>
+      <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
       {% if page.alt-layout %}The alternate layouts are not officially supported by Patternfly.  {% endif %}These examples are included for development testing purposes.  For official documentation, see <a href="https://www.patternfly.org" class="alert-link">https://www.patternfly.org</a> and <a href="http://getbootstrap.com" class="alert-link">http://getbootstrap.com</a>.
     </div>
   </div>{% endif  %}{% endstrip %}

--- a/tests/pages/_includes/widgets/cards/aggregate-status-adipiscing-mini.html
+++ b/tests/pages/_includes/widgets/cards/aggregate-status-adipiscing-mini.html
@@ -1,13 +1,13 @@
 <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini">
   <h2 class="card-pf-title">
     <a href="#">
-      <span class="pficon pficon-cluster"></span>
+      <span class="pficon pficon-cluster" aria-hidden="true"></span>
       <span class="card-pf-aggregate-status-count">9</span> Adipiscing
     </a>
   </h2>
   <div class="card-pf-body">
     <p class="card-pf-aggregate-status-notifications">
-      <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span></span>
+      <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok" aria-hidden="true"></span></span>
     </p>
   </div>
 </div>

--- a/tests/pages/_includes/widgets/cards/aggregate-status-adipiscing.html
+++ b/tests/pages/_includes/widgets/cards/aggregate-status-adipiscing.html
@@ -4,7 +4,7 @@
   </h2>
   <div class="card-pf-body">
     <p class="card-pf-aggregate-status-notifications">
-      <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span></span>
+      <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok" aria-hidden="true"></span></span>
     </p>
   </div>
 </div>

--- a/tests/pages/_includes/widgets/cards/aggregate-status-amet-mini.html
+++ b/tests/pages/_includes/widgets/cards/aggregate-status-amet-mini.html
@@ -7,7 +7,7 @@
   </h2>
   <div class="card-pf-body">
     <p class="card-pf-aggregate-status-notifications">
-      <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-error-circle-o"></span>4</a></span>
+      <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-error-circle-o" aria-hidden="true"></span>4</a></span>
     </p>
   </div>
 </div>

--- a/tests/pages/_includes/widgets/cards/aggregate-status-amet.html
+++ b/tests/pages/_includes/widgets/cards/aggregate-status-amet.html
@@ -4,8 +4,8 @@
   </h2>
   <div class="card-pf-body">
     <p class="card-pf-aggregate-status-notifications">
-      <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-error-circle-o"></span>4</a></span>
-      <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-warning-triangle-o"></span>1</a></span>
+      <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-error-circle-o" aria-hidden="true"></span>4</a></span>
+      <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>1</a></span>
     </p>
   </div>
 </div>

--- a/tests/pages/_includes/widgets/cards/aggregate-status-ipsum-mini.html
+++ b/tests/pages/_includes/widgets/cards/aggregate-status-ipsum-mini.html
@@ -5,7 +5,7 @@
   </h2>
   <div class="card-pf-body">
     <p class="card-pf-aggregate-status-notifications">
-      <span class="card-pf-aggregate-status-notification"><a href="#" class="add" data-toggle="tooltip" data-placement="top" title="Add Ipsum"><span class="pficon pficon-add-circle-o"></span></a></span>
+      <span class="card-pf-aggregate-status-notification"><a href="#" class="add" data-toggle="tooltip" data-placement="top" title="Add Ipsum"><span class="pficon pficon-add-circle-o" aria-hidden="true"></span></a></span>
     </p>
   </div>
 </div>

--- a/tests/pages/_includes/widgets/cards/aggregate-status-ipsum.html
+++ b/tests/pages/_includes/widgets/cards/aggregate-status-ipsum.html
@@ -4,7 +4,7 @@
   </h2>
   <div class="card-pf-body">
     <p class="card-pf-aggregate-status-notifications">
-      <span class="card-pf-aggregate-status-notification"><a href="#" class="add" data-toggle="tooltip" data-placement="top" title="Add Ipsum"><span class="pficon pficon-add-circle-o"></span></a></span>
+      <span class="card-pf-aggregate-status-notification"><a href="#" class="add" data-toggle="tooltip" data-placement="top" title="Add Ipsum"><span class="pficon pficon-add-circle-o" aria-hidden="true"></span></a></span>
     </p>
   </div>
 </div>

--- a/tests/pages/_includes/widgets/cards/dashboard-timeframe-footer.html
+++ b/tests/pages/_includes/widgets/cards/dashboard-timeframe-footer.html
@@ -18,7 +18,7 @@
     </div>
     <p>
       <a href="#" class="card-pf-link-with-icon">
-        <span class="pficon pficon-add-circle-o"></span>Add New Cluster
+        <span class="pficon pficon-add-circle-o" aria-hidden="true"></span>Add New Cluster
       </a>
     </p>
   </div>

--- a/tests/pages/_includes/widgets/cards/object-status.html
+++ b/tests/pages/_includes/widgets/cards/object-status.html
@@ -8,7 +8,7 @@
     </h2>
     <div class="card-pf-items text-center">
       <div class="card-pf-item">
-        <span class="pficon pficon-screen"></span>
+        <span class="pficon pficon-screen" aria-hidden="true"></span>
         <span class="card-pf-item-text">8</span>
       </div>
       <div class="card-pf-item">

--- a/tests/pages/_includes/widgets/cards/status-inline-actions-xs.html
+++ b/tests/pages/_includes/widgets/cards/status-inline-actions-xs.html
@@ -3,12 +3,12 @@
     <div class="card-pf-heading-kebab">
       {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId="dropupKebabRight2" dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
       <h2 class="card-pf-title">
-        <span class="pficon pficon-cluster"></span> Storage_1
+        <span class="pficon pficon-cluster" aria-hidden="true"></span> Storage_1
       </h2>
     </div>
     <div class="progress-pf-legend">
       {% include widgets/charts/utilization-bar.html id="utilizationBarChart" %}
-      <p><span class="pficon pficon-warning-triangle-o"></span> <strong>10%</strong> in use</p>
+      <p><span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span> <strong>10%</strong> in use</p>
     </div>
   </div>
 </div>

--- a/tests/pages/_includes/widgets/cards/summary-inline-actions-xs.html
+++ b/tests/pages/_includes/widgets/cards/summary-inline-actions-xs.html
@@ -3,7 +3,7 @@
     <div class="card-pf-heading-kebab">
       {% include widgets/kebab.html dropmenuType="dropup" dropmenuPosition="pull-right" dropmenuId="dropupKebabRight3" dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
       <h2 class="card-pf-title">
-        <span class="pficon pficon-service"></span> Zone_1
+        <span class="pficon pficon-service" aria-hidden="true"></span> Zone_1
       </h2>
     </div>
     <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque. <a href="#">More info</a></p>

--- a/tests/pages/_includes/widgets/communication/alert-danger-dismissable.html
+++ b/tests/pages/_includes/widgets/communication/alert-danger-dismissable.html
@@ -1,7 +1,7 @@
 <div class="alert alert-danger alert-dismissable">
   <button type="button" class="close" data-dismiss="alert" aria-hidden="true">
-    <span class="pficon pficon-close"></span>
+    <span class="pficon pficon-close" ></span>
   </button>
-  <span class="pficon pficon-error-circle-o"></span>
+  <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
   <strong>Hey there is a problem!</strong> Yeah this is really messed up and you should <a href="#" class="alert-link">know about it</a>.
 </div>

--- a/tests/pages/_includes/widgets/communication/alert-danger.html
+++ b/tests/pages/_includes/widgets/communication/alert-danger.html
@@ -1,4 +1,4 @@
 <div class="alert alert-danger">
-  <span class="pficon pficon-error-circle-o"></span>
+  <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
   <strong>Hey there is a problem!</strong> Yeah this is really messed up and you should <a href="#" class="alert-link">know about it</a>.
 </div>

--- a/tests/pages/_includes/widgets/communication/alert-info-dismissable.html
+++ b/tests/pages/_includes/widgets/communication/alert-info-dismissable.html
@@ -2,6 +2,6 @@
   <button type="button" class="close" data-dismiss="alert" aria-hidden="true">
     <span class="pficon pficon-close"></span>
   </button>
-  <span class="pficon pficon-info"></span>
+  <span class="pficon pficon-info" aria-hidden="true"></span>
   <strong>This is some general information.</strong> You should <a href="#" class="alert-link">know about this</a>.
 </div>

--- a/tests/pages/_includes/widgets/communication/alert-success-button.html
+++ b/tests/pages/_includes/widgets/communication/alert-success-button.html
@@ -1,5 +1,5 @@
 <div class="alert alert-success">
   <button class="btn btn-default pull-right" type="submit">Button</button>
-  <span class="pficon pficon-ok"></span>
+  <span class="pficon pficon-ok" aria-hidden="true"></span>
   <strong>Great job!</strong> This is really working out <a href="#" class="alert-link">great for us</a>.
 </div>

--- a/tests/pages/_includes/widgets/communication/alert-success-dismissable.html
+++ b/tests/pages/_includes/widgets/communication/alert-success-dismissable.html
@@ -2,6 +2,6 @@
   <button type="button" class="close" data-dismiss="alert" aria-hidden="true">
     <span class="pficon pficon-close"></span>
   </button>
-  <span class="pficon pficon-ok"></span>
+  <span class="pficon pficon-ok" aria-hidden="true"></span>
   <strong>Great job!</strong> This is really working out <a href="#" class="alert-link">great for us</a>.
 </div>

--- a/tests/pages/_includes/widgets/communication/alert-warning-dismissable.html
+++ b/tests/pages/_includes/widgets/communication/alert-warning-dismissable.html
@@ -2,6 +2,6 @@
   <button type="button" class="close" data-dismiss="alert" aria-hidden="true">
     <span class="pficon pficon-close"></span>
   </button>
-  <span class="pficon pficon-warning-triangle-o"></span>
+  <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
   <strong>There might be a problem here!</strong> We are not really sure, but <a href="#" class="alert-link">it might be bad</a>.
 </div>

--- a/tests/pages/_includes/widgets/communication/alert-warning.html
+++ b/tests/pages/_includes/widgets/communication/alert-warning.html
@@ -1,4 +1,4 @@
 <div class="alert alert-warning">
-  <span class="pficon pficon-warning-triangle-o"></span>
+  <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
   <strong>There might be a problem here!</strong> We are not really sure, but <a href="#" class="alert-link">it might be bad</a>.
 </div>

--- a/tests/pages/_includes/widgets/communication/blank-slate.html
+++ b/tests/pages/_includes/widgets/communication/blank-slate.html
@@ -1,6 +1,6 @@
 <div class="blank-slate-pf {{include.extraClass}}" id="{{include.id}}">
   <div class="blank-slate-pf-icon">
-    <span class="pficon pficon pficon-add-circle-o"></span>
+    <span class="pficon pficon pficon-add-circle-o" aria-hidden="true"></span>
   </div>
   <h1>
     Empty State Title

--- a/tests/pages/_includes/widgets/communication/toast-danger.html
+++ b/tests/pages/_includes/widgets/communication/toast-danger.html
@@ -1,4 +1,4 @@
 <div class="toast-pf alert alert-danger">
-  <span class="pficon pficon-error-circle-o"></span>
+  <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
   Failed to add <strong>server_abc</strong>.
 </div>

--- a/tests/pages/_includes/widgets/communication/toast-in-context.html
+++ b/tests/pages/_includes/widgets/communication/toast-in-context.html
@@ -5,6 +5,6 @@
   <div class="pull-right toast-pf-action">
     <a href="#">Start Server</a>
   </div>
-  <span class="pficon pficon-ok"></span>
+  <span class="pficon pficon-ok" aria-hidden="true"></span>
   <strong>server_abc</strong> has been added to main server group.
 </div>

--- a/tests/pages/_includes/widgets/communication/toast-info.html
+++ b/tests/pages/_includes/widgets/communication/toast-info.html
@@ -3,6 +3,6 @@
   <div class="pull-right toast-pf-action">
     <a href="#">Reload Server</a>
   </div>
-  <span class="pficon pficon-info"></span>
+  <span class="pficon pficon-info" aria-hidden="true"></span>
   <strong>Great job!</strong> This is really working out.
 </div>

--- a/tests/pages/_includes/widgets/communication/toast-max-width.html
+++ b/tests/pages/_includes/widgets/communication/toast-max-width.html
@@ -5,6 +5,6 @@
   <div class="pull-right toast-pf-action">
     <a href="#">Reload Server</a>
   </div>
-  <span class="pficon pficon-warning-triangle-o"></span>
+  <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
   Max-width is set on this example.
 </div>

--- a/tests/pages/_includes/widgets/communication/toast-success.html
+++ b/tests/pages/_includes/widgets/communication/toast-success.html
@@ -2,6 +2,6 @@
   <button type="button" class="close" data-dismiss="alert" aria-hidden="true">
     <span class="pficon pficon-close"></span>
   </button>
-  <span class="pficon pficon-ok"></span>
+  <span class="pficon pficon-ok" aria-hidden="true"></span>
   The server configuration changed.
 </div>

--- a/tests/pages/_includes/widgets/communication/toast-warning.html
+++ b/tests/pages/_includes/widgets/communication/toast-warning.html
@@ -5,6 +5,6 @@
   <div class="pull-right toast-pf-action">
     <a href="#">Reload Server</a>
   </div>
-  <span class="pficon pficon-warning-triangle-o"></span>
+  <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
   The server configuration changed.
 </div>

--- a/tests/pages/_includes/widgets/layouts/cards-alt.html
+++ b/tests/pages/_includes/widgets/layouts/cards-alt.html
@@ -16,7 +16,7 @@
             </h2>
             <div class="card-pf-body">
               <p class="card-pf-aggregate-status-notifications">
-                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>1</span></a>
+                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o" aria-hidden="true"></span>1</span></a>
               </p>
             </div>
           </div>
@@ -37,13 +37,13 @@
           <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini">
             <h2 class="card-pf-title">
               <a href="#">
-                <span class="pficon pficon-image"></span>
+                <span class="pficon pficon-image" aria-hidden="true"></span>
                 <span class="card-pf-aggregate-status-count">12</span> Lorem
               </a>
             </h2>
             <div class="card-pf-body">
               <p class="card-pf-aggregate-status-notifications">
-                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>1</span></a>
+                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o" aria-hidden="true"></span>1</span></a>
               </p>
             </div>
           </div>
@@ -100,7 +100,7 @@
               </div>
               <p>
                 <a href="#" class="card-pf-link-with-icon">
-                  <span class="pficon pficon-flag"></span>View CPU Events
+                  <span class="pficon pficon-flag" aria-hidden="true"></span>View CPU Events
                 </a>
               </p>
             </div>

--- a/tests/pages/_includes/widgets/layouts/cards.html
+++ b/tests/pages/_includes/widgets/layouts/cards.html
@@ -16,7 +16,7 @@
             </h2>
             <div class="card-pf-body">
               <p class="card-pf-aggregate-status-notifications">
-                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>1</span></a>
+                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o" aria-hidden="true"></span>1</span></a>
               </p>
             </div>
           </div>
@@ -24,11 +24,11 @@
         <div class="col-xs-6 col-sm-4 col-md-2">
           <div class="card-pf card-pf-accented card-pf-aggregate-status">
             <h2 class="card-pf-title">
-              <a href="#"><span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">6</span> Dolar Sit</a>
+              <a href="#"><span class="fa fa-shield" aria-hidden="true"></span><span class="card-pf-aggregate-status-count">6</span> Dolar Sit</a>
             </h2>
             <div class="card-pf-body">
               <p class="card-pf-aggregate-status-notifications">
-                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>1</span></a>
+                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o" aria-hidden="true"></span>1</span></a>
               </p>
             </div>
           </div>
@@ -36,11 +36,11 @@
         <div class="col-xs-6 col-sm-4 col-md-2">
           <div class="card-pf card-pf-accented card-pf-aggregate-status">
             <h2 class="card-pf-title">
-              <a href="#"><span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">199</span> Consectetur</a>
+              <a href="#"><span class="fa fa-shield" aria-hidden="true"></span><span class="card-pf-aggregate-status-count">199</span> Consectetur</a>
             </h2>
             <div class="card-pf-body">
               <p class="card-pf-aggregate-status-notifications">
-                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>1</span></a>
+                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o" aria-hidden="true"></span>1</span></a>
               </p>
             </div>
           </div>
@@ -61,13 +61,13 @@
           <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini">
             <h2 class="card-pf-title">
               <a href="#">
-                <span class="pficon pficon-image"></span>
+                <span class="pficon pficon-image" aria-hidden="true"></span>
                 <span class="card-pf-aggregate-status-count">12</span> Lorem
               </a>
             </h2>
             <div class="card-pf-body">
               <p class="card-pf-aggregate-status-notifications">
-                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>1</span></a>
+                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o" aria-hidden="true"></span>1</span></a>
               </p>
             </div>
           </div>
@@ -76,13 +76,13 @@
           <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini">
             <h2 class="card-pf-title">
               <a href="#">
-                <span class="fa fa-shield"></span>
+                <span class="fa fa-shield" aria-hidden="true"></span>
                 <span class="card-pf-aggregate-status-count">6</span> Dolar Sit
               </a>
             </h2>
             <div class="card-pf-body">
               <p class="card-pf-aggregate-status-notifications">
-                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>1</span></a>
+                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o" aria-hidden="true"></span>1</span></a>
               </p>
             </div>
           </div>
@@ -91,13 +91,13 @@
           <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini">
             <h2 class="card-pf-title">
               <a href="#">
-                <span class="fa fa-rocket"></span>
+                <span class="fa fa-rocket" aria-hidden="true"></span>
                 <span class="card-pf-aggregate-status-count">199</span> Consectetur
               </a>
             </h2>
             <div class="card-pf-body">
               <p class="card-pf-aggregate-status-notifications">
-                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>23</span></a>
+                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o" aria-hidden="true"></span>23</span></a>
               </p>
             </div>
           </div>
@@ -213,7 +213,7 @@
               </div>
               <p>
                 <a href="#" class="card-pf-link-with-icon disabled">
-                  <span class="pficon pficon-flag"></span>View CPU Events
+                  <span class="pficon pficon-flag" aria-hidden="true"></span>View CPU Events
                 </a>
               </p>
             </div>

--- a/tests/pages/_includes/widgets/layouts/nav-horizontal-notification-drawer.html
+++ b/tests/pages/_includes/widgets/layouts/nav-horizontal-notification-drawer.html
@@ -22,7 +22,7 @@
       </li>
       <li class="dropdown">
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-          <span class="pficon pficon-user"></span>
+          <span class="pficon pficon-user" aria-hidden="true"></span>
           Brian Johnson <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">

--- a/tests/pages/_includes/widgets/layouts/navbar-primary.html
+++ b/tests/pages/_includes/widgets/layouts/navbar-primary.html
@@ -17,7 +17,7 @@
           </li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-              <span class="pficon pficon-user"></span>
+              <span class="pficon pficon-user" aria-hidden="true"></span>
               Brian Johnson <b class="caret"></b>
             </a>
             <ul class="dropdown-menu">

--- a/tests/pages/_includes/widgets/layouts/navbar-vertical.html
+++ b/tests/pages/_includes/widgets/layouts/navbar-vertical.html
@@ -24,10 +24,10 @@
           <div class="arrow"></div>
           <ul class="list-group">
             <li class="list-group-item">
-              <span class="i pficon pficon-info"></span> Modified Datasources ExampleDS
+              <span class="i pficon pficon-info" aria-hidden="true"></span> Modified Datasources ExampleDS
             </li>
             <li class="list-group-item">
-              <span class="i pficon pficon-info"></span> Error: System Failure
+              <span class="i pficon pficon-info" aria-hidden="true"></span> Error: System Failure
             </li>
           </ul>
           <div class="footer">

--- a/tests/pages/_includes/widgets/layouts/toolbar.html
+++ b/tests/pages/_includes/widgets/layouts/toolbar.html
@@ -49,7 +49,7 @@
                       <button class="btn btn-link" type="button">
                         <span class="fa fa-angle-down"></span>
                       </button>
-                      <button class="btn btn-link btn-find-close" type="button">
+                      <button class="btn btn-link btn-find-close" type="button" aria-hidden="true">
                         <span class="pficon pficon-close"></span>
                       </button>
                     </div>
@@ -70,19 +70,19 @@
                   <li>
                     <span class="label label-info">
                       Name: nameofthething
-                      <a href="#"><span class="pficon pficon-close"></span></a>
+                      <a href="#"><span class="pficon pficon-close" aria-hidden="true"></span></a>
                     </span>
                   </li>
                   <li>
                     <span class="label label-info">
                       Name: nameofthething
-                      <a href="#"><span class="pficon pficon-close"></span></a>
+                      <a href="#"><span class="pficon pficon-close" aria-hidden="true"></span></a>
                     </span>
                   </li>
                   <li>
                     <span class="label label-info">
                       Name: nameofthething
-                      <a href="#"><span class="pficon pficon-close"></span></a>
+                      <a href="#"><span class="pficon pficon-close" aria-hidden="true"></span></a>
                     </span>
                   </li>
                 </ul>

--- a/tests/pages/_includes/widgets/list-view/list-view-default.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-default.html
@@ -22,19 +22,19 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>8</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>8</strong> Clusters
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-container-node"></span>
+            <span class="pficon pficon-container-node" aria-hidden="true"></span>
             <strong>18</strong> Nodes
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-image"></span>
+            <span class="pficon pficon-image" aria-hidden="true"></span>
             <strong>4</strong> Images
           </div>
         </div>

--- a/tests/pages/_includes/widgets/list-view/list-view-standard-rows-compound-expansion.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-standard-rows-compound-expansion.html
@@ -23,29 +23,29 @@
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-screen"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <strong>8</strong> Hosts
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-cluster"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <strong>6</strong> Clusters
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-container-node"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <strong>10</strong> Nodes
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-image"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <strong>8</strong> Images
             </div>
           </div>
@@ -54,7 +54,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -96,7 +96,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -138,7 +138,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -180,7 +180,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -245,29 +245,29 @@
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-screen"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <strong>8</strong> Hosts
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-cluster"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <strong>6</strong> Clusters
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-container-node"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <strong>10</strong> Nodes
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-image"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <strong>8</strong> Images
             </div>
           </div>
@@ -276,7 +276,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -318,7 +318,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -360,7 +360,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -402,7 +402,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -467,29 +467,29 @@
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-screen"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <strong>8</strong> Hosts
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-cluster"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <strong>6</strong> Clusters
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-container-node"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <strong>10</strong> Nodes
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-image"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <strong>8</strong> Images
             </div>
           </div>
@@ -498,7 +498,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -540,7 +540,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -582,7 +582,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -624,7 +624,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -675,7 +675,7 @@
     </div>
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="fa fa-linux list-view-pf-icon-sm"></span>
+        <span class="fa fa-linux list-view-pf-icon-sm" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -689,29 +689,29 @@
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-screen"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <strong>8</strong> Hosts
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-cluster"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <strong>6</strong> Clusters
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-container-node"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <strong>10</strong> Nodes
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-image"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <strong>8</strong> Images
             </div>
           </div>
@@ -720,7 +720,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -762,7 +762,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -804,7 +804,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -846,7 +846,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -897,7 +897,7 @@
     </div>
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="fa fa-briefcase list-view-pf-icon-sm"></span>
+        <span class="fa fa-briefcase list-view-pf-icon-sm" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -911,29 +911,29 @@
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-screen"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <strong>8</strong> Hosts
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-cluster"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <strong>6</strong> Clusters
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-container-node"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <strong>10</strong> Nodes
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-image"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <strong>8</strong> Images
             </div>
           </div>
@@ -942,7 +942,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -984,7 +984,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -1026,7 +1026,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -1068,7 +1068,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -1119,7 +1119,7 @@
     </div>
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="fa fa-coffee list-view-pf-icon-sm"></span>
+        <span class="fa fa-coffee list-view-pf-icon-sm" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -1133,29 +1133,29 @@
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-screen"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <strong>8</strong> Hosts
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-cluster"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <strong>6</strong> Clusters
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-container-node"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <strong>10</strong> Nodes
             </div>
           </div>
           <div class="list-view-pf-additional-info-item">
             <div class="list-view-pf-expand">
-              <span class="fa fa-angle-right"></span>
-              <span class="pficon pficon-image"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <strong>8</strong> Images
             </div>
           </div>
@@ -1164,7 +1164,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -1206,7 +1206,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -1248,7 +1248,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -1290,7 +1290,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">

--- a/tests/pages/_includes/widgets/list-view/list-view-standard-rows-simple-expansion.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-standard-rows-simple-expansion.html
@@ -2,7 +2,7 @@
   <div class="list-group-item">
     <div class="list-group-item-header">
       <div class="list-view-pf-expand">
-        <span class="fa fa-angle-right"></span>
+        <span class="fa fa-angle-right" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-checkbox">
         <input type="checkbox">
@@ -13,7 +13,7 @@
       </div>
       <div class="list-view-pf-main-info">
         <div class="list-view-pf-left">
-          <span class="fa fa-plane list-view-pf-icon-sm"></span>
+          <span class="fa fa-plane list-view-pf-icon-sm" aria-hidden="true"></span>
         </div>
         <div class="list-view-pf-body">
           <div class="list-view-pf-description">
@@ -26,19 +26,19 @@
           </div>
           <div class="list-view-pf-additional-info">
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-screen"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <strong>8</strong> Hosts
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-cluster"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <strong>6</strong> Clusters
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-container-node"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <strong>10</strong> Nodes
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-image"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <strong>8</strong> Images
             </div>
           </div>
@@ -47,7 +47,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -105,19 +105,19 @@
           </div>
           <div class="list-view-pf-additional-info">
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-screen"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <strong>4</strong> Hosts
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-cluster"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <strong>2</strong> Clusters
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-container-node"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <strong>11</strong> Nodes
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-image"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <strong>6</strong> Images
             </div>
           </div>
@@ -126,7 +126,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -184,19 +184,19 @@
           </div>
           <div class="list-view-pf-additional-info">
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-screen"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <strong>4</strong> Hosts
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-cluster"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <strong>2</strong> Clusters
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-container-node"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <strong>10</strong> Nodes
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-image"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <strong>6</strong> Images
             </div>
           </div>
@@ -205,7 +205,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -263,19 +263,19 @@
           </div>
           <div class="list-view-pf-additional-info">
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-screen"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <strong>4</strong> Hosts
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-cluster"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <strong>2</strong> Clusters
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-container-node"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <strong>10</strong> Nodes
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-image"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <strong>6</strong> Images
             </div>
           </div>
@@ -284,7 +284,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -342,19 +342,19 @@
           </div>
           <div class="list-view-pf-additional-info">
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-screen"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <strong>4</strong> Hosts
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-cluster"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <strong>2</strong> Clusters
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-container-node"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <strong>10</strong> Nodes
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-image"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <strong>6</strong> Images
             </div>
           </div>
@@ -363,7 +363,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">
@@ -408,7 +408,7 @@
       </div>
       <div class="list-view-pf-main-info">
         <div class="list-view-pf-left">
-          <span class="fa fa-coffee list-view-pf-icon-sm"></span>
+          <span class="fa fa-coffee list-view-pf-icon-sm" aria-hidden="true"></span>
         </div>
         <div class="list-view-pf-body">
           <div class="list-view-pf-description">
@@ -421,19 +421,19 @@
           </div>
           <div class="list-view-pf-additional-info">
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-screen"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <strong>4</strong> Hosts
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-cluster"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <strong>2</strong> Clusters
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-container-node"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <strong>10</strong> Nodes
             </div>
             <div class="list-view-pf-additional-info-item">
-              <span class="pficon pficon-image"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <strong>6</strong> Images
             </div>
           </div>
@@ -442,7 +442,7 @@
     </div>
     <div class="list-group-item-container container-fluid hidden">
       <div class="close">
-        <span class="pficon pficon-close"></span>
+        <span class="pficon pficon-close" aria-hidden="true"></span>
       </div>
       <div class="row">
         <div class="col-md-3">

--- a/tests/pages/_includes/widgets/list-view/list-view-standard-rows.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-standard-rows.html
@@ -22,19 +22,19 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>8</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>6</strong> Clusters
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-container-node"></span>
+            <span class="pficon pficon-container-node" aria-hidden="true"></span>
             <strong>10</strong> Nodes
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-image"></span>
+            <span class="pficon pficon-image" aria-hidden="true"></span>
             <strong>8</strong> Images
           </div>
         </div>
@@ -51,7 +51,7 @@
     </div>
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="fa fa-magic list-view-pf-icon-sm"></span>
+        <span class="fa fa-magic list-view-pf-icon-sm" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -64,19 +64,19 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>4</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>2</strong> Clusters
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-container-node"></span>
+            <span class="pficon pficon-container-node" aria-hidden="true"></span>
             <strong>11</strong> Nodes
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-image"></span>
+            <span class="pficon pficon-image" aria-hidden="true"></span>
             <strong>6</strong> Images
           </div>
         </div>
@@ -93,7 +93,7 @@
     </div>
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="fa fa-gamepad list-view-pf-icon-sm"></span>
+        <span class="fa fa-gamepad list-view-pf-icon-sm" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -106,19 +106,19 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>4</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>2</strong> Clusters
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-container-node"></span>
+            <span class="pficon pficon-container-node" aria-hidden="true"></span>
             <strong>10</strong> Nodes
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-image"></span>
+            <span class="pficon pficon-image" aria-hidden="true"></span>
             <strong>6</strong> Images
           </div>
         </div>
@@ -135,7 +135,7 @@
     </div>
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="fa fa-linux list-view-pf-icon-sm"></span>
+        <span class="fa fa-linux list-view-pf-icon-sm" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -148,19 +148,19 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>4</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>2</strong> Clusters
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-container-node"></span>
+            <span class="pficon pficon-container-node" aria-hidden="true"></span>
             <strong>10</strong> Nodes
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-image"></span>
+            <span class="pficon pficon-image" aria-hidden="true"></span>
             <strong>6</strong> Images
           </div>
         </div>
@@ -177,7 +177,7 @@
     </div>
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="fa fa-briefcase list-view-pf-icon-sm"></span>
+        <span class="fa fa-briefcase list-view-pf-icon-sm" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -190,19 +190,19 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>4</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>2</strong> Clusters
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-container-node"></span>
+            <span class="pficon pficon-container-node" aria-hidden="true"></span>
             <strong>10</strong> Nodes
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-image"></span>
+            <span class="pficon pficon-image" aria-hidden="true"></span>
             <strong>6</strong> Images
           </div>
         </div>
@@ -219,7 +219,7 @@
     </div>
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="fa fa-coffee list-view-pf-icon-sm"></span>
+        <span class="fa fa-coffee list-view-pf-icon-sm" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -232,19 +232,19 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>4</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>2</strong> Clusters
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-container-node"></span>
+            <span class="pficon pficon-container-node" aria-hidden="true"></span>
             <strong>10</strong> Nodes
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-image"></span>
+            <span class="pficon pficon-image" aria-hidden="true"></span>
             <strong>6</strong> Images
           </div>
         </div>

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-2.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-2.html
@@ -22,20 +22,20 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>8</strong> Clusters
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>8</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-container-node"></span>
+            <span class="pficon pficon-container-node" aria-hidden="true"></span>
             <strong>18</strong>
             Nodes
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-image"></span>
+            <span class="pficon pficon-image" aria-hidden="true"></span>
             <strong>4</strong> Images
           </div>
         </div>

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-4.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-4.html
@@ -18,11 +18,11 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>8</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>8</strong> Clusters
           </div>
         </div>

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-5.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-5.html
@@ -2,7 +2,7 @@
   <div class="list-group-item">
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="pficon pficon-ok list-view-pf-icon-md list-view-pf-icon-success"></span>
+        <span class="pficon pficon-ok list-view-pf-icon-md list-view-pf-icon-success" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -15,11 +15,11 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>108</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>28</strong> Clusters
           </div>
         </div>
@@ -29,7 +29,7 @@
   <div class="list-group-item">
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="pficon pficon-info list-view-pf-icon-md list-view-pf-icon-info"></span>
+        <span class="pficon pficon-info list-view-pf-icon-md list-view-pf-icon-info" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -42,11 +42,11 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>8</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>28</strong> Clusters
           </div>
         </div>
@@ -56,7 +56,7 @@
   <div class="list-group-item">
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="pficon pficon-warning-triangle-o list-view-pf-icon-md list-view-pf-icon-warning"></span>
+        <span class="pficon pficon-warning-triangle-o list-view-pf-icon-md list-view-pf-icon-warning" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -69,11 +69,11 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>108</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>28</strong> Clusters
           </div>
         </div>
@@ -83,7 +83,7 @@
   <div class="list-group-item">
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="pficon pficon-error-circle-o list-view-pf-icon-md list-view-pf-icon-danger"></span>
+        <span class="pficon pficon-error-circle-o list-view-pf-icon-md list-view-pf-icon-danger" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -96,11 +96,11 @@
         </div>
         <div class="list-view-pf-additional-info">
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-screen"></span>
+            <span class="pficon pficon-screen" aria-hidden="true"></span>
             <strong>8</strong> Hosts
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>28</strong> Clusters
           </div>
         </div>

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-6.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-6.html
@@ -10,7 +10,7 @@
     </div>
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
-        <span class="fa fa-plane list-view-pf-icon-sm"></span>
+        <span class="fa fa-plane list-view-pf-icon-sm" aria-hidden="true"></span>
       </div>
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
@@ -27,7 +27,7 @@
             <img src="http://placehold.it/60x60" alt="placeholder image">
           </div>
           <div class="list-view-pf-additional-info-item">
-            <span class="pficon pficon-cluster"></span>
+            <span class="pficon pficon-cluster" aria-hidden="true"></span>
             <strong>8</strong> Clusters
           </div>
           <div class="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked">

--- a/tests/pages/_includes/widgets/navigation/horizontal-multi-level.html
+++ b/tests/pages/_includes/widgets/navigation/horizontal-multi-level.html
@@ -17,7 +17,7 @@
       </li>
       <li class="dropdown">
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-          <span class="pficon pficon-user"></span>
+          <span class="pficon pficon-user" aria-hidden="true"></span>
           Brian Johnson
           <b class="caret"></b>
         </a>

--- a/tests/pages/_includes/widgets/navigation/horizontal-persistent-secondary-tertiary.html
+++ b/tests/pages/_includes/widgets/navigation/horizontal-persistent-secondary-tertiary.html
@@ -17,7 +17,7 @@
       </li>
       <li class="dropdown">
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-          <span class="pficon pficon-user"></span>
+          <span class="pficon pficon-user" aria-hidden="true"></span>
           Brian Johnson
           <b class="caret"></b>
         </a>

--- a/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar.html
+++ b/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar.html
@@ -17,7 +17,7 @@
       </li>
       <li class="dropdown">
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-          <span class="pficon pficon-user"></span>
+          <span class="pficon pficon-user" aria-hidden="true"></span>
           Brian Johnson <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">

--- a/tests/pages/_includes/widgets/navigation/secondary-nav-amet.html
+++ b/tests/pages/_includes/widgets/navigation/secondary-nav-amet.html
@@ -11,11 +11,11 @@
         {% if page.nav-badges %}
         <div class="badge-container-pf">
           <div class="badge">
-            <span class="pficon pficon-error-circle-o"></span>
+            <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
             <span>3</span>
           </div>
           <div class="badge">
-            <span class="pficon pficon-warning-triangle-o"></span>
+            <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
             <span>1</span>
           </div>
         </div>
@@ -33,7 +33,7 @@
         {% if page.nav-badges %}
         <div class="badge-container-pf">
           <div class="badge">
-            <span class="pficon pficon-warning-triangle-o"></span>
+            <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
             <span>2</span>
           </div>
         </div>
@@ -51,7 +51,7 @@
         {% if page.nav-badges %}
         <div class="badge-container-pf">
           <div class="badge">
-            <span class="pficon pficon-warning-triangle-o"></span>
+            <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
             <span>5</span>
           </div>
           <div class="badge">

--- a/tests/pages/_includes/widgets/navigation/tertiary-ipsum-intellegam.html
+++ b/tests/pages/_includes/widgets/navigation/tertiary-ipsum-intellegam.html
@@ -10,11 +10,11 @@
         {% if page.nav-badges %}
         <div class="badge-container-pf">
           <div class="badge">
-            <span class="pficon pficon-error-circle-o"></span>
+            <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
             <span>10</span>
           </div>
           <div class="badge">
-            <span class="pficon pficon-warning-triangle-o"></span>
+            <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
             <span>4</span>
           </div>
         </div>
@@ -27,11 +27,11 @@
         {% if page.nav-badges %}
         <div class="badge-container-pf">
           <div class="badge">
-            <span class="pficon pficon-error-circle-o"></span>
+            <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
             <span>1</span>
           </div>
           <div class="badge">
-            <span class="pficon pficon-warning-triangle-o"></span>
+            <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
             <span>3</span>
           </div>
         </div>
@@ -44,11 +44,11 @@
         {% if page.nav-badges %}
         <div class="badge-container-pf">
           <div class="badge">
-            <span class="pficon pficon-error-circle-o"></span>
+            <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
             <span>3</span>
           </div>
           <div class="badge">
-            <span class="pficon pficon-warning-triangle-o"></span>
+            <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
             <span>1</span>
           </div>
         </div>

--- a/tests/pages/_includes/widgets/notification-drawer-notifications.html
+++ b/tests/pages/_includes/widgets/notification-drawer-notifications.html
@@ -1,7 +1,7 @@
 <div class="drawer-pf-notification unread">
   {% assign menu_id = 'dropdownKebabRight1' | append: include.id %}
   {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId=menu_id dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
-  <span class="pficon pficon-info pull-left"></span>
+  <span class="pficon pficon-info pull-left" aria-hidden="true"></span>
   <span class="drawer-pf-notification-message">A New Event! Huzzah! Bold!</span>
   <div class="drawer-pf-notification-info">
     <span class="date">3/31/16</span>
@@ -11,7 +11,7 @@
 <div class="drawer-pf-notification unread">
   {% assign menu_id = 'dropdownKebabRight2' | append: include.id %}
   {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId=menu_id dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
-  <span class="pficon pficon-ok pull-left"></span>
+  <span class="pficon pficon-ok pull-left" aria-hidden="true"></span>
   <span class="drawer-pf-notification-message">Another Event Notification</span>
   <div class="drawer-pf-notification-info">
     <span class="date">3/31/16</span>
@@ -21,7 +21,7 @@
 <div class="drawer-pf-notification">
   {% assign menu_id = 'dropdownKebabRight3' | append: include.id %}
   {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId=menu_id dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
-  <span class="pficon pficon-warning-triangle-o pull-left"></span>
+  <span class="pficon pficon-warning-triangle-o pull-left" aria-hidden="true"></span>
   <span class="drawer-pf-notification-message">Another Event Notification</span>
   <div class="drawer-pf-notification-info">
     <span class="date">3/31/16</span>
@@ -31,7 +31,7 @@
 <div class="drawer-pf-notification">
   {% assign menu_id = 'dropdownKebabRight4' | append: include.id %}
   {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId=menu_id dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
-  <span class="pficon pficon-error-circle-o pull-left"></span>
+  <span class="pficon pficon-error-circle-o pull-left" aria-hidden="true"></span>
   <span class="drawer-pf-notification-message">Another Event Notification</span>
   <div class="drawer-pf-notification-info">
     <span class="date">3/31/16</span>

--- a/tests/pages/_includes/widgets/notifications-drawer-notifications.html
+++ b/tests/pages/_includes/widgets/notifications-drawer-notifications.html
@@ -1,6 +1,6 @@
 <div class="drawer-pf-notification unread">
   {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId="dropdownKebabRight5" dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
-  <span class="pficon pficon-info pull-left"></span>
+  <span class="pficon pficon-info pull-left" aria-hidden="true"></span>
   <span class="drawer-pf-notification-message">A New Event! Huzzah! Bold!</span>
   <div class="drawer-pf-notification-info">
     <span class="date">3/31/16</span>
@@ -9,7 +9,7 @@
 </div>
 <div class="drawer-pf-notification unread">
   {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId="dropdownKebabRight6" dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
-  <span class="pficon pficon-ok pull-left"></span>
+  <span class="pficon pficon-ok pull-left" aria-hidden="true"></span>
   <span class="drawer-pf-notification-message">Another Event Notification</span>
   <div class="drawer-pf-notification-info">
     <span class="date">3/31/16</span>
@@ -18,7 +18,7 @@
 </div>
 <div class="drawer-pf-notification">
   {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId="dropdownKebabRight7" dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
-  <span class="pficon pficon-warning-triangle-o pull-left"></span>
+  <span class="pficon pficon-warning-triangle-o pull-left" aria-hidden="true"></span>
   <span class="drawer-pf-notification-message">Another Event Notification</span>
   <div class="drawer-pf-notification-info">
     <span class="date">3/31/16</span>
@@ -27,7 +27,7 @@
 </div>
 <div class="drawer-pf-notification">
   {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId="dropdownKebabRight8" dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
-  <span class="pficon pficon-error-circle-o pull-left"></span>
+  <span class="pficon pficon-error-circle-o pull-left" aria-hidden="true"></span>
   <span class="drawer-pf-notification-message">Another Event Notification</span>
   <div class="drawer-pf-notification-info">
     <span class="date">3/31/16</span>

--- a/tests/pages/_includes/widgets/table-view/tmpl/toolbar-all.html
+++ b/tests/pages/_includes/widgets/table-view/tmpl/toolbar-all.html
@@ -54,7 +54,7 @@
                   <span class="fa fa-angle-down"></span>
                 </button>
                 <button class="btn btn-link btn-find-close" type="button">
-                  <span class="pficon pficon-close"></span>
+                  <span class="pficon pficon-close" aria-hidden="true"></span>
                 </button>
               </div>
             </div>

--- a/tests/pages/_includes/widgets/table-view/tmpl/toolbar.html
+++ b/tests/pages/_includes/widgets/table-view/tmpl/toolbar.html
@@ -38,7 +38,7 @@
                 <span class="fa fa-angle-down"></span>
               </button>
               <button class="btn btn-link btn-find-close" type="button">
-                <span class="pficon pficon-close"></span>
+                <span class="pficon pficon-close" aria-hidden="true"></span>
               </button>
             </div>
           </div>

--- a/tests/pages/_layouts/page.html
+++ b/tests/pages/_layouts/page.html
@@ -7,7 +7,7 @@ layout: default
         <h1>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</h1>
       </div>
       <div class="alert alert-warning">
-        <span class="pficon pficon-warning-triangle-o"></span>
+        <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
         These examples are included for development testing purposes.  For official documentation, see <a href="https://www.patternfly.org" class="alert-link">https://www.patternfly.org</a>{% if page.alert-message %}{{ page.alert-message }}{% else %}{{ site.alert-message }}{% endif %}
       </div>
       <hr>

--- a/tests/pages/alerts.html
+++ b/tests/pages/alerts.html
@@ -7,11 +7,11 @@ resource: true
 {% include widgets/communication/alert-danger.html %}
 {% include widgets/communication/alert-warning.html %}
       <div class="alert alert-success">
-        <span class="pficon pficon-ok"></span>
+        <span class="pficon pficon-ok" aria-hidden="true"></span>
         <strong>Great job!</strong> This is really working out <a href="#" class="alert-link">great for us</a>.
       </div>
       <div class="alert alert-info">
-        <span class="pficon pficon-info"></span>
+        <span class="pficon pficon-info" aria-hidden="true"></span>
         <strong>This is some general information.</strong> You should <a href="#" class="alert-link">know about this</a>.
       </div>
       <hr>

--- a/tests/pages/dashboard.html
+++ b/tests/pages/dashboard.html
@@ -14,7 +14,7 @@ weight: 3
         <div class="col-sm-8 col-md-9">
           <div class="page-header page-header-bleed-right">
             <div class="actions pull-right">
-              <a href="#"><span class="pficon pficon-refresh"></span> Refresh Results</a>
+              <a href="#"><span class="pficon pficon-refresh" aria-hidden="true"></span> Refresh Results</a>
             </div>
             <h1>{{ page.title }}</h1>
           </div>

--- a/tests/pages/icons.html
+++ b/tests/pages/icons.html
@@ -10,251 +10,251 @@ resource: true
           <p>Custom icons and selections from <a href="http://icomoon.io/#icons">IcoMoon - Free</a>.</p>
           <ul class="icons list-unstyled">
             <li>
-              <span class="pficon pficon-middleware"></span>
+              <span class="pficon pficon-middleware" aria-hidden="true"></span>
               <span class="icon-class">pficon-middleware</span>
             </li>
             <li>
-              <span class="pficon pficon-add-circle-o"></span>
+              <span class="pficon pficon-add-circle-o" aria-hidden="true"></span>
               <span class="icon-class">pficon-add-circle-o</span>
             </li>
             <li>
-              <span class="pficon pficon-blueprint"></span>
+              <span class="pficon pficon-blueprint" aria-hidden="true"></span>
               <span class="icon-class">pficon-blueprint</span>
             </li>
             <li>
-              <span class="pficon pficon-build"></span>
+              <span class="pficon pficon-build" aria-hidden="true"></span>
               <span class="icon-class">pficon-build</span>
             </li>
             <li>
-              <span class="pficon pficon-builder-image"></span>
+              <span class="pficon pficon-builder-image" aria-hidden="true"></span>
               <span class="icon-class">pficon-builder-image</span>
             </li>
             <li>
-              <span class="pficon pficon-bundle"></span>
+              <span class="pficon pficon-bundle" aria-hidden="true"></span>
               <span class="icon-class">pficon-bundle</span>
             </li>
             <li>
-              <span class="pficon pficon-close"></span>
+              <span class="pficon pficon-close" aria-hidden="true"></span>
               <span class="icon-class">pficon-close</span>
             </li>
             <li>
-              <span class="pficon pficon-cloud-security"></span>
+              <span class="pficon pficon-cloud-security" aria-hidden="true"></span>
               <span class="icon-class">pficon-cloud-security</span>
             </li>
             <li>
-              <span class="pficon pficon-cloud-tenant"></span>
+              <span class="pficon pficon-cloud-tenant" aria-hidden="true"></span>
               <span class="icon-class">pficon-cloud-tenant</span>
             </li>
             <li>
-              <span class="pficon pficon-cluster"></span>
+              <span class="pficon pficon-cluster" aria-hidden="true"></span>
               <span class="icon-class">pficon-cluster</span>
             </li>
             <li>
-              <span class="pficon pficon-container-node"></span>
+              <span class="pficon pficon-container-node" aria-hidden="true"></span>
               <span class="icon-class">pficon-container-node</span>
             </li>
             <li>
-              <span class="pficon pficon-cpu"></span>
+              <span class="pficon pficon-cpu" aria-hidden="true"></span>
               <span class="icon-class">pficon-cpu</span>
             </li>
             <li>
-              <span class="pficon pficon-delete"></span>
+              <span class="pficon pficon-delete" aria-hidden="true"></span>
               <span class="icon-class">pficon-delete</span>
             </li>
             <li>
-              <span class="pficon pficon-domain"></span>
+              <span class="pficon pficon-domain" aria-hidden="true"></span>
               <span class="icon-class">pficon-domain</span>
             </li>
             <li>
-              <span class="pficon pficon-edit"></span>
+              <span class="pficon pficon-edit" aria-hidden="true"></span>
               <span class="icon-class">pficon-edit</span>
             </li>
             <li>
-              <span class="pficon pficon-enterprise"></span>
+              <span class="pficon pficon-enterprise" aria-hidden="true"></span>
               <span class="icon-class">pficon-enterprise</span>
             </li>
             <li>
-              <span class="pficon pficon-error-circle-o"></span>
+              <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
               <span class="icon-class">pficon-error-circle-o</span>
             </li>
             <li>
-              <span class="pficon pficon-export"></span>
+              <span class="pficon pficon-export" aria-hidden="true"></span>
               <span class="icon-class">pficon-export</span>
             </li>
             <li>
-              <span class="pficon pficon-flag"></span>
+              <span class="pficon pficon-flag" aria-hidden="true"></span>
               <span class="icon-class">pficon-flag</span>
             </li>
             <li>
-              <span class="pficon pficon-flavor"></span>
+              <span class="pficon pficon-flavor" aria-hidden="true"></span>
               <span class="icon-class">pficon-flavor</span>
             </li>
             <li>
-              <span class="pficon pficon-folder-close"></span>
+              <span class="pficon pficon-folder-close" aria-hidden="true"></span>
               <span class="icon-class">pficon-folder-close</span>
             </li>
             <li>
-              <span class="pficon pficon-folder-open"></span>
+              <span class="pficon pficon-folder-open" aria-hidden="true"></span>
               <span class="icon-class">pficon-folder-open</span>
             </li>
             <li>
-              <span class="pficon pficon-help"></span>
+              <span class="pficon pficon-help" aria-hidden="true"></span>
               <span class="icon-class">pficon-help</span>
             </li>
             <li>
-              <span class="pficon pficon-home"></span>
+              <span class="pficon pficon-home" aria-hidden="true"></span>
               <span class="icon-class">pficon-home</span>
             </li>
             <li>
-              <span class="pficon pficon-history"></span>
+              <span class="pficon pficon-history" aria-hidden="true"></span>
               <span class="icon-class">pficon-history</span>
             </li>
             <li>
-              <span class="pficon pficon-image"></span>
+              <span class="pficon pficon-image" aria-hidden="true"></span>
               <span class="icon-class">pficon-image</span>
             </li>
             <li>
-              <span class="pficon pficon-import"></span>
+              <span class="pficon pficon-import" aria-hidden="true"></span>
               <span class="icon-class">pficon-import</span>
             </li>
             <li>
-              <span class="pficon pficon-info"></span>
+              <span class="pficon pficon-info" aria-hidden="true"></span>
               <span class="icon-class">pficon-info</span>
             </li>
             <li>
-              <span class="pficon pficon-memory"></span>
+              <span class="pficon pficon-memory" aria-hidden="true"></span>
               <span class="icon-class">pficon-memory</span>
             </li>
             <li>
-              <span class="pficon pficon-network"></span>
+              <span class="pficon pficon-network" aria-hidden="true"></span>
               <span class="icon-class">pficon-network</span>
             </li>
             <li>
-              <span class="pficon pficon-ok"></span>
+              <span class="pficon pficon-ok" aria-hidden="true"></span>
               <span class="icon-class">pficon-ok</span>
             </li>
             <li>
-              <span class="pficon pficon-print"></span>
+              <span class="pficon pficon-print" aria-hidden="true"></span>
               <span class="icon-class">pficon-print</span>
             </li>
             <li>
-              <span class="pficon pficon-private"></span>
+              <span class="pficon pficon-private" aria-hidden="true"></span>
               <span class="icon-class">pficon-private</span>
             </li>
             <li>
-              <span class="pficon pficon-project"></span>
+              <span class="pficon pficon-project" aria-hidden="true"></span>
               <span class="icon-class">pficon-project</span>
             </li>
             <li>
-              <span class="pficon pficon-regions"></span>
+              <span class="pficon pficon-regions" aria-hidden="true"></span>
               <span class="icon-class">pficon-regions</span>
             </li>
             <li>
-              <span class="pficon pficon-registry"></span>
+              <span class="pficon pficon-registry" aria-hidden="true"></span>
               <span class="icon-class">pficon-registry</span>
             </li>
             <li>
-              <span class="pficon pficon-replicator"></span>
+              <span class="pficon pficon-replicator" aria-hidden="true"></span>
               <span class="icon-class">pficon-replicator</span>
             </li>
             <li>
-              <span class="pficon pficon-repository"></span>
+              <span class="pficon pficon-repository" aria-hidden="true"></span>
               <span class="icon-class">pficon-repository</span>
             </li>
             <li>
-              <span class="pficon pficon-resource-pool"></span>
+              <span class="pficon pficon-resource-pool" aria-hidden="true"></span>
               <span class="icon-class">pficon-resource-pool</span>
             </li>
             <li>
-              <span class="pficon pficon-resources-almost-full"></span>
+              <span class="pficon pficon-resources-almost-full" aria-hidden="true"></span>
               <span class="icon-class">pficon-resources-almost-full</span>
             </li>
             <li>
-              <span class="pficon pficon-resources-full"></span>
+              <span class="pficon pficon-resources-full" aria-hidden="true"></span>
               <span class="icon-class">pficon-resources-full</span>
             </li>
             <li>
-              <span class="pficon pficon-restart"></span>
+              <span class="pficon pficon-restart" aria-hidden="true"></span>
               <span class="icon-class">pficon-restart</span>
             </li>
             <li>
-              <span class="pficon pficon-route"></span>
+              <span class="pficon pficon-route" aria-hidden="true"></span>
               <span class="icon-class">pficon-route</span>
             </li>
             <li>
-              <span class="pficon pficon-running"></span>
+              <span class="pficon pficon-running" aria-hidden="true"></span>
               <span class="icon-class">pficon-running</span>
             </li>
             <li>
-              <span class="pficon pficon-save"></span>
+              <span class="pficon pficon-save" aria-hidden="true"></span>
               <span class="icon-class">pficon-save</span>
             </li>
             <li>
-              <span class="pficon pficon-screen"></span>
+              <span class="pficon pficon-screen" aria-hidden="true"></span>
               <span class="icon-class">pficon-screen</span>
             </li>
             <li>
-              <span class="pficon pficon-server"></span>
+              <span class="pficon pficon-server" aria-hidden="true"></span>
               <span class="icon-class">pficon-server</span>
             </li>
             <li>
-              <span class="pficon pficon-server-group"></span>
+              <span class="pficon pficon-server-group" aria-hidden="true"></span>
               <span class="icon-class">pficon-server-group</span>
             </li>
             <li>
-              <span class="pficon pficon-service"></span>
+              <span class="pficon pficon-service" aria-hidden="true"></span>
               <span class="icon-class">pficon-service</span>
             </li>
             <li>
-              <span class="pficon pficon-settings"></span>
+              <span class="pficon pficon-settings" aria-hidden="true"></span>
               <span class="icon-class">pficon-settings</span>
             </li>
             <li>
-              <span class="pficon pficon-storage-domain"></span>
+              <span class="pficon pficon-storage-domain" aria-hidden="true"></span>
               <span class="icon-class">pficon-storage-domain</span>
             </li>
             <li>
-              <span class="pficon pficon-tenant"></span>
+              <span class="pficon pficon-tenant" aria-hidden="true"></span>
               <span class="icon-class">pficon-tenant</span>
             </li>
             <li>
-              <span class="pficon pficon-thumb-tack-o"></span>
+              <span class="pficon pficon-thumb-tack-o" aria-hidden="true"></span>
               <span class="icon-class">pficon-thumb-tack-o</span>
             </li>
             <li>
-              <span class="pficon pficon-topology"></span>
+              <span class="pficon pficon-topology" aria-hidden="true"></span>
               <span class="icon-class">pficon-topology</span>
             </li>
             <li>
-              <span class="pficon pficon-trend-down"></span>
+              <span class="pficon pficon-trend-down" aria-hidden="true"></span>
               <span class="icon-class">pficon-trend-down</span>
             </li>
             <li>
-              <span class="pficon pficon-trend-up"></span>
+              <span class="pficon pficon-trend-up" aria-hidden="true"></span>
               <span class="icon-class">pficon-trend-up</span>
             </li>
             <li>
-              <span class="pficon pficon-user"></span>
+              <span class="pficon pficon-user" aria-hidden="true"></span>
               <span class="icon-class">pficon-user</span>
             </li>
             <li>
-              <span class="pficon pficon-users"></span>
+              <span class="pficon pficon-users" aria-hidden="true"></span>
               <span class="icon-class">pficon-users</span>
             </li>
             <li>
-              <span class="pficon pficon-virtual-machine"></span>
+              <span class="pficon pficon-virtual-machine" aria-hidden="true"></span>
               <span class="icon-class">pficon-virtual-machine</span>
             </li>
             <li>
-              <span class="pficon pficon-volume"></span>
+              <span class="pficon pficon-volume" aria-hidden="true"></span>
               <span class="icon-class">pficon-volume</span>
             </li>
             <li>
-              <span class="pficon pficon-warning-triangle-o"></span>
+              <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
               <span class="icon-class">pficon-warning-triangle-o</span>
             </li>
             <li>
-              <span class="pficon pficon-zone"></span>
+              <span class="pficon pficon-zone" aria-hidden="true"></span>
               <span class="icon-class">pficon-zone</span>
             </li>
           </ul>
@@ -264,123 +264,123 @@ resource: true
           <p>All <a href="http://fontawesome.io/icons/">Font Awesome</a> icons are available, but only these are recommended for use with PatternFly.</p>
           <ul class="icons list-unstyled">
             <li>
-              <span class="fa fa-angle-down"></span>
+              <span class="fa fa-angle-down" aria-hidden="true"></span>
               <span class="icon-class">fa-angle-down</span>
             </li>
             <li>
-              <span class="fa fa-angle-left"></span>
+              <span class="fa fa-angle-left" aria-hidden="true"></span>
               <span class="icon-class">fa-angle-left</span>
             </li>
             <li>
-              <span class="fa fa-angle-right"></span>
+              <span class="fa fa-angle-right" aria-hidden="true"></span>
               <span class="icon-class">fa-angle-right</span>
             </li>
             <li>
-              <span class="fa fa-angle-up"></span>
+              <span class="fa fa-angle-up" aria-hidden="true"></span>
               <span class="icon-class">fa-angle-up</span>
             </li>
             <li>
-              <span class="fa fa-angle-double-left"></span>
+              <span class="fa fa-angle-double-left" aria-hidden="true"></span>
               <span class="icon-class">fa-angle-double-left</span>
             </li>
             <li>
-              <span class="fa fa-angle-double-right"></span>
+              <span class="fa fa-angle-double-right" aria-hidden="true"></span>
               <span class="icon-class">fa-angle-double-right</span>
             </li>
             <li>
-              <span class="fa fa-arrow-circle-o-down"></span>
+              <span class="fa fa-arrow-circle-o-down" aria-hidden="true"></span>
               <span class="icon-class">fa-arrow-circle-o-down</span>
             </li>
             <li>
-              <span class="fa fa-ban"></span>
+              <span class="fa fa-ban" aria-hidden="true"></span>
               <span class="icon-class">fa-ban</span>
             </li>
             <li>
-              <span class="fa fa-bug"></span>
+              <span class="fa fa-bug" aria-hidden="true"></span>
               <span class="icon-class">fa-bug</span>
             </li>
             <li>
-              <span class="fa fa-check"></span>
+              <span class="fa fa-check" aria-hidden="true"></span>
               <span class="icon-class">fa-check</span>
             </li>
             <li>
-              <span class="fa fa-clock-o"></span>
+              <span class="fa fa-clock-o" aria-hidden="true"></span>
               <span class="icon-class">fa-clock-o</span>
             </li>
             <li>
-              <span class="fa fa-cube"></span>
+              <span class="fa fa-cube" aria-hidden="true"></span>
               <span class="icon-class">fa-cube</span>
             </li>
             <li>
-              <span class="fa fa-cubes"></span>
+              <span class="fa fa-cubes" aria-hidden="true"></span>
               <span class="icon-class">fa-cubes</span>
             </li>
             <li>
-              <span class="fa fa-database"></span>
+              <span class="fa fa-database" aria-hidden="true"></span>
               <span class="icon-class">fa-database</span>
             </li>
             <li>
-              <span class="fa fa-envelope"></span>
+              <span class="fa fa-envelope" aria-hidden="true"></span>
               <span class="icon-class">fa-envelope</span>
             </li>
             <li>
-              <span class="fa fa-filter"></span>
+              <span class="fa fa-filter" aria-hidden="true"></span>
               <span class="icon-class">fa-filter</span>
             </li>
             <li>
-              <span class="fa fa-lock"></span>
+              <span class="fa fa-lock" aria-hidden="true"></span>
               <span class="icon-class">fa-lock</span>
             </li>
             <li>
-              <span class="fa fa-map-marker"></span>
+              <span class="fa fa-map-marker" aria-hidden="true"></span>
               <span class="icon-class">fa-map-marker</span>
             </li>
             <li>
-              <span class="fa fa-minus"></span>
+              <span class="fa fa-minus" aria-hidden="true"></span>
               <span class="icon-class">fa-minus</span>
             </li>
             <li>
-              <span class="fa fa-plus"></span>
+              <span class="fa fa-plus" aria-hidden="true"></span>
               <span class="icon-class">fa-plus</span>
             </li>
             <li>
-              <span class="fa fa-plus-square"></span>
+              <span class="fa fa-plus-square" aria-hidden="true"></span>
               <span class="icon-class">fa-plus-square</span>
             </li>
             <li>
-              <span class="fa fa-power-off"></span>
+              <span class="fa fa-power-off" aria-hidden="true"></span>
               <span class="icon-class">fa-power-off</span>
             </li>
             <li>
-              <span class="fa fa-refresh"></span>
+              <span class="fa fa-refresh" aria-hidden="true"></span>
               <span class="icon-class">fa-refresh</span>
             </li>
             <li>
-              <span class="fa fa-search"></span>
+              <span class="fa fa-search" aria-hidden="true"></span>
               <span class="icon-class">fa-search</span>
             </li>
             <li>
-              <span class="fa fa-shield"></span>
+              <span class="fa fa-shield" aria-hidden="true"></span>
               <span class="icon-class">fa-shield</span>
             </li>
             <li>
-              <span class="fa fa-star"></span>
+              <span class="fa fa-star" aria-hidden="true"></span>
               <span class="icon-class">fa-star</span>
             </li>
             <li>
-              <span class="fa fa-star-o"></span>
+              <span class="fa fa-star-o" aria-hidden="true"></span>
               <span class="icon-class">fa-star-o</span>
             </li>
             <li>
-              <span class="fa fa-tachometer"></span>
+              <span class="fa fa-tachometer" aria-hidden="true"></span>
               <span class="icon-class">fa-tachometer</span>
             </li>
             <li>
-              <span class="fa fa-thumb-tack"></span>
+              <span class="fa fa-thumb-tack" aria-hidden="true"></span>
               <span class="icon-class">fa-thumb-tack</span>
             </li>
             <li>
-              <span class="fa fa-unlock-alt"></span>
+              <span class="fa fa-unlock-alt" aria-hidden="true"></span>
               <span class="icon-class">fa-unlock-alt</span>
             </li>
           </ul>

--- a/tests/pages/infotip.html
+++ b/tests/pages/infotip.html
@@ -20,18 +20,18 @@ resource: true
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown open">
               <a href="#" data-toggle="dropdown">
-                <span class="pficon pficon-info"></span>
+                <span class="pficon pficon-info" aria-hidden="true"></span>
                 Messages: <strong>2</strong>
               </a>
               <div class="dropdown-menu infotip bottom-right">
                 <div class="arrow"></div>
                 <ul class="list-group">
                   <li class="list-group-item">
-                    <span class="i pficon pficon-info"></span>
+                    <span class="i pficon pficon-info" aria-hidden="true"></span>
                     Added Datasources TestDS
                   </li>
                   <li class="list-group-item">
-                    <span class="i pficon pficon-info"></span>
+                    <span class="i pficon pficon-info" aria-hidden="true"></span>
                     Modified Datasources ExampleDS
                   </li>
                 </ul>

--- a/tests/pages/navbar.html
+++ b/tests/pages/navbar.html
@@ -26,7 +26,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
@@ -115,7 +115,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -216,7 +216,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -318,7 +318,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -558,7 +558,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -799,7 +799,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -1051,7 +1051,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -1303,7 +1303,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -1558,7 +1558,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -1716,7 +1716,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -1876,7 +1876,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -2034,7 +2034,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -2195,7 +2195,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -2367,7 +2367,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -2539,7 +2539,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -2711,7 +2711,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -2883,7 +2883,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -3058,7 +3058,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -3230,7 +3230,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -3468,7 +3468,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -3706,7 +3706,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>
@@ -3944,7 +3944,7 @@ url-js-extra: '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/boots
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
+                <span class="pficon pficon-user" aria-hidden="true"></span>
                 Brian Johnson
                 <b class="caret"></b>
               </a>

--- a/tests/pages/progress-bars.html
+++ b/tests/pages/progress-bars.html
@@ -166,7 +166,7 @@ resource: true
         </div>
       </div>
       <div class="progress-description">
-        <span class="pficon pficon-warning-triangle-o"></span>
+        <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
         <strong>Network Activity:</strong>  10.10.121.02
       </div>
       <div class="progress progress-label-top-right">
@@ -175,7 +175,7 @@ resource: true
         </div>
       </div>
       <div class="progress-description">
-        <span class="pficon pficon-error-circle-o"></span>
+        <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
         <strong>Network Activity:</strong>  10.10.121.02
       </div>
       <div class="progress progress-label-top-right">

--- a/tests/pages/toast.html
+++ b/tests/pages/toast.html
@@ -9,14 +9,14 @@ resource: true
     <div class="pull-right toast-pf-action">
       <a href="#">Start Server</a>
     </div>
-    <span class="pficon pficon-ok"></span>
+    <span class="pficon pficon-ok" aria-hidden="true"></span>
     <strong>server</strong> has been added.
   </div>
   <div class="toast-pf alert alert-danger alert-dismissable">
     <button type="button" class="close" data-dismiss="alert" aria-hidden="true">
       <span class="pficon pficon-close"></span>
     </button>
-    <span class="pficon pficon-error-circle-o"></span>
+    <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
     Failed to add <strong>server_abc</strong>.
   </div>
   <div class="toast-pf alert alert-warning">
@@ -24,11 +24,11 @@ resource: true
     <div class="pull-right toast-pf-action">
       <a href="#">Reload Server</a>
     </div>
-    <span class="pficon pficon-warning-triangle-o"></span>
+    <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
     The server configuration changed.
   </div>
   <div class="toast-pf alert alert-info">
-    <span class="pficon pficon-info"></span>
+    <span class="pficon pficon-info" aria-hidden="true"></span>
     Praesent sagittis est et arcu fringilla placerat. Cras erat ante, dapibus non mauris ac, volutpat sollicitudin ligula. Morbi gravida nisl vel risus tempor, sit amet luctus erat tempus. Curabitur blandit sem non pretium bibendum. Donec eleifend non turpis vitae vestibulum. Vestibulum ut sem ac nunc posuere blandit sed porta lorem. Cras rutrum velit vel leo iaculis imperdiet.
   </div>
 </div>


### PR DESCRIPTION
## Description

[Bootstrap's documentation](http://getbootstrap.com/components/#glyphicons-how-to-use) has the following recommendation:

> Modern versions of assistive technologies will announce CSS generated content, as well as specific Unicode characters. To avoid unintended and confusing output in screen readers (particularly when icons are used purely for decoration), we hide them with the `aria-hidden="true"` attribute.

## Changes

This PR updates the PatternFly examples to add `aria-hidden="true"` to `<span class="pficon">` tags.

No changes were made if:

* The icon is embedded in another element with `aria-hidden="true"` (for example, buttons with font icons as labels)
* The icon has a "title" attribute (I suspect screen readers would look for these, so would not want to suppress those)

Caveats/notes:

* This was done manually, so there may be some mistakes
* I haven't run any test suite since I don't know how (yet!)
* No changes were made to JavaScript, as in the cases where icons are added dynamically
* I specifically looked for files containing `pficon` and quickly went through them one by one. I fixed similar `fa` class icons as I came across them, but did not focus on those

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [ ] **Cross browser**: works in Firefox
- [ ] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [ ] **Responsive**: works in extra small, small, medium and large view ports.
- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.