### PR TITLE
NPM Script Update & Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ PatternFly can be installed and managed through [NPM](https://www.npmjs.com/). T
 npm install patternfly --save
 ```
 
-Patternfly stays up to date with the Node LTS [Release Schedule](https://github.com/nodejs/LTS#lts_schedule). If you're using Patternfly downstream, we suggest the use of an actively supported version of Node/NPM, although prior versions of Node may work.
+PatternFly stays up to date with the Node LTS [Release Schedule](https://github.com/nodejs/LTS#lts_schedule). If you're using PatternFly downstream, we suggest the use of an actively supported version of Node/NPM, although prior versions of Node may work.
 
 ### Install with Bower
 
@@ -75,11 +75,23 @@ The PatternFly code includes a number of dependencies that are not committed to 
 
 ### Install NPM Dependencies
 
-The development includes the use of a number of helpful tasks. In order to setup your development environment to allow running of these tasks, you need to install the local nodejs packages declared in `package.json`. To do this run:
+The development includes the use of a number of helpful tasks. In order to setup your development environment to allow running of these tasks, you need to install the local nodejs packages declared in `package.json`.
 
-    npm install
+To do this clone, and change directories into PatternFly:
 
-Since Patternfly is shrink wrapped, npm 3 will install all necessary development packages into `node_modules/patternfly/node_modules`. At this point, the gruntjs tasks are available for use such as starting a local development server or building the master CSS file.
+```
+cd [PathToYourRepository]
+```
+
+then
+
+```
+npm install
+```
+
+This should take care of the majority of dependencies, including [Jekyll](http://jekyllrb.com/). During the install you may be asked for your password as part of the [Ruby](https://www.ruby-lang.org/en/documentation/installation/) installation process.
+
+Since PatternFly is shrink wrapped, npm 3 will install all necessary development packages into `node_modules/patternfly/node_modules`. At this point, the gruntjs tasks are available for use such as starting a local development server or building the master CSS file.
 
 If you prefer a flat dependency structure, you can define your own dependencies explicitly. That will flatten out the node_modules structure and place dependencies in the root node_modules directory.
 
@@ -89,8 +101,16 @@ Additionally you may need to install the grunt command line utility.  To do this
 
 Test pages are optionally generated using [Jekyll](http://jekyllrb.com/). To use jekyll to build the test pages, ensure Ruby is installed and available then run:
 
-    gem install bundle
-    bundle install
+```
+npm run jekyll
+```
+
+or
+
+```
+gem install bundle
+bundle install
+```
 
 Then set the environment variable PF_PAGE_BUILDER=jekyll.  eg.:
     PF_PAGE_BUILDER=jekyll grunt build
@@ -99,7 +119,9 @@ Then set the environment variable PF_PAGE_BUILDER=jekyll.  eg.:
 
 Anytime you pull a new version of PatternFly, make sure you also run
 
-    npm update
+```
+npm update
+```
 
 so you get the latest version of the dependencies specified in package.json.
 
@@ -107,7 +129,15 @@ so you get the latest version of the dependencies specified in package.json.
 
 A local development server can be quickly fired up by using the Gruntjs server task:
 
-    grunt server
+```
+npm start
+```
+
+or
+
+```
+grunt server
+```
 
 This local static asset server (i.e., [http://localhost:9000](http://localhost:9000)) has the advantage of having livereload integration. Thus, if you start the Gruntjs server, any changes you make to `.html` or `.less` files will be automatically reloaded into your browser and the changes reflected almost immediately. This has the obvious benefit of not having to refresh your browser and still be able to see the changes as you add or remove them from your development files.  Additionally, any changes made to Jekyll source files (`tests/pages/`) will trigger a Jekyll build.
 
@@ -121,7 +151,15 @@ See [http://codeguide.patternfly.org/](http://codeguide.patternfly.org/).
 
 In development, styling is written and managed through multiple lesscss files. In order to generate a CSS file of all styling, run the build Gruntjs task:
 
-    grunt build
+```
+npm run build
+```
+
+or
+
+```
+grunt build
+```
 
 This task will compile and minify the lesscss files into CSS files located at `dist/css/patternfly.min.css` and `dist/css/patternfly-additional.min.css`.
 
@@ -140,6 +178,12 @@ The HTML pages in `dist/tests` are generated using Jekyll.  Do *not* edit these 
 
 ### Unit Testing
 Unit tests are written for [Karma test server] (https://karma-runner.github.io/1.0/index.html) with [Jasmine](http://jasmine.github.io/)
+
+```
+npm test
+```
+
+or
 
 ```
 grunt karma

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "autoprefixer": "^6.4.0",
     "connect-livereload": "~0.5.4",
     "front-matter": "^2.1.1",
+    "grunt-cli": "~1.2.0",
     "grunt": "~1.0.1",
     "grunt-contrib-concat": "^1.0.0",
     "grunt-contrib-connect": "~1.0.2",
@@ -65,7 +66,11 @@
     "patternfly-bootstrap-treeview": "~2.1.0"
   },
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start"
+    "test": "grunt karma",
+    "build": "grunt build",
+    "jekyll": "ruby --version || echo \"Ruby required\"; gem install bundler || sudo gem install bundler; bundle install; set -e",
+    "start": "npm run build; grunt server & open http://localhost:9000",
+    "postinstall": "npm run jekyll"
   },
   "description": "This reference implementation of PatternFly is based on [Bootstrap v3](http://getbootstrap.com/).  Think of PatternFly as a \"skinned\" version of Bootstrap with additional components and customizations.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "scripts": {
     "test": "grunt karma",
     "build": "grunt build",
-    "jekyll": "ruby --version || echo \"Ruby required\"; gem install bundler || sudo gem install bundler; bundle install; set -e",
+    "jekyll": "ruby --version || echo \"Ruby required\"; gem install bundler; bundle install; set -e",
     "start": "npm run build; grunt server & open http://localhost:9000",
     "postinstall": "npm run jekyll"
   },


### PR DESCRIPTION
## Description

Goal, simplify install process for users unfamiliar with dev installs. Implementation of NPM scripts as aliases/shortcuts towards Grunt tasks and automated Jekyll postinstall. 

May need some review input on the "jekyll" NPM script within package.json to verify syntax. Per @bleathem removed redundant jekyll install.

## Todos
- N/A, cross browser test
- N/A, Are you sure it works on IE9?
- N/A, Is it reponsive?

## Steps to test or reproduce and link to rawgit

```sh
$ git pull https://github.com/cdcabrera/patternfly.git NPM-Scripts-4x:NPM-Scripts-4x
$ npm install
$ npm start
```

@bleathem 