### PR TITLE
Moves flex on list content to an additional class

### DIFF
--- a/src/less/list-pf.less
+++ b/src/less/list-pf.less
@@ -64,7 +64,7 @@
 }
 
 // add this class to manage flexed contents in the list item content
-.list-pf-flex-content {
+.list-pf-content-flex {
   align-items: flex-start;
   display:flex;
   flex-grow: 1;

--- a/src/less/list-pf.less
+++ b/src/less/list-pf.less
@@ -59,6 +59,12 @@
 }
 
 .list-pf-content {
+  flex-grow: 1;
+  min-width: 0;
+}
+
+// add this class to manage flexed contents in the list item content
+.list-pf-flex-content {
   align-items: flex-start;
   display:flex;
   flex-grow: 1;

--- a/tests/pages/list-pf.html
+++ b/tests/pages/list-pf.html
@@ -164,7 +164,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-flex-content">
+      <div class="list-pf-content list-pf-content-flex">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -191,7 +191,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-flex-content">
+      <div class="list-pf-content list-pf-content-flex">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -218,7 +218,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-flex-content ">
+      <div class="list-pf-content list-pf-content-flex ">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -246,7 +246,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-flex-content ">
+      <div class="list-pf-content list-pf-content-flex ">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -279,7 +279,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-flex-content ">
+      <div class="list-pf-content list-pf-content-flex ">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -306,7 +306,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-flex-content ">
+      <div class="list-pf-content list-pf-content-flex ">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -333,7 +333,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-flex-content ">
+      <div class="list-pf-content list-pf-content-flex ">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -361,7 +361,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-flex-content ">
+      <div class="list-pf-content list-pf-content-flex ">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>

--- a/tests/pages/list-pf.html
+++ b/tests/pages/list-pf.html
@@ -164,7 +164,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-content">
+      <div class="list-pf-flex-content">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -191,7 +191,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-content">
+      <div class="list-pf-flex-content">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -218,7 +218,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-content ">
+      <div class="list-pf-flex-content ">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -246,7 +246,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-content ">
+      <div class="list-pf-flex-content ">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -279,7 +279,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-content ">
+      <div class="list-pf-flex-content ">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -306,7 +306,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-content ">
+      <div class="list-pf-flex-content ">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -333,7 +333,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-content ">
+      <div class="list-pf-flex-content ">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>
@@ -361,7 +361,7 @@ resource: true
       <div class="list-pf-select">
         <input type="checkbox">
       </div>
-      <div class="list-pf-content ">
+      <div class="list-pf-flex-content ">
         <div class="list-pf-left">
           <span class="fa fa-plane list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
         </div>


### PR DESCRIPTION
## Description
This fixes a backwards compatibility issue with the list-pf-contents being flexed by default.

## Todos
- [x] cross browser test - tested on Chrome, Firefox, Safari *Needs IE
- [ ] Are you sure it works on IE9?
- [x] Is it responsive?

## Steps to test or reproduce and link to rawgit
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

Also, you may want to please any @mentions you'd like to review.
