### PR TITLE
fix stacked list text overflow in description heading

### DIFF
--- a/src/less/list-view.less
+++ b/src/less/list-view.less
@@ -156,6 +156,7 @@
   flex:     1 0 50%;
   .list-view-pf-stacked & {
     display: block;
+    flex: none; // Fix FF
   }
   @media (min-width: @screen-md-min) {
     align-items: center;

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-1.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-1.html
@@ -11,7 +11,7 @@
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
           <div class="list-group-item-heading">
-            Event One
+            This is EVENT One that is with very LONG and should not overflow and push other elements out of the bounding box.
             <small>Feb 23, 2015 12:32 am</small>
           </div>
           <div class="list-group-item-text">


### PR DESCRIPTION
Closes #559

## Description
See issue #559.

## Todos
- [x] cross browser test
- [x] Are you sure it works on IE9?
- [X] Is it reponsive?