### PR TITLE
Update patternfly.dataTables.pfPagination.js

### DIFF
--- a/src/js/patternfly.dataTables.pfPagination.js
+++ b/src/js/patternfly.dataTables.pfPagination.js
@@ -96,7 +96,7 @@
   var FIRST_PAGE_SELECTOR = ".pagination-pf-back .fa-angle-double-left"; // First page button
   var FORWARD_ACTIONS_SELECTOR = ".pagination-pf-forward"; // Forward navigation actions
   var LAST_PAGE_SELECTOR = ".pagination-pf-forward .fa-angle-double-right"; // Last page button
-  var PAGE_SIZE_SELECTOR = ".bootstrap-select .pagination-pf-pagesize"; // Page size selection
+  var PAGE_SIZE_SELECTOR = "select.pagination-pf-pagesize"; // Page size selection
   var TOTAL_ITEMS_SELECTOR = ".pagination-pf-items-total"; // Total items
   var TOTAL_PAGES_SELECTOR = ".pagination-pf-pages"; // Total pages text
   var PREVIOUS_PAGE_SELECTOR = ".pagination-pf-back .fa-angle-left"; // Previous page button


### PR DESCRIPTION
Fix bug reported by Issue #616
Pull Request #617 did not fix bug

## Description
Issue #616 is not only for chrome. bug exists for firefox to. old selector for PAGE_SIZE_SELECTOR select two element and new selector for Pull Request #617 select no element. i changed selector to select only one correct element.

## Todos
- [x] cross browser test

## Steps to test or reproduce and link to rawgit
Updating patternfly.dataTables.pfPagination.js file will correct problem in rawgit test pages
