### PR TITLE
move close button to the front

### DIFF
--- a/src/less/close.less
+++ b/src/less/close.less
@@ -5,6 +5,8 @@
 
 .close {
   text-shadow: none;
+  z-index: 1;
+  position: relative;
   .opacity(.6);
   &:hover,
   &:focus {


### PR DESCRIPTION
## Description
Fix for #526 , if the element has any elements following it (within a parent) they may end up overlapping. Browsers will stack an element on top of the preceding one.

## Changes

* Changed position to relative and added z-index 1, this should have no effect on notifications and similar elements where the icon is also used.

## Link to rawgit

* [rawgit](http://rawgit.com/michpetrov/patternfly/close-button-dist/dist/tests/list-view-compound-expansion.html)

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [ ] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.