### PR TITLE
Fix app-launcher alignment with no icon

### DIFF
--- a/src/less/application-launcher.less
+++ b/src/less/application-launcher.less
@@ -40,12 +40,17 @@
 
   .applauncher-pf-link-icon {
     font-size: @applauncher-pf-menu-link-icon-font-size;
+    text-align: center;
+    width: @applauncher-pf-menu-link-icon-width;
+    min-height: @applauncher-pf-menu-link-icon-width;
+    @media (min-width: @screen-sm-min) {
+      padding-right: @applauncher-pf-icon-padding-right;
+    }
   }
 
   .applauncher-pf-link-icon,
   .applauncher-pf-link-title {
     display: inline-block;
-    width: auto;
     vertical-align: middle;
   }
 
@@ -69,6 +74,7 @@
     .applauncher-pf-link-title {
       display: block;
       padding: 0;
+      width: auto;
     }
 
     .applauncher-pf-link-title {

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -23,6 +23,7 @@
 @applauncher-pf-menu-link-background-color-hover:                   @color-pf-black-150;
 @applauncher-pf-menu-link-shadow:                                   @color-pf-black-300;
 @applauncher-pf-menu-link-icon-font-size:                           2em;
+@applauncher-pf-menu-link-icon-width:                               ((9 * @applauncher-pf-menu-link-icon-font-size) / 14); //Numbers to imitate fa-fw class
 @bootstrap-switch-handle-default-bg-color:                          @color-pf-black-100;
 @bootstrap-treeview-highlight-color:                                @color-pf-blue-300;
 @btn-default-bg-img-start:                                          @color-pf-black-100;

--- a/tests/pages/_includes/widgets/navigation/application-launcher.html
+++ b/tests/pages/_includes/widgets/navigation/application-launcher.html
@@ -241,7 +241,8 @@
           </li>
           <li class="applauncher-pf-item" role="menuitem">
             <a class="applauncher-pf-link" href="#">
-              <i class="applauncher-pf-link-icon pficon pficon-build" aria-hidden="true"></i>
+              <!-- Placeholder left to maintain spacing -->
+              <i class="applauncher-pf-link-icon" aria-hidden="true"></i>
               <span class="applauncher-pf-link-title">Suavitate</span>
             </a>
           </li>


### PR DESCRIPTION
## Description
Adds a simulated fa-fw (fixed width) style to the icons in the app launcher to ensure that text lines up properly. Adds an example with a placeholder element (with no icon specified) to correctly align an item with no icon. Closes #648.

![screen shot 2017-05-31 at 1 52 24 pm](https://cloud.githubusercontent.com/assets/3300756/26650336/142eb706-4617-11e7-9200-31d0d6eb53f3.png)
![screen shot 2017-05-31 at 1 52 17 pm](https://cloud.githubusercontent.com/assets/3300756/26650339/1576386e-4617-11e7-8afe-67d07fbc65dd.png)
![screen shot 2017-05-31 at 1 52 32 pm](https://cloud.githubusercontent.com/assets/3300756/26650341/16866058-4617-11e7-95a2-49eedc7fa4df.png)
 

## Todos
- [x] cross browser test
- [X] Are you sure it works on IE9?
- [X] Is it reponsive?
