### PR TITLE
Fixed calculation of oSettings._iDisplayStart in patternfly-functions.js

### DIFF
--- a/src/js/patternfly-functions.js
+++ b/src/js/patternfly-functions.js
@@ -171,7 +171,7 @@
             }
 
             iNewStart = oSettings._iDisplayLength * (this.value - 1);
-            if (iNewStart >= oSettings.fnRecordsDisplay()) {
+            if (iNewStart >= oSettings.fnRecordsDisplay() || iNewStart < 0) {
               /* Display overrun */
               oSettings._iDisplayStart = (Math.ceil(oSettings.fnRecordsDisplay() /
                 oSettings._iDisplayLength) - 1) * oSettings._iDisplayLength;

--- a/src/js/patternfly-functions.js
+++ b/src/js/patternfly-functions.js
@@ -173,7 +173,7 @@
             iNewStart = oSettings._iDisplayLength * (this.value - 1);
             if (iNewStart >= oSettings.fnRecordsDisplay()) {
               /* Display overrun */
-              oSettings._iDisplayStart = (Math.ceil((oSettings.fnRecordsDisplay() - 1) /
+              oSettings._iDisplayStart = (Math.ceil(oSettings.fnRecordsDisplay() /
                 oSettings._iDisplayLength) - 1) * oSettings._iDisplayLength;
               fnDraw(oSettings);
               return;


### PR DESCRIPTION
## Description
Fix for DataTables bootstrap_input pagination controller when the table includes exactly one row.

Relates to https://github.com/patternfly/patternfly/issues/555

## Changes
Changed calculation of oSettings._iDisplayStart when iNewStart is greater than oSettings.fnRecordsDisplay()