### PR TITLE
Adds masthead utility links on the vertical nav on small viewports

### DIFF
--- a/tests/pages/_includes/widgets/navigation/vertical-navigation.html
+++ b/tests/pages/_includes/widgets/navigation/vertical-navigation.html
@@ -69,13 +69,13 @@
         </div>
 
         <ul class="list-group">
-          <li class="list-group-item " data-target="#amet-detracto-tertiary">
+          <li class="list-group-item">
             <a>
               <span class="list-group-item-value">Preferences</span>
             </a>
           </li>
 
-          <li class="list-group-item " data-target="#amet-mediocrem-tertiary">
+          <li class="list-group-item">
             <a>
               <span class="list-group-item-value">Logout</span>
             </a>
@@ -95,12 +95,12 @@
           <span>Help</span>
         </div>
         <ul class="list-group">
-          <li class="list-group-item " data-target="#amet-detracto-tertiary">
+          <li class="list-group-item">
             <a>
               <span class="list-group-item-value">Help</span>
             </a>
           </li>
-          <li class="list-group-item " data-target="#amet-mediocrem-tertiary">
+          <li class="list-group-item">
             <a>
               <span class="list-group-item-value">About</span>
             </a>

--- a/tests/pages/_includes/widgets/navigation/vertical-navigation.html
+++ b/tests/pages/_includes/widgets/navigation/vertical-navigation.html
@@ -3,8 +3,7 @@
 {% else %}
   {% include widgets/layouts/navbar-vertical.html %}
 {% endif %}
-<div class="nav-pf-vertical
-     {% if page.submenus %}nav-pf-vertical-with-sub-menus{% endif %}
+<div class="nav-pf-vertical nav-pf-vertical-with-sub-menus
      {% if page.persistent-secondary %}nav-pf-persistent-secondary{% endif %}
      {% if page.collapsible-menus %}nav-pf-vertical-collapsible-menus{% endif %}
      {% if page.hide-icons %}hidden-icons-pf{% endif %}
@@ -57,7 +56,61 @@
         <span class="list-group-item-value">Lorem</span>
       </a>
     </li>
+
+    <li class="list-group-item secondary-nav-item-pf mobile-nav-item-pf visible-xs-block" data-target="#amet-secondary">
+      <a>
+        <span class="pficon pficon-user" data-toggle="tooltip" title="" data-original-title="User"></span>
+        <span class="list-group-item-value">User</span>
+      </a>
+      <div id="user-secondary" class="nav-pf-secondary-nav">
+        <div class="nav-item-pf-header">
+          <a class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
+          <span>User</span>
+        </div>
+
+        <ul class="list-group">
+          <li class="list-group-item " data-target="#amet-detracto-tertiary">
+            <a>
+              <span class="list-group-item-value">Preferences</span>
+            </a>
+          </li>
+
+          <li class="list-group-item " data-target="#amet-mediocrem-tertiary">
+            <a>
+              <span class="list-group-item-value">Logout</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </li>
+
+    <li class="list-group-item secondary-nav-item-pf mobile-nav-item-pf visible-xs-block" data-target="#amet-secondary">
+      <a>
+        <span class="pficon pficon-help" data-toggle="tooltip" title="" data-original-title="Amet"></span>
+        <span class="list-group-item-value">Help</span>
+      </a>
+      <div id="help-secondary" class="nav-pf-secondary-nav">
+        <div class="nav-item-pf-header">
+          <a class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
+          <span>Help</span>
+        </div>
+        <ul class="list-group">
+          <li class="list-group-item " data-target="#amet-detracto-tertiary">
+            <a>
+              <span class="list-group-item-value">Help</span>
+            </a>
+          </li>
+          <li class="list-group-item " data-target="#amet-mediocrem-tertiary">
+            <a>
+              <span class="list-group-item-value">About</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </li>
+
   </ul>
+
 </div>
 <div class="container-fluid container-cards-pf container-pf-nav-pf-vertical
      {% if page.persistent-secondary %}nav-pf-persistent-secondary{% endif %}


### PR DESCRIPTION
## Description
This PR is related to [this jira issue](https://patternfly.atlassian.net/browse/PTNFLY-1934) and fixes #496

You can preview it here:
https://rawgit.com/andresgalante/patternfly/vertical-nav-PTNFLY-1934-dist/dist/tests/vertical-navigation-primary-only.html

@jennyhaines @LHinson it does not reproduce the mockups for 2 reasons: 

1- Changing the colors to a darker black on the lower part of the vertical nav was extremely tricky when you start dealing with the nested navigations.
2- Since they are smaller, the hitting area is shorter than whats recommend (40px).

Can we play with our constrains for pf4 and implement it following the mockups for pf5?

@jeff-phillips-18 Please take a look at it, I don't really know how the submeus are generated and I fell like I have hardcoded it.

Thanks a lot ❤️ 