### PR TITLE
Fix NPM Post Install, Build Package Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ then
 npm install
 ```
 
-This should take care of the majority of dependencies, including [Jekyll](http://jekyllrb.com/). During the install you may be asked for your password as part of the [Ruby](https://www.ruby-lang.org/en/documentation/installation/) installation process.
+This should take care of the majority of dependencies.
 
 Since PatternFly is shrink wrapped, npm 3 will install all necessary development packages into `node_modules/patternfly/node_modules`. At this point, the gruntjs tasks are available for use such as starting a local development server or building the master CSS file.
 
@@ -116,7 +116,9 @@ gem install bundle
 bundle install
 ```
 
-Then set the environment variable PF_PAGE_BUILDER=jekyll.  eg.:
+During the install you may be asked for your password as part of the [Ruby](https://www.ruby-lang.org/en/documentation/installation/) installation process.
+
+Next, set the environment variable PF_PAGE_BUILDER=jekyll.  eg.:
     PF_PAGE_BUILDER=jekyll grunt build
 
 #### Keeping NPM Dependencies Updated

--- a/package.json
+++ b/package.json
@@ -70,9 +70,8 @@
   "scripts": {
     "test": "grunt karma",
     "build": "grunt build",
-    "jekyll": "ruby --version || echo \"Ruby required\"; gem install bundler; bundle install; set -e",
-    "start": "npm run build; grunt server & open http://localhost:9000",
-    "postinstall": "npm run jekyll"
+    "jekyll": "ruby --version || echo \"Ruby required\"; bundler -v || gem install bundler; bundle check || bundle install; set -e",
+    "start": "npm run build; grunt server & open http://localhost:9000"
   },
   "description": "This reference implementation of PatternFly is based on [Bootstrap v3](http://getbootstrap.com/).  Think of PatternFly as a \"skinned\" version of Bootstrap with additional components and customizations.",
   "repository": {


### PR DESCRIPTION
## Description
Addresses issue of recursively installing the ```bundle```. Removed NPM ```postinstall``` script all together, retained NPM script ```jekyll``` since it reflects an optional install path indicated through the ReadMe, can remove if needed.

Closes #664 

## Todos
- N/A cross browser test
- N/A Are you sure it works on IE9?
- N/A Is it responsive?

## Steps to test or reproduce and link to rawgit
```shell
$ git pull https://github.com/cdcabrera/patternfly.git postinstall-update:postinstall-update
$ npm install
$ npm start
```

Or test by including the repository ```-dist``` branch in your ```package.json```
```json
{
  "dependencies": {
    "patternfly": "https://github.com/cdcabrera/patternfly.git#postinstall-update-dist"
  }
}
```

@bleathem @priley86 @Agathver
