### PR TITLE
Updated readme and quick start to reflect dependency install locations

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -53,54 +53,54 @@ We provide compiled CSS and JS (`patternfly.*`), as well as compiled and minifie
 4. Add the following script includes to your HTML file(s), adjusting where necessary to pull in only what you need:
 
         <!-- jQuery -->
-        <script src="node_modules/jquery/dist/jquery.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/jquery/dist/jquery.min.js"></script>
 
         <!-- Bootstrap JS -->
-        <script src="node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
 
         <!-- C3, D3 - Charting Libraries -->
-        <script src="node_modules/c3/c3.min.js"></script>
-        <script src="node_modules/d3/d3.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/c3/c3.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/d3/d3.min.js"></script>
 
         <!-- Datatables, jQuery Grid Component -->
         <!-- Note: jquery.dataTables.js must occur in the html source before patternfly*.js.-->
-        <script src="node_modules/datatables/media/js/jquery.dataTables.min.js"></script>
-        <script src="node_modules/drmonty-datatables-colvis/js/dataTables.colVis.js"></script>
-        <script src="node_modules/datatables.net-colreorder/js/dataTables.colReorder.js"></script>
+        <script src="node_modules/patternfly/node_modules/datatables/media/js/jquery.dataTables.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/drmonty-datatables-colvis/js/dataTables.colVis.js"></script>
+        <script src="node_modules/patternfly/node_modules/datatables.net-colreorder/js/dataTables.colReorder.js"></script>
 
         <!-- PatternFly Custom Componets -  Sidebar, Popovers and Datatables Customizations -->
         <!-- Note: jquery.dataTables.js must occur in the html source before patternfly*.js.-->
-        <script src="node_modules/patternfly/dist/js/patternfly.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/patternfly/dist/js/patternfly.min.js"></script>
 
         <!-- Bootstrap Combobox -->
-        <script src="node_modules/patternfly-bootstrap-combobox/js/bootstrap-combobox.js"></script>
+        <script src="node_modules/patternfly/node_modules/patternfly-bootstrap-combobox/js/bootstrap-combobox.js"></script>
 
         <!-- Bootstrap Date Picker -->
-        <script src="node_modules/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js"></script>
 
         <!-- Moment - required by Bootstrap Date Time Picker -->
-        <script src="node_modules/moment/min/moment.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/moment/min/moment.min.js"></script>
 
         <!-- Bootstrap Date Time Picker - requires Moment -->
-        <script src="node_modules/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js"></script>
 
         <!-- Bootstrap Select -->
-        <script src="node_modules/bootstrap-select/dist/js/bootstrap-select.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/bootstrap-select/dist/js/bootstrap-select.min.js"></script>
 
         <!-- Bootstrap Switch -->
-        <script src="node_modules/bootstrap-switch/dist/js/bootstrap-switch.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/bootstrap-switch/dist/js/bootstrap-switch.min.js"></script>
 
         <!-- Bootstrap Touchspin -->
-        <script src="node_modules/bootstrap-touchspin/dist/jquery.bootstrap-touchspin.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/bootstrap-touchspin/dist/jquery.bootstrap-touchspin.min.js"></script>
 
         <!-- Bootstrap Tree View -->
-        <script src="node_modules/patternfly-bootstrap-treeview/dist/bootstrap-treeview.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/patternfly-bootstrap-treeview/dist/bootstrap-treeview.min.js"></script>
 
         <!-- Google Code Prettify - Syntax highlighting of code snippets -->
-        <script src="node_modules/google-code-prettify/bin/prettify.min.js"></script>
+        <script src="node_modules/patternfly/node_modules/google-code-prettify/bin/prettify.min.js"></script>
 
         <!-- MatchHeight - Used to make sure dashboard cards are the same height -->
