### PR TITLE
Remove direct child selectors from setupVerticalNavigation

### DIFF
--- a/src/js/patternfly-functions.js
+++ b/src/js/patternfly-functions.js
@@ -843,43 +843,45 @@
       },
 
       bindMenuItemsBehavior = function (handleSelection) {
-        $(document).find('.nav-pf-vertical > .list-group > .list-group-item').each(function (index, primaryItem) {
-          var $primaryItem = $(primaryItem);
+        $(document).find('.nav-pf-vertical .list-group-item').each(function (index, item) {
+          var onClickFn,
+            $item = $(item),
+            $nav = $item.closest('[class*="nav-pf-"]');
 
-          // Set main nav active item on click or show secondary nav if it has a secondary nav bar and we are in the mobile state
-          $primaryItem.on('click.pf.secondarynav.data-api', function (event) {
-            var $this = $(this), $secondaryItem, tertiaryItem;
+          if ($nav.hasClass('nav-pf-vertical')) {
+            // Set main nav active item on click or show secondary nav if it has a secondary nav bar and we are in the mobile state
+            onClickFn = function (event) {
+              var $this = $(this), $secondaryItem, $tertiaryItem, $activeItem;
 
-            if (!$this.hasClass('secondary-nav-item-pf')) {
-              hideSecondaryMenu();
-              if (inMobileState()) {
-                updateMobileMenu();
-                navElement.removeClass('show-mobile-nav');
-              }
-              if (handleSelection) {
-                setPrimaryActiveItem($this);
-                // Don't process the click on the item
+              if (!$this.hasClass('secondary-nav-item-pf')) {
+                hideSecondaryMenu();
+                if (inMobileState()) {
+                  updateMobileMenu();
+                  navElement.removeClass('show-mobile-nav');
+                }
+                if (handleSelection) {
+                  setActiveItem($this);
+                  // Don't process the click on the item
+                  event.stopImmediatePropagation();
+                }
+              } else if (inMobileState()) {
+                updateMobileMenu($this);
+              } else if (handleSelection) {
+                $activeItem = $secondaryItem = $item.find('.nav-pf-secondary-nav > .list-group > .list-group-item').eq(0);
+
+                if ($secondaryItem.hasClass('tertiary-nav-item-pf')) {
+                  $activeItem = $secondaryItem.find('.nav-pf-tertiary-nav > .list-group > .list-group-item').eq(0);
+                }
+
+                setActiveItem($activeItem);
                 event.stopImmediatePropagation();
               }
-            } else if (inMobileState()) {
-              updateMobileMenu($this);
-            } else if (handleSelection) {
-              $secondaryItem = $($primaryItem.find('.nav-pf-secondary-nav > .list-group > .list-group-item')[0]);
-              if ($secondaryItem.hasClass('tertiary-nav-item-pf')) {
-                tertiaryItem = $secondaryItem.find('.nav-pf-tertiary-nav > .list-group > .list-group-item')[0];
-                setTertiaryActiveItem($(tertiaryItem), $secondaryItem, $primaryItem);
-              } else {
-                setSecondaryActiveItem($secondaryItem, $this);
-              }
-              event.stopImmediatePropagation();
-            }
-          });
+            };
 
-          $primaryItem.find('.nav-pf-secondary-nav > .list-group > .list-group-item').each(function (index, secondaryItem) {
-            var $secondaryItem = $(secondaryItem);
+          } else if ($nav.hasClass('nav-pf-secondary-nav')) {
             // Set secondary nav active item on click or show tertiary nav if it has a tertiary nav bar and we are in the mobile state
-            $secondaryItem.on('click.pf.secondarynav.data-api', function (event) {
-              var $this = $(this), tertiaryItem;
+            onClickFn = function (event) {
+              var $this = $(this), $tertiaryItem, $primaryItem;
               if (!$this.hasClass('tertiary-nav-item-pf')) {
                 if (inMobileState()) {
                   updateMobileMenu();
@@ -887,37 +889,39 @@
                 }
                 updateSecondaryMenuDisplayAfterSelection();
                 if (handleSelection) {
-                  setSecondaryActiveItem($secondaryItem, $primaryItem);
+                  setActiveItem($item);
                   // Don't process the click on the item
                   event.stopImmediatePropagation();
                 }
               } else if (inMobileState()) {
+                $primaryItem = $item.parents('.list-group-item');
                 updateMobileMenu($this, $primaryItem);
                 event.stopImmediatePropagation();
               } else if (handleSelection) {
-                tertiaryItem = $secondaryItem.find('.nav-pf-tertiary-nav > .list-group > .list-group-item')[0];
-                setTertiaryActiveItem($(tertiaryItem), $secondaryItem, $primaryItem);
+                $tertiaryItem = $item.find('.nav-pf-tertiary-nav > .list-group > .list-group-item').eq(0);
+                setActiveItem($tertiaryItem);
                 event.stopImmediatePropagation();
               }
-            });
+            };
 
-            $secondaryItem.find('.nav-pf-tertiary-nav > .list-group > .list-group-item').each(function (index, tertiaryItem) {
-              var $tertiaryItem = $(tertiaryItem);
-              // Set tertiary nav active item on click
-              $tertiaryItem.on('click.pf.secondarynav.data-api', function (event) {
-                if (inMobileState()) {
-                  updateMobileMenu();
-                  navElement.removeClass('show-mobile-nav');
-                }
-                updateSecondaryMenuDisplayAfterSelection();
-                if (handleSelection) {
-                  setTertiaryActiveItem($tertiaryItem, $secondaryItem, $primaryItem);
-                  // Don't process the click on the item
-                  event.stopImmediatePropagation();
-                }
-              });
-            });
-          });
+          } else if ($nav.hasClass('nav-pf-tertiary-nav')) {
+            // Set tertiary nav active item on click
+            onClickFn = function (event) {
+              if (inMobileState()) {
+                updateMobileMenu();
+                navElement.removeClass('show-mobile-nav');
+              }
+              updateSecondaryMenuDisplayAfterSelection();
+              if (handleSelection) {
+                setActiveItem($item);
+                // Don't process the click on the item
+                event.stopImmediatePropagation();
+              }
+            };
+          }
+
+          // register event handler
+          $item.on('click.pf.secondarynav.data-api', onClickFn);
         });
 
         $(document).find('.secondary-nav-item-pf').each(function (index, secondaryItem) {
@@ -1110,4 +1114,3 @@
     init(handleItemSelections);
   };
 }(jQuery));
-

--- a/src/js/patternfly-functions.js
+++ b/src/js/patternfly-functions.js
@@ -638,30 +638,12 @@
         });
       },
 
