### PR TITLE
Links on the vertical nav mast head are blue

### DIFF
--- a/src/less/navbar-vertical.less
+++ b/src/less/navbar-vertical.less
@@ -27,6 +27,7 @@
     }
 
     .nav-item-iconic {
+      color: @navbar-pf-vertical-color;
       cursor: pointer;
       line-height: 1;
       max-height: (@navbar-pf-vertical-height - @navbar-pf-vertical-border-width); // to keep Firefox from oversizing icons
@@ -35,6 +36,7 @@
 
       &:hover,
       &:focus {
+        color: @navbar-pf-vertical-active-color;
         background-color: transparent;
 
         .caret,


### PR DESCRIPTION
## Description
if user adds text beside the icons on the vertical nav mast head on the right they should be light grey. This PR is for fixing the [bug](https://github.com/patternfly/patternfly/issues/554).

## PR checklist (if relevant)
- [] works in IE9
- [] works in IE10
- [] works in IE11
- [] works in Edge
- [x] works in Chrome
- [x] works in Firefox
- [x] works in Safari
- [x] works in Opera

## Link to rawgit
* https://rawgit.com/dabeng/patternfly/mast-head-dist/dist/tests/vertical-navigation-primary-only.html
* https://rawgit.com/dabeng/patternfly/mast-head-dist/dist/tests/vertical-navigation-with-badges.html
* https://rawgit.com/dabeng/patternfly/mast-head-dist/dist/tests/vertical-navigation-with-secondary.html
* https://rawgit.com/dabeng/patternfly/mast-head-dist/dist/tests/vertical-navigation-with-tertiary-no-icons.html
* https://rawgit.com/dabeng/patternfly/mast-head-dist/dist/tests/vertical-navigation-with-tertiary-pins.html

@LHinson  @andresgalante , would you like to review it ?
