### PR TITLE
Table View: Show/Hide Columns - PF Core

### DIFF
--- a/src/js/patternfly.dataTables.pfColVis.js
+++ b/src/js/patternfly.dataTables.pfColVis.js
@@ -1,0 +1,151 @@
+/**
+ * @summary     pfColVis for DataTables
+ * @description An extension providing columns visibility control functionality for DataTables. This ensures
+ * DataTables meets the Patternfly design pattern with a toolbar.
+ *
+ * To enable a colvis, the user just need to specify a region for placing colvis menu. By default, the colvis
+ * menu includes the items derived from all columns of Datatables. And of course user can also limit the
+ * generation of the column's visibility checkbox through picking out column index.
+ *
+ * The toolbar is expected to contain the classes as shown in the example below.
+ *
+ * Example:
+ *
+ * <!-- NOTE: Some configuration may be omitted for clarity -->
+ * <div class="row toolbar-pf table-view-pf-toolbar" id="toolbar1">
+ *   <div class="col-sm-12">
+ *     <form class="toolbar-pf-actions">
+ *       <div class="form-group toolbar-pf-filter">
+ *       </div>
+ *       <div class="form-group toolbar-pf-sort">
+ *         <div class="dropdown btn-group">
+ *         </div>
+ *         <button class="btn btn-link" type="button">
+ *           <span class="fa fa-sort-alpha-asc"></span>
+ *         </button>
+ *         <div class="dropdown btn-group">
+ *          <button class="btn btn-link dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+ *           <span class="fa fa-columns"></span>
+ *          </button>
+ *          <ul class="dropdown-menu table-view-pf-colvis-menu">
+ *            <li><input type="checkbox" value="1" checked><label>Rendering Engine</label></li>
+ *            <li><input type="checkbox" value="2" checked><label>Browser</label></li>
+ *            <li><input type="checkbox" value="3" checked><label>Platform(s)</label></li>
+ *            <li><input type="checkbox" value="4" checked><label>Engine Version</label></li>
+ *            <li><input type="checkbox" value="5" checked><label>CSS Grade</label></li>
+ *          </ul>
+ *         </div>
+ *       </div>
+ *       ...
+ *     </form>
+ *   </div>
+ * </div>
+ * <table class="table table-striped table-bordered table-hover" id="table1">
+ *   <thead>
+ *     <tr>
+ *       <th><input type="checkbox" name="selectAll"></th>
+ *       <th>Rendering Engine</th>
+ *       <th>Browser</th>
+ *     </tr>
+ *   </thead>
+ * </table>
+ * ...
+ * <script>
+ * // NOTE: Some properties may be omitted for clarity
+ * $(document).ready(function() {
+ *   var dt = $("#table1").DataTable({
+ *     columns: [
+ *       { data: null, ... },
+ *       { data: "engine" },
+ *       { data: "browser" }
+ *     ],
+ *     data: [
+ *       { engine: "Gecko", browser: "Firefox" }
+ *       { engine: "Trident", browser: "Mozilla" }
+ *     ],
+ *     dom: "t",
+ *     pfConfig: {
+ *       ...
+ *       colvisMenuSelector: '.table-view-pf-colvis-menu'
+ *     }
+ *   });
+ *
+ * });
+ * </script>
+ */
+(function (factory) {
+  "use strict";
+  if (typeof define === "function" && define.amd ) {
+    // AMD
+    define (["jquery", "datatables.net"], function ($) {
+      return factory ($, window, document);
+    });
+  } else if (typeof exports === "object") {
+    // CommonJS
+    module.exports = function (root, $) {
+      if (!root) {
+        root = window;
+      }
+      if (!$ || !$.fn.dataTable) {
+        $ = require("datatables.net")(root, $).$;
+      }
+      return factory($, root, root.document);
+    };
+  } else {
+    // Browser
+    factory(jQuery, window, document);
+  }
+}(function ($, window, document, undefined) {
+  "use strict";
+  var DataTable = $.fn.dataTable;
+
+  DataTable.pfColVis = {};
+
+  /**
+   * Initialize
+   *
+   * @param {DataTable.Api} dt DataTable
+   * @private
+   */
+  DataTable.pfColVis.init = function (dt) {
+    var i;
+    var ctx = dt.settings()[0];
+    var opts = (ctx.oInit.pfConfig) ? ctx.oInit.pfConfig : {};
+
+    if (opts.colvisMenuSelector === undefined) {
+      return;
+    }
+
+    ctx._pfColVis = {};
+    ctx._pfColVis.colvisMenu = $(opts.colvisMenuSelector, opts.toolbarSelector);
+
+    // Attach event handler for checkbox of ColVis menu
+    ctx._pfColVis.colvisMenu.on('click', 'li', { 'dt': dt }, colvisMenuHandler);
+  };
+
+  // Local functions
+
+  /**
+   * Handle actions when ColVis menu items are toggled
+   *
+   * @param {object} jquery eventObject - click event of ColVis menu items
+   * @private
+   */
+  function colvisMenuHandler (event) {
+    var $check = $(this).children(':checkbox');
+    if (event.target.nodeName !== 'INPUT') {
+      event.stopPropagation();
+      $check.prop('checked', !$check.prop('checked'));
+    }
+    event.data.dt.column($check.val()).visible($check.prop('checked'));
+  }
+
+  // DataTables creation
+  $(document).on("init.dt", function (e, ctx, json) {
+    if (e.namespace !== "dt") {
+      return;
+    }
+    DataTable.pfColVis.init(new DataTable.Api(ctx));
+  });
+  return DataTable.pfColVis;
+}));

