### PR TITLE
Bug fix: Escapes calc on wizard step

### DIFF
--- a/src/less/wizard.less
+++ b/src/less/wizard.less
@@ -178,7 +178,7 @@
     font-size: @font-size-base;
     font-weight: 700;
     height: 25px;
-    left: calc(50% - 13px);
+    left: ~"calc(50% - 13px)";
     line-height: 22px;
     position: absolute;
     top: 27px;


### PR DESCRIPTION
## Description
@jawnsy found a bug on RCUE: https://github.com/redhat-rcue/rcue/issues/69

It's generated because less is compiling `calc` a value in px on RCUE.

On this PR I am [escaping](https://github.com/SomMeri/less4j/wiki/Less-Language-Escaping) `calc` to avoid that problem.

## Link to rawgit
https://rawgit.com/andresgalante/patternfly/fix-wizard-calc-dist/dist/tests/wizard.html

This PR closes https://github.com/redhat-rcue/rcue/issues/69

@jawnsy Can you also review this one please?