-      setPrimaryActiveItem = function (item) {
-        // Make the clicked on item active
-        $(document).find('.nav-pf-vertical > .list-group > .list-group-item.active').each(function (index, element) {
-          $(element).removeClass('active');
-        });
-        item.addClass('active');
-      },
+      setActiveItem = function (item) {
+        // remove all .active
+        $('.nav-pf-vertical .list-group-item.active').removeClass('active');
 
-      setSecondaryActiveItem = function (item, $primaryParent) {
-        $(document).find('.nav-pf-secondary-nav > .list-group > .list-group-item.active').each(function (index, element) {
-          $(element).removeClass('active');
-        });
-        item.addClass('active');
-
-        setPrimaryActiveItem($primaryParent);
-      },
-
-      setTertiaryActiveItem = function (item, $secondaryParent, $primaryParent) {
-        $(document).find('.nav-pf-tertiary-nav > .list-group > .list-group-item.active').each(function (index, element) {
-          $(element).removeClass('active');
-        });
-        item.addClass('active');
-
-        setSecondaryActiveItem($secondaryParent, $primaryParent);
+        // add .active to item and its parents
+        item.addClass('active').parents('.list-group-item').addClass('active');
       },
 
       updateSecondaryMenuDisplayAfterSelection = function () {


### PR DESCRIPTION
## Description
Attempt to resolve #549 

Removes direct child selectors from _setupVerticalNavigation_ and also simplifies the method to set active items.

Fiddle with example: [jsfiddle](https://jsfiddle.net/knokit/ehum0hqu/4/)

