### PR TITLE
Removes !important from some secondary tab styles

### DIFF
--- a/src/less/tabs.less
+++ b/src/less/tabs.less
@@ -31,7 +31,7 @@
     > li:first-child > a {
       padding-left: 15px;
       &:before {
-        left: 15px !important;
+        left: 15px;
       }
     }
   }
@@ -48,7 +48,7 @@
 .nav-tabs-pf {
   &.nav-justified {
     @media (min-width: @grid-float-breakpoint) {
-      border-bottom: 1px solid @nav-tabs-justified-link-border-color;
+      border-bottom: @nav-tabs-justified-link-border-color;
     }
     > li {
       &:first-child > a {
@@ -57,8 +57,8 @@
       > a {
         border-bottom: 0;
         &:before {
-          left: 0 !important;
-          right: 0 !important;
+          left: 0;
+          right: 0;
         }
       }
     }
@@ -83,7 +83,7 @@
       > a {
         padding-left: 0;
         &:before {
-          left: 0 !important;
+          left: 0;
         }
       }
     }


### PR DESCRIPTION
## Description
This removes `!important` from several styles relating to secondary tab bottom border position. These were forcing use of `!important` downstream. See https://github.com/patternfly-webcomponents/patternfly-webcomponents/pull/44

## Todos
- [x] cross browser test
- [ ] Are you sure it works on IE9? 
- [x] Is it responsive?

## Steps to test or reproduce and link to rawgit
(no preview; my Travis build is failing on publishing)

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

@priley86 @andresgalante 
