### PR TITLE
Fix #634: Header link inside panel-info is almost unreadable

### DIFF
--- a/src/less/panels.less
+++ b/src/less/panels.less
@@ -28,12 +28,24 @@
     }
   }
 
+  .panel-info {
+    border-color: @panel-info-border;
+    .panel-heading {
+      background-color: @panel-group-pf-info-heading-bg;
+    }
+    + .panel-default {
+      border-top-color: @panel-info-border;
+    }
+  }
   .panel-primary {
     border-color: @panel-primary-border;
     .panel-heading {
       background-color: @panel-group-pf-primary-heading-bg;
     }
     + .panel-default {
+      border-top-color: @panel-primary-border;
+    }
+    + .panel-info {
       border-top-color: @panel-primary-border;
     }
   }
@@ -43,6 +55,9 @@
       background-color: @panel-group-pf-success-heading-bg;
     }
     + .panel-default {
+      border-top-color: @panel-success-border;
+    }
+    + .panel-info {
       border-top-color: @panel-success-border;
     }
     + .panel-primary {
@@ -55,6 +70,9 @@
       background-color: @panel-group-pf-warning-heading-bg;
     }
     + .panel-default {
+      border-top-color: @panel-warning-border;
+    }
+    + .panel-info {
       border-top-color: @panel-warning-border;
     }
     + .panel-primary {
@@ -70,6 +88,9 @@
       background-color: @panel-group-pf-danger-heading-bg;
     }
     + .panel-default {
+      border-top-color: @panel-danger-border;
+    }
+    + .panel-info {
       border-top-color: @panel-danger-border;
     }
     + .panel-primary {

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -431,6 +431,7 @@
 @panel-group-pf-primary-heading-bg:                                 lighten(@brand-primary, 38%);
 @panel-group-pf-success-heading-bg:                                 @alert-success-bg;
 @panel-group-pf-warning-heading-bg:                                 @alert-warning-bg;
+@panel-group-pf-info-heading-bg:                                    lighten(desaturate(spin(@brand-info, 13), 45), 60%);
 @panel-danger-border:                                               @brand-danger;
 @panel-danger-heading-bg:                                           @brand-danger;
 @panel-info-border:                                                 @brand-info;

--- a/tests/pages/accordions.html
+++ b/tests/pages/accordions.html
@@ -187,6 +187,20 @@ resource: true
           </div>
         </div>
       </div>
+      <div class="panel panel-info">
+        <div class="panel-heading" data-component="collapse-heading">
+          <h4 class="panel-title">
+            <a data-toggle="collapse" data-parent="#alternatives-accordion" href="#info-collapse">
+              Pellentesque
+            </a>
+          </h4>
+        </div>
+        <div id="info-collapse" class="panel-collapse collapse">
+          <div class="panel-body">
+            Aenean tempor ligula at scelerisque egestas. Quisque eu congue lorem. Morbi nec molestie nisl. Sed porttitor mauris eu pharetra vestibulum. Nulla efficitur faucibus nunc. Phasellus id dignissim massa. Ut sollicitudin et enim vel aliquam. Curabitur vel rutrum arcu, ut pellentesque massa. Cras efficitur mi vitae ante lacinia fringilla.
+          </div>
+        </div>
+      </div>
       <div class="panel panel-primary">
         <div class="panel-heading" data-component="collapse-heading">
           <h4 class="panel-title">


### PR DESCRIPTION
This adds a new variable that modifies @brand-info to try to find a more
suitable background color for info panels in a panel-group.

The style of other panel types had to be supplemented to ensure that
"higher priority" panel borders take precedence.

#634 
