### PR TITLE
autoprefixer: support old firefox versions and placeholder fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Development setup requires Node.js and Ruby. If you do not already have Node.js,
 
 The PatternFly code includes a number of dependencies that are not committed to this repository.  To add them, follow the instructions below under "Install NPM Dependencies".  Please make sure you keep them updated (see [Keeping NPM Dependencies Updated](#keeping-npm-dependencies-updated)).
 
+## Autoprefixer
+
+Patternfly uses [Autoprefixer](https://github.com/postcss/autoprefixer) to auto add prefixes to its output CSS. Since Patternfly extends some of the core Bootstrap3 less which contains prefixes, we also explicitly add prefixes in these cases to ensure backwards compatibility with Bootstrap3. If consuming Patternfly LESS and compiling, you can define your own target prefixes using [browserlist](https://github.com/ai/browserslist).
+
 ### Install NPM Dependencies
 
 The development includes the use of a number of helpful tasks. In order to setup your development environment to allow running of these tasks, you need to install the local nodejs packages declared in `package.json`. To do this run:

--- a/src/less/mixins.less
+++ b/src/less/mixins.less
@@ -75,7 +75,10 @@
 
 // Placeholder text
 .placeholder(@color: @input-color-placeholder) {
-  &::placeholder            { color: @color; font-style: italic; }
+  &:-moz-placeholder            { color: @color; font-style: italic; } // Firefox 4-18
+  &::-moz-placeholder           { color: @color; font-style: italic; opacity: 1; } // Firefox 19+
+  &:-ms-input-placeholder       { color: @color; font-style: italic; } // Internet Explorer 10+
+  &::-webkit-input-placeholder  { color: @color; font-style: italic; } // Safari and Chrome
 }
 
 // PatternFly-specific


### PR DESCRIPTION
## Description
This fix adds other Firefox version prefixes to autoprefixer that were missed before, along with a fix for `form-control::placeholder` prefixed css.

Fixes #597 

cc @andresgalante @rhamilto 
