### PR TITLE
fix JS scope in examples

### DIFF
--- a/tests/pages/_includes/widgets/forms/expand-collapse-section.html
+++ b/tests/pages/_includes/widgets/forms/expand-collapse-section.html
@@ -60,9 +60,9 @@
   // Initialize form
   $(document).ready(function() {
     // set default state to collapsed for expandable field section
-    $('.fields-section-header-pf').attr('aria-expanded', 'false');
-    $('.fields-section-pf .form-group').addClass('hidden');
-    $('.fa.field-section-toggle-pf').removeClass('fa-angle-down');
+    $('#{{include.id-fieldsection}} .fields-section-header-pf').attr('aria-expanded', 'false');
+    $('#{{include.id-fieldsection}} .fields-section-pf .form-group').addClass('hidden');
+    $('#{{include.id-fieldsection}} .fa.field-section-toggle-pf').removeClass('fa-angle-down');
 
     // click the field section heading to expand the section
     $("#{{include.id-fieldsection}} .field-section-toggle-pf").click(function(event){

--- a/tests/pages/_includes/widgets/layouts/card-view-multi-select.html
+++ b/tests/pages/_includes/widgets/layouts/card-view-multi-select.html
@@ -1,6 +1,7 @@
 {% include widgets/layouts/navbar-primary.html %}
 {% include widgets/layouts/toolbar.html %}
-<div class="container-fluid container-cards-pf" id="card-container">
+{% assign id = include.id | default: 'pf-card-multi-select' %}
+<div id="{{id}}" class="container-fluid container-cards-pf">
   <div class="row row-cards-pf">
     <div class="col-xs-12 col-sm-4 col-md-3 col-lg-2">
 {% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-multi-select" %}
@@ -55,18 +56,18 @@
 <script>
   $(function() {
     // matchHeight the contents of each .card-pf and then the .card-pf itself
-    $(".row-cards-pf > [class*='col'] > .card-pf > .card-pf-body").matchHeight();
+    $("#{{id}} .row-cards-pf > [class*='col'] > .card-pf > .card-pf-body").matchHeight();
   });
   $(document).ready(function() {
     // Card Multi Select
-    $('input[type=checkbox]').click(function() {
+    $('#{{id}} input[type=checkbox]').click(function() {
       if ($(this).parent().parent().hasClass('active'))
       { $(this).parent().parent().removeClass('active'); }
       else
       { $(this).parent().parent().addClass('active'); }
     });
     // allow users to select multiple cards with shift key
-    $('#card-container').on('click', '.card-pf-view-checkbox>input', function(event) {
+    $('#{{id}}').on('click', '.card-pf-view-checkbox>input', function(event) {
       var $cardsContainer = $('.container-cards-pf');
       var prevIndex = $cardsContainer.data('prevIndex');
       var $cards = $cardsContainer.find('.card-pf');

--- a/tests/pages/_includes/widgets/layouts/card-view-single-select.html
+++ b/tests/pages/_includes/widgets/layouts/card-view-single-select.html
@@ -1,6 +1,7 @@
 {% include widgets/layouts/navbar-primary.html %}
 {% include widgets/layouts/toolbar.html %}
-<div class="container-fluid container-cards-pf">
+{% assign id = include.id | default: 'pf-card-single-select' %}
+<div id="{{id}}" class="container-fluid container-cards-pf">
   <div class="row row-cards-pf">
     <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
 {% include widgets/cards/object-status.html class1="card-pf-view-select card-pf-view-single-select" %}
@@ -25,15 +26,15 @@
 <script>
   $(function() {
     // matchHeight the contents of each .card-pf and then the .card-pf itself
-    $(".row-cards-pf > [class*='col'] > .card-pf > .card-pf-body").matchHeight();
+    $("#{{id}} .row-cards-pf > [class*='col'] > .card-pf > .card-pf-body").matchHeight();
   });
   $(document).ready(function() {
     // Card Single Select
-    $('.card-pf-view-single-select').click(function() {
+    $('#{{id}} .card-pf-view-single-select').click(function() {
       if ($(this).hasClass('active'))
       { $(this).removeClass('active'); }
       else
-      { $('.card-pf-view-single-select').removeClass('active'); $(this).addClass('active'); }
+      { $('#{{id}} .card-pf-view-single-select').removeClass('active'); $(this).addClass('active'); }
     });
   });
 </script>

--- a/tests/pages/_includes/widgets/list-view/list-view-default.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-default.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf">
+{% assign id = include.id | default: 'pf-list-default' %}
+<div id="{{id}}" class="list-group list-view-pf">
   <div class="list-group-item">
     <div class="list-view-pf-checkbox">
       <input type="checkbox">
@@ -45,7 +46,7 @@
 <script>
   // Row Checkbox Selection
   $(document).ready(function () {
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {

--- a/tests/pages/_includes/widgets/list-view/list-view-standard-rows-compound-expansion.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-standard-rows-compound-expansion.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf list-view-pf-view">
+{% assign id = include.id | default: "pf-list-compound-expansion" %}
+<div id="{{id}}" class="list-group list-view-pf list-view-pf-view">
   <div class="list-group-item">
     <div class="list-view-pf-checkbox">
       <input type="checkbox">
@@ -1335,7 +1336,7 @@
 <script>
   $(document).ready(function () {
     // Row Checkbox Selection
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {
@@ -1343,14 +1344,14 @@
       }
     });
     // toggle dropdown menu
-    $(".list-view-pf-actions").on("show.bs.dropdown", function () {
+    $("#{{id}} .list-view-pf-actions").on("show.bs.dropdown", function () {
       var $this = $(this);
       var $dropdown = $this.find(".dropdown");
       var space = $(window).height() - $dropdown[0].getBoundingClientRect().top - $this.find(".dropdown-menu").outerHeight(true);
       $dropdown.toggleClass("dropup", space < 10);
     });
     // compound expansion
-    $(".list-view-pf-expand").on("click", function () {
+    $("#{{id}} .list-view-pf-expand").on("click", function () {
       var $this = $(this);
       var $heading = $(this).parents(".list-group-item");
       //var $row = $heading.parent();
@@ -1378,7 +1379,7 @@
     });
 
     // click close button to close the panel
-    $(".list-group-item-container .close").on("click", function (){
+    $("#{{id}} .list-group-item-container .close").on("click", function (){
       var $this = $(this);
       var $panel = $this.parent();
 

--- a/tests/pages/_includes/widgets/list-view/list-view-standard-rows-simple-expansion.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-standard-rows-simple-expansion.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf list-view-pf-view">
+{% assign id = include.id | default: "pf-list-simple-expansion" %}
+<div id="{{id}}" class="list-group list-view-pf list-view-pf-view">
   <div class="list-group-item">
     <div class="list-group-item-header">
       <div class="list-view-pf-expand">
@@ -477,7 +478,7 @@
 <script>
   $(document).ready(function () {
     // Row Checkbox Selection
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {
@@ -485,7 +486,7 @@
       }
     });
     // toggle dropdown menu
-    $('.list-view-pf-actions').on('show.bs.dropdown', function () {
+    $("#{{id}} .list-view-pf-actions").on('show.bs.dropdown', function () {
       var $this = $(this);
       var $dropdown = $this.find('.dropdown');
       var space = $(window).height() - $dropdown[0].getBoundingClientRect().top - $this.find('.dropdown-menu').outerHeight(true);
@@ -493,7 +494,7 @@
     });
 
     // click the list-view heading then expand a row
-    $(".list-group-item-header").click(function(event){
+    $("#{{id}} .list-group-item-header").click(function(event){
       if(!$(event.target).is("button, a, input, .fa-ellipsis-v")){
         $(this).find(".fa-angle-right").toggleClass("fa-angle-down")
           .end().parent().toggleClass("list-view-pf-expand-active")
@@ -503,7 +504,7 @@
     })
 
     // click the close button, hide the expand row and remove the active status
-    $(".list-group-item-container .close").on("click", function (){
+    $("#{{id}} .list-group-item-container .close").on("click", function (){
       $(this).parent().addClass("hidden")
         .parent().removeClass("list-view-pf-expand-active")
           .find(".fa-angle-right").removeClass("fa-angle-down");

--- a/tests/pages/_includes/widgets/list-view/list-view-standard-rows.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-standard-rows.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf list-view-pf-view">
+{% assign id = include.id | default: 'pf-list-standard' %}
+<div id="{{id}}" class="list-group list-view-pf list-view-pf-view">
   <div class="list-group-item">
     <div class="list-view-pf-checkbox">
       <input type="checkbox">
@@ -255,7 +256,7 @@
 <script>
   $(document).ready(function () {
     // Row Checkbox Selection
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {
@@ -263,14 +264,14 @@
       }
     });
     // toggle dropdown menu
-    $('.list-view-pf-actions').on('show.bs.dropdown', function () {
+    $('#{{id}} .list-view-pf-actions').on('show.bs.dropdown', function () {
       var $this = $(this);
       var $dropdown = $this.find('.dropdown');
       var space = $(window).height() - $dropdown[0].getBoundingClientRect().top - $this.find('.dropdown-menu').outerHeight(true);
       $dropdown.toggleClass('dropup', space < 10);
     });
     // allow users to select multiple list items with shift key
-    $('.list-group').on('click', '.list-view-pf-checkbox>input', function(event) {
+    $('#{{id}} .list-group').on('click', '.list-view-pf-checkbox>input', function(event) {
       var $list = $('.list-group');
       var prevIndex = $list.data('preIndex');
       var $listItems = $list.children('.list-group-item');

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-3.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-3.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf">
+{% assign id = include.id | default: 'pf-list-var3' %}
+<div id="{{id}}" class="list-group list-view-pf">
   <div class="list-group-item list-view-pf-stacked list-view-pf-top-align">
     <div class="list-view-pf-checkbox">
       <input type="checkbox">
@@ -36,7 +37,7 @@
 <script>
   // Row Checkbox Selection
   $(document).ready(function () {
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-4.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-4.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf">
+{% assign id = include.id | default: 'pf-list-var4' %}
+<div id="{{id}}" class="list-group list-view-pf">
   <div class="list-group-item">
     <div class="list-view-pf-checkbox">
       <input type="checkbox">
@@ -33,7 +34,7 @@
 <script>
   // Row Checkbox Selection
   $(document).ready(function () {
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-5.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-5.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf list-view-pf-equalized-column">
+{% assign id = include.id | default: 'pf-list-var5' %}
+<div id="{{id}}" class="list-group list-view-pf list-view-pf-equalized-column">
   <div class="list-group-item">
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
@@ -111,9 +112,9 @@
 <script>
   // Equalize column width
   $(document).ready(function () {
-  	var widest = 0;
-  	$('.list-view-pf-equalized-column .list-view-pf-additional-info-item').each( function() {
-  		widest = $(this).width() > widest ? $(this).width() : widest;
-  	}).width(widest);
+    var widest = 0;
+    $('#{{id}} .list-view-pf-equalized-column .list-view-pf-additional-info-item').each( function() {
+      widest = $(this).width() > widest ? $(this).width() : widest;
+    }).width(widest);
   });
 </script>

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-6.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-6.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf">
+{% assign id = include.id | default: 'pf-list-var6' %}
+<div id="{{id}}" class="list-group list-view-pf">
   <div class="list-group-item list-view-pf-stacked list-view-pf-top-align">
     <div class="list-view-pf-checkbox">
       <input type="checkbox">
@@ -41,7 +42,7 @@
 <script>
   // Row Checkbox Selection
   $(document).ready(function () {
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {

--- a/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar-page.html
+++ b/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar-page.html
@@ -3,18 +3,19 @@
 {% else %}
   {% include widgets/navigation/horizontal-primary-nav-bar.html %}
 {% endif %}
-<div class="container-fluid container-cards-pf" id="main">
+{% assign id = include.id | default: 'main' %}
+<div id="{{id}}" class="container-fluid container-cards-pf">
 {% include widgets/layouts/cards-alt.html %}
 </div>
 <script>
   $(document).ready(function() {
     // matchHeight the contents of each .card-pf and then the .card-pf itself
-    $(".row-cards-pf > [class*='col'] > .card-pf .card-pf-title").matchHeight();
-    $(".row-cards-pf > [class*='col'] > .card-pf > .card-pf-body").matchHeight();
-    $(".row-cards-pf > [class*='col'] > .card-pf > .card-pf-footer").matchHeight();
-    $(".row-cards-pf > [class*='col'] > .card-pf").matchHeight();
+    $("#{{id}} .row-cards-pf > [class*='col'] > .card-pf .card-pf-title").matchHeight();
+    $("#{{id}} .row-cards-pf > [class*='col'] > .card-pf > .card-pf-body").matchHeight();
+    $("#{{id}} .row-cards-pf > [class*='col'] > .card-pf > .card-pf-footer").matchHeight();
+    $("#{{id}} .row-cards-pf > [class*='col'] > .card-pf").matchHeight();
 
     // initialize tooltips
-    $('[data-toggle="tooltip"]').tooltip();
+    $('#{{id}} [data-toggle="tooltip"]').tooltip();
   });
 </script>

--- a/tests/pages/_includes/widgets/navigation/vertical-navigation.html
+++ b/tests/pages/_includes/widgets/navigation/vertical-navigation.html
@@ -4,7 +4,8 @@
 {% else %}
   {% include widgets/layouts/navbar-vertical.html notification-drawer=true icons=launchericons %}
 {% endif %}
-<div class="nav-pf-vertical nav-pf-vertical-with-sub-menus
+{% assign id = include.id | default: 'pf-vertical-nav' %}
+<div id="{{id}}" class="nav-pf-vertical nav-pf-vertical-with-sub-menus
      {% if page.persistent-secondary %}nav-pf-persistent-secondary{% endif %}
      {% if page.collapsible-menus %}nav-pf-vertical-collapsible-menus{% endif %}
      {% if page.hide-icons %}hidden-icons-pf{% endif %}
@@ -162,10 +163,10 @@
 <script>
   $(document).ready(function() {
     // matchHeight the contents of each .card-pf and then the .card-pf itself
-    $(".row-cards-pf > [class*='col'] > .card-pf .card-pf-title").matchHeight();
-    $(".row-cards-pf > [class*='col'] > .card-pf > .card-pf-body").matchHeight();
-    $(".row-cards-pf > [class*='col'] > .card-pf > .card-pf-footer").matchHeight();
-    $(".row-cards-pf > [class*='col'] > .card-pf").matchHeight();
+    $("#{{id}} .row-cards-pf > [class*='col'] > .card-pf .card-pf-title").matchHeight();
+    $("#{{id}} .row-cards-pf > [class*='col'] > .card-pf > .card-pf-body").matchHeight();
+    $("#{{id}} .row-cards-pf > [class*='col'] > .card-pf > .card-pf-footer").matchHeight();
+    $("#{{id}} .row-cards-pf > [class*='col'] > .card-pf").matchHeight();
 
     // Initialize the vertical navigation
     $().setupVerticalNavigation(true);

--- a/tests/pages/_includes/widgets/notification-drawer.html
+++ b/tests/pages/_includes/widgets/notification-drawer.html
@@ -1,4 +1,5 @@
-<div class="drawer-pf hide drawer-pf-notifications-non-clickable">
+{% assign id = include.id | default: 'pf-drawer' %}
+<div id="{{id}}" class="drawer-pf hide drawer-pf-notifications-non-clickable">
   <div class="drawer-pf-title">
     <a class="drawer-pf-toggle-expand fa fa-angle-double-left hidden-xs"></a>
     <a  class="drawer-pf-close pficon pficon-close"></a>
@@ -117,7 +118,7 @@
 
     // Show/Hide Notifications Drawer
     $('.drawer-pf-trigger').click(function() {
-      var $drawer = $('.drawer-pf');
+      var $drawer = $('#{{id}}.drawer-pf');
 
       $(this).toggleClass('open');
       if ($drawer.hasClass('hide')) {
@@ -139,13 +140,13 @@
        $('.nav-pf-vertical').removeClass('show-mobile-nav');
      }
     });
-    $('.drawer-pf-close').click(function() {
-      var $drawer = $('.drawer-pf');
+    $('#{{id}} .drawer-pf-close').click(function() {
+      var $drawer = $('#{{id}}.drawer-pf');
 
-      $('.drawer-pf-trigger').removeClass('open');
+      $('#{{id}} .drawer-pf-trigger').removeClass('open');
       $drawer.addClass('hide');
     });
-    $('.drawer-pf-toggle-expand').click(function() {
+    $('#{{id}} .drawer-pf-toggle-expand').click(function() {
       var $drawer = $('.drawer-pf');
       var $drawerNotifications = $drawer.find('.drawer-pf-notification');
 
@@ -159,7 +160,7 @@
     });
 
     // Mark All Read / Clear All
-    $('.panel-collapse').each(function (index, panel) {
+    $('#{{id}} .panel-collapse').each(function (index, panel) {
       var $panel = $(panel);
       var unreadCount = $panel.find('.drawer-pf-notification.unread').length;
       $(panel.parentElement).find('.panel-counter').text(unreadCount + ' New Event' + (unreadCount !== 1 ? 's' : ''));


### PR DESCRIPTION
Limited the scope of JavaScript in several examples, i.e. when included on a page the accompanying script will only apply to the given example and will not affect the rest of the page or other examples.

(Omitted the template since this is not a design change)