### PR TITLE
Replaced jQuery references with patternfly ones in a patternfly-settings-*.js file

### DIFF
--- a/src/js/patternfly-settings-charts.js
+++ b/src/js/patternfly-settings-charts.js
@@ -198,7 +198,7 @@
       },
       getDefaultPieTooltip = function () {
         return {
-          contents: $().pfPieTooltipContents
+          contents: patternfly.pfPieTooltipContents
         };
       },
       getDefaultPieLegend = function () {
@@ -316,7 +316,7 @@
       },
       getDefaultSingleLineTooltip = function () {
         return {
-          contents: $().pfGetBarChartTooltipContentsFn()
+          contents: patternfly.pfGetBarChartTooltipContentsFn()
         };
       },
       getDefaultSingleLineLegend = function () {
@@ -357,7 +357,7 @@
       },
       getDefaultSingleAreaTooltip = function () {
         return {
-          contents: $().pfGetBarChartTooltipContentsFn()
+          contents: patternfly.pfGetBarChartTooltipContentsFn()
         };
       },
       getDefaultSingleAreaLegend = function () {
@@ -421,4 +421,3 @@
     };
   };
 })(window);
-


### PR DESCRIPTION
In this PR I replaced jQuery references with patternfly ones in a patternfly-settings-charts.js file.