### PR TITLE
Fix Datatable Api pfEmpty.updateState()

### DIFF
--- a/src/js/patternfly.dataTables.pfEmpty.js
+++ b/src/js/patternfly.dataTables.pfEmpty.js
@@ -238,7 +238,7 @@
    */
   DataTable.Api.register("pfEmpty.updateState()", function () {
     return this.iterator("table", function (ctx) {
-      update(new DataTable.Api(ctx));
+      updateState(new DataTable.Api(ctx));
     });
   });
 


### PR DESCRIPTION
in patternfly.dataTables.pfEmpty.js registered Datatable Api pfEmpty.updateState() has a wrong function call.

## Description
update function is not exists but updateState is correct function. it is defined in call scope and accessible but update function is not exist and using Datatable Api lead to error