--- a/src/less/table-view.less
+++ b/src/less/table-view.less
@@ -134,6 +134,24 @@ table.dataTable {
   }
 }
 
+.table-view-pf-colvis-menu {
+  > li {
+    padding: 5px 10px;
+    &:hover {
+      background-color: #def3ff;
+    }
+    > input {
+      margin-top: 0;
+      margin-right: 10px;
+      vertical-align: middle;
+    }
+    > label {
+      margin-bottom: 0;
+    }
+  }
+
+}
+
 // Inline action button and kebab
 // Sets button height to 100% of td height in firefox and chrome, but not in IE when wrapping occurs.
 // Button height must be set dynamically in IE to be equal to td height.

--- a/tests/pages/_includes/widgets/table-view/js/config.js
+++ b/tests/pages/_includes/widgets/table-view/js/config.js
@@ -70,7 +70,8 @@ $("#{{include.tableId}}").DataTable({
     ],
     paginationSelector: "#{{include.paginationId}}",
     toolbarSelector: "#{{include.toolbarId}}",
-    selectAllSelector: 'th:first-child input[type="checkbox"]'
+    selectAllSelector: 'th:first-child input[type="checkbox"]',
+    colvisMenuSelector: '.table-view-pf-colvis-menu'
   },
   select: {
     selector: 'td:first-child input[type="checkbox"]',

--- a/tests/pages/_includes/widgets/table-view/tmpl/toolbar-all.html
+++ b/tests/pages/_includes/widgets/table-view/tmpl/toolbar-all.html
@@ -32,6 +32,18 @@
           <button class="btn btn-link" type="button">
             <span class="fa fa-sort-alpha-asc"></span>
           </button>
+          <div class="dropdown btn-group">
+            <button class="btn btn-link dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <span class="fa fa-columns"></span>
+            </button>
+            <ul class="dropdown-menu table-view-pf-colvis-menu">
+              <li><input type="checkbox" value="1" checked><label>Rendering Engine</label></li>
+              <li><input type="checkbox" value="2" checked><label>Browser</label></li>
+              <li><input type="checkbox" value="3" checked><label>Platform(s)</label></li>
+              <li><input type="checkbox" value="4" checked><label>Engine Version</label></li>
+              <li><input type="checkbox" value="5" checked><label>CSS Grade</label></li>
+            </ul>
+          </div>
         </div>
         <div class="form-group">
           <button class="btn btn-default" type="button" id="{{include.actionId1}}">Delete Rows</button>

--- a/tests/pages/table-view-navbar.html
+++ b/tests/pages/table-view-navbar.html
@@ -9,6 +9,7 @@ url-js-extra: [ '//cdn.datatables.net/1.10.12/js/jquery.dataTables.min.js',
                 '//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/bootstrap-select.min.js',
                 '../../dist/js/patternfly.dataTables.pfEmpty.js',
                 '../../dist/js/patternfly.dataTables.pfFilter.js',
+                '../../dist/js/patternfly.dataTables.pfColVis.js',
                 '../../dist/js/patternfly.dataTables.pfPagination.js',
                 '../../dist/js/patternfly.dataTables.pfResize.js',
                 '../../dist/js/patternfly.dataTables.pfSelect.js' ]


### PR DESCRIPTION
## Description
Adding column visibility toggle functionality for table-view. According to the design style, colvis menu should be included in the sort control group of toolbar. So if sort controls are included, then colvis menu is available. Additionally, with the help of this PR, users are allowed to identify a range that decides which columns can be toggled visibility.

## PR checklist (if relevant)
- [] works in IE9
- [] works in IE10
- [] works in IE11
- [] works in Edge
- [x] works in Chrome
- [x] works in Firefox
- [x] works in Safari
- [x] works in Opera

## Link to rawgit
https://rawgit.com/dabeng/patternfly/ColVis-dist/dist/tests/table-view-navbar.html

@LHinson @andresgalante @bleathem @jeff-phillips-18, would you like to review it ?
