### PR TITLE
Avoid long words overflowing alerts in narrow situations

### DIFF
--- a/src/less/alerts.less
+++ b/src/less/alerts.less
@@ -7,6 +7,7 @@
   padding-left: 47px;
   padding-right: (@alert-padding + 3);
   position: relative;
+  word-wrap: break-word;
   .alert-link {
     color: @link-color;
     &:hover {


### PR DESCRIPTION
Really long words broke outside the alert in narrow situations.

Fixes issue #491