### PR TITLE
Kebab menu in Toast Notifications is not vertically aligned

### DIFF
--- a/src/less/toast.less
+++ b/src/less/toast.less
@@ -26,6 +26,11 @@
   .toast-pf-action {
     margin-left: 15px;
   }
+  .dropdown-kebab-pf .btn-link {
+    padding-top: 0;
+    padding-bottom: 0;
+    vertical-align: text-bottom;
+  }
   /* Medium devices (desktops, 992px and up) */
   @media (min-width: @screen-md-min) {
     display: inline-block;


### PR DESCRIPTION
## Description
Within the toast notifications with the kebab menu, the menu kebab indicator is not vertically aligned with the text. Adding the kebab menu also increases the height of the toast notification (from 45px to 50px).
This PR is for fixing [bug](https://github.com/patternfly/patternfly/issues/406).

## PR checklist (if relevant)
- [] works in IE9
- [] works in IE10
- [] works in IE11
- [] works in Edge
- [x] works in Chrome
- [x] works in Firefox
- [x] works in Safari
- [x] works in Opera

## Link to rawgit
https://rawgit.com/dabeng/patternfly/kebab-menu-dist/dist/tests/toast.html

@LHinson  @bleathem @jeff-phillips-18, would you like to review it ?