### PR TITLE
Fix NO_EFFECT warning in Coverity scanning

### DIFF
--- a/src/js/patternfly-functions.js
+++ b/src/js/patternfly-functions.js
@@ -581,7 +581,7 @@
       if (parent) {
         // Calculate indentation depth
         i = parent.find('.treegrid-node > span.indent').length + 1;
-        for (i; i > 0; i -= 1) {
+        for (; i > 0; i -= 1) {
           node.children('.treegrid-node').prepend('<span class="indent"/>');
         }
         // Render expand/collapse icons


### PR DESCRIPTION
This is a loop with a tiny bit of dead code. It's not a big deal
but changing this line helps projects that use Patternfly not
have to deal with another waiver.

```
Defect Type: NO_EFFECT
remediation: Perhaps this code is incomplete or mistyped in some way.
```