### PR TITLE
just allowing users to resize the textarea vertically

### DIFF
--- a/src/less/wizard.less
+++ b/src/less/wizard.less
@@ -215,6 +215,10 @@
   }
 }
 
+.wizard-pf-contents textarea {
+  resize: vertical;
+}
+
 /* styles the content of a review page */
 .wizard-pf-review-steps {
   list-style: none;


### PR DESCRIPTION
## Description
allowing the users to resize the textarea on wizard, which may only be resized vertically. This PR aims to fix the [bug](https://github.com/patternfly/patternfly/issues/479).

## Steps to test or reproduce and link to rawgit
You can review the [result](https://cdn.rawgit.com/dabeng/patternfly/wizard-v-dist/dist/tests/wizard.html).

@andresgalante , would you like to review this PR?
