### PR TITLE
PTNFLY-2178: fix time-picker repositioning

### DIFF
--- a/src/less/time-picker.less
+++ b/src/less/time-picker.less
@@ -16,10 +16,15 @@
   &.dropdown-menu {
     left: 0!important;
     padding: 0;
-    top: 23px!important;
     width: calc(~"100% - 25px");
     &:before, &:after {
       content: none;
+    }
+    &.top {
+      margin-bottom: -1px;
+    }
+    &.bottom {
+      margin-top: -1px;
     }
   }
   .timepicker-hour {


### PR DESCRIPTION
## Description
Fix for #337. The timepicker is set to reposition itself if there's not enough room below the input (switching from `.dropdown-menu.bottom` to `.dropdown-menu.top`). The original rule was set globally so it wasn't working.

I opted for negative margin to avoid using `!important`, since that's what was causing the issue in the first place. 

## Todos
- [ ] cross browser test (tested in Chrome, Firefox, Opera)
- [ ] Are you sure it works on IE9? (I would assume so)
- [x] Is it reponsive?

## Steps to test or reproduce and link to rawgit
[Rawgit](https://rawgit.com/michpetrov/patternfly/time-picker-fix-dist/dist/tests/time-picker.html)
