### PR TITLE
Remove @supports flex for ie11

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -27,7 +27,9 @@
     "value-no-vendor-prefix": true,
     "shorthand-property-no-redundant-values": true,
     "property-case": "lower",
-    "declaration-block-no-duplicate-properties": true,
+    "declaration-block-no-duplicate-properties": [true, {
+      "ignore": ["consecutive-duplicates-with-different-values"]
+    }],
     "declaration-block-no-ignored-properties": true,
     "declaration-block-trailing-semicolon": "always",
     "declaration-block-semicolon-space-before": "never",

--- a/src/less/list-view.less
+++ b/src/less/list-view.less
@@ -100,9 +100,7 @@
 .list-view-pf-additional-info-item {
   align-items: center;
   display: inline-block;
-  @supports (display: flex) {
-    display: flex;
-  }
+  display: flex;
   margin-right: (@grid-gutter-width/2);
   max-width:100%;
   text-align: center;

--- a/src/less/wizard.less
+++ b/src/less/wizard.less
@@ -112,9 +112,7 @@
 .wizard-pf-steps-indicator {
   font-size: ceil((@font-size-base * 1.3333));
   display: inline-block;
-  @supports(display: flex) {
-    display: flex;
-  }
+  display: flex;
   height: 120px;
   justify-content: space-around;
   list-style: none;


### PR DESCRIPTION
## Description
* removes @supports flex for wizard-pf-steps-indicator and list-view-pf-additional-info-item
* eases duplicate rule restriction based on values [only](https://stylelint.io/user-guide/rules/declaration-block-no-duplicate-properties/#ignore-consecutive-duplicates-with-different-values)

Include related PRs or Issues
https://github.com/openshift/origin-web-catalog/pull/223#issuecomment-301068315

## Todos
- [x] cross browser test
- [x] Are you sure it works on IE9?
- [x] Is it reponsive?


cc @andresgalante @rhamilto 
