### PR TITLE
Expand the message to full width when notification drawer is expanded.

### DIFF
--- a/src/less/notifications-drawer.less
+++ b/src/less/notifications-drawer.less
@@ -91,6 +91,10 @@
     margin-right: 5px;
     padding-right: 9px;
   }
+  > .dropdown-kebab-pf {
+    margin-top: -3px;
+  }
+
   .pficon {
     font-size: @font-size-large;
     margin-top: 3px;
@@ -131,6 +135,15 @@
     font-size: @font-size-base;
     margin: 0;
     padding: 6px 15px;
+  }
+}
+
+.drawer-pf-notification.expanded-notification {
+  .drawer-pf-notification-content {
+    display: flex;
+    .drawer-pf-notification-message {
+      flex: 1 1;
+    }
   }
 }
 

--- a/tests/pages/_includes/widgets/notification-drawer-notifications.html
+++ b/tests/pages/_includes/widgets/notification-drawer-notifications.html
@@ -2,39 +2,47 @@
   {% assign menu_id = 'dropdownKebabRight1' | append: include.id %}
   {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId=menu_id dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
   <span class="pficon pficon-info pull-left"></span>
-  <span class="drawer-pf-notification-message">A New Event! Huzzah! Bold!</span>
-  <div class="drawer-pf-notification-info">
-    <span class="date">3/31/16</span>
-    <span class="time">12:12:44 PM</span>
+  <div class="drawer-pf-notification-content">
+    <span class="drawer-pf-notification-message">A New Event! Huzzah! Bold!</span>
+    <div class="drawer-pf-notification-info">
+      <span class="date">3/31/16</span>
+      <span class="time">12:12:44 PM</span>
+    </div>
   </div>
 </div>
 <div class="drawer-pf-notification unread">
   {% assign menu_id = 'dropdownKebabRight2' | append: include.id %}
   {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId=menu_id dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
   <span class="pficon pficon-ok pull-left"></span>
-  <span class="drawer-pf-notification-message">Another Event Notification</span>
-  <div class="drawer-pf-notification-info">
-    <span class="date">3/31/16</span>
-    <span class="time">12:12:44 PM</span>
+  <div class="drawer-pf-notification-content">
+    <span class="drawer-pf-notification-message">Another Event Notification</span>
+    <div class="drawer-pf-notification-info">
+      <span class="date">3/31/16</span>
+      <span class="time">12:12:44 PM</span>
+    </div>
   </div>
 </div>
 <div class="drawer-pf-notification">
   {% assign menu_id = 'dropdownKebabRight3' | append: include.id %}
   {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId=menu_id dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
   <span class="pficon pficon-warning-triangle-o pull-left"></span>
-  <span class="drawer-pf-notification-message">Another Event Notification</span>
-  <div class="drawer-pf-notification-info">
-    <span class="date">3/31/16</span>
-    <span class="time">12:12:44 PM</span>
+  <div class="drawer-pf-notification-content">
+    <span class="drawer-pf-notification-message">Another Event Notification</span>
+    <div class="drawer-pf-notification-info">
+      <span class="date">3/31/16</span>
+      <span class="time">12:12:44 PM</span>
+    </div>
   </div>
 </div>
 <div class="drawer-pf-notification">
   {% assign menu_id = 'dropdownKebabRight4' | append: include.id %}
   {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="pull-right" dropmenuId=menu_id dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
-  <span class="pficon pficon-error-circle-o pull-left"></span>
-  <span class="drawer-pf-notification-message">Another Event Notification</span>
-  <div class="drawer-pf-notification-info">
-    <span class="date">3/31/16</span>
-    <span class="time">12:12:44 PM</span>
+  <div class="drawer-pf-notification-content">
+    <span class="pficon pficon-error-circle-o pull-left"></span>
+    <span class="drawer-pf-notification-message">Another Event Notification</span>
+    <div class="drawer-pf-notification-info">
+      <span class="date">3/31/16</span>
+      <span class="time">12:12:44 PM</span>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Long notification messages cause incorrect layout in the notification drawer

Fixes #668

Viewable at:
http://rawgit.com/jeff-phillips-18/patternfly/notifications-dist/dist/tests/notification-drawer-horizontal-nav.html
http://rawgit.com/jeff-phillips-18/patternfly/notifications-dist/dist/tests/notification-drawer-vertical-nav.html

For release notes:

Existing consumers can gain this functionality by wrapping the drawer-pf-notification-message and drawer-pf-notification-info elements inside a drawer-pf-notification-content element.