-        <script src="node_modules/jquery-match-height/jquery.matchHeight-min.js"></script>
+        <script src="node_modules/patternfly/node_modules/jquery-match-height/jquery.matchHeight-min.js"></script>
 
         <!-- Angular Application? You May Want to Consider Pulling Angular-PatternFly And Angular-UI Bootstrap instead of bootstrap.js -->
         <!-- See https://github.com/patternfly/angular-patternfly for more information -->

--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ Are you using [Wiredep](https://github.com/taptapship/wiredep)?  PatternFly's CS
 
 ```
 exclude: [
-  "node_modules/patternfly-bootstrap-combobox/css/bootstrap-combobox.css",
-  "node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker.css",
-  "node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker3.css",
-  "node_modules/bootstrap-select/dist/css/bootstrap-select.css",
-  "node_modules/bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css",
-  "node_modules/patternfly-bootstrap-treeview/dist/bootstrap-treeview.min.css",
-  "node_modules/c3/c3.css",
-  "node_modules/datatables/media/css/jquery.dataTables.css",
-  "node_modules/datatables.net-colreorder-bs/css/colReorder.bootstrap.css",
-  "node_modules/drmonty-datatables-colvis/css/dataTables.colVis.css",
-  "node_modules/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css",
-  "node_modules/font-awesome/css/font-awesome.css",
-  "node_modules/google-code-prettify/bin/prettify.min.css"
+  "node_modules/patternfly/node_modules/patternfly-bootstrap-combobox/css/bootstrap-combobox.css",
+  "node_modules/patternfly/node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker.css",
+  "node_modules/patternfly/node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker3.css",
+  "node_modules/patternfly/node_modules/bootstrap-select/dist/css/bootstrap-select.css",
+  "node_modules/patternfly/node_modules/bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css",
+  "node_modules/patternfly/node_modules/patternfly-bootstrap-treeview/dist/bootstrap-treeview.min.css",
+  "node_modules/patternfly/node_modules/c3/c3.css",
+  "node_modules/patternfly/node_modules/datatables/media/css/jquery.dataTables.css",
+  "node_modules/patternfly/node_modules/datatables.net-colreorder-bs/css/colReorder.bootstrap.css",
+  "node_modules/patternfly/node_modules/drmonty-datatables-colvis/css/dataTables.colVis.css",
+  "node_modules/patternfly/node_modules/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css",
+  "node_modules/patternfly/node_modules/font-awesome/css/font-awesome.css",
+  "node_modules/patternfly/node_modules/google-code-prettify/bin/prettify.min.css"
 ],
 ```
 
@@ -79,7 +79,9 @@ The development includes the use of a number of helpful tasks. In order to setup
 
     npm install
 
-This will install all necessary development packages into `node_modules/`. At this point, the gruntjs tasks are available for use such as starting a local development server or building the master CSS file.
+Since Patternfly is shrink wrapped, npm 3 will install all necessary development packages into `node_modules/patternfly/node_modules`. At this point, the gruntjs tasks are available for use such as starting a local development server or building the master CSS file.
+
+If you prefer a flat dependency structure, you can define your own dependencies explicitly. That will flatten out the node_modules structure and place dependencies in the root node_modules directory.
 
 Additionally you may need to install the grunt command line utility.  To do this run:
 


### PR DESCRIPTION
## Description
Updated readme and quick start to reflect dependency install locations when npm 3 and shrink wrap are used.

The npm install of patternfly 3.16.0 includes a shrinkwrap file; thus, npm 3 installs dependencies are installed under the node_modules/patternfly/node_modules directory. Previous versions v3.0.0 - v3.9.0 also included this shrinkwrap file and those dependencies were installed under the same directory as well. For some reason, the npm install for versions v3.10.0 - v3.15.0 omitted the shrinkwrap file (even though it was properly committed), so dependencies for those versions inadvertently install at the root node_modules directory.

If users prefer a flat dependency structure, they can define their own dependencies explicitly. That will flatten out the node_modules structure and place dependencies in the root node_modules directory.

## Changes

Updated readme and quick start to reflect proper dependency install locations.
