### PR TITLE
Implement Notification Drawer Updates

### DIFF
--- a/src/less/notifications-drawer.less
+++ b/src/less/notifications-drawer.less
@@ -48,30 +48,78 @@
       content: "\f101";
     }
   }
+  .blank-slate-pf {
+    border: 0;
+    margin-bottom: 0;
+    padding: 30px;
+
+    .blank-slate-pf-icon {
+      font-size: 3em;
+      line-height: 1em;
+    }
+
+    h1 {
+      font-size: 1em;
+      margin-bottom: 0;
+      margin-top: 15px;
+    }
+  }
 }
-.drawer-pf-toggle-expand {
+.drawer-pf-close, .drawer-pf-toggle-expand {
   color: inherit;
   cursor: pointer;
-  left: 0;
   padding: 2px 5px;
   position: absolute;
-  &:before {
-    content: "\f100";
-    font-family: "FontAwesome";
-  }
   &:hover,
   &:focus {
     color: inherit;
     text-decoration: none;
   }
 }
+.drawer-pf-toggle-expand {
+  left: 0;
+  &:before {
+    content: "\f100";
+    font-family: "FontAwesome";
+  }
+  &:hover {
+    color: @link-color;
+  }
+}
+.drawer-pf-close {
+  right: 0;
+  &:before {
+    content: "\e60b";
+    font-family: "PatternFlyIcons-webfont";
+  }
+}
+
 
 .drawer-pf-action {
+  display: flex;
   .btn-link {
     color: @link-color;
     padding: 10px 0;
+    .pficon, .fa {
+      margin-right: 3px;
+    }
 
     &:hover { color: @link-hover-color; }
+  }
+}
+
+.drawer-pf-action-link {
+  border-left: solid 1px @color-pf-black-300;
+  flex: 1 1 0%;
+  margin: 10px 0;
+  text-align: center;
+
+  &:first-of-type {
+    border-left-width: 0;
+  }
+
+  .btn-link {
+    padding: 0;
   }
 }
 
@@ -112,6 +160,10 @@
   }
 }
 
+.drawer-pf-notification-content {
+  cursor: default;
+}
+
 .drawer-pf-notification-info,
 .drawer-pf-notification-message {
   display: block;
@@ -130,7 +182,7 @@
   background-color: @color-pf-black-100;
   border-bottom: 1px solid @card-pf-border-color;
   position: absolute;
-  width: 318px;
+  width: 100%;
   h3 {
     font-size: @font-size-base;
     margin: 0;

--- a/src/less/notifications-drawer.less
+++ b/src/less/notifications-drawer.less
@@ -68,6 +68,7 @@
 .drawer-pf-close, .drawer-pf-toggle-expand {
   color: inherit;
   cursor: pointer;
+  line-height: inherit;
   padding: 2px 5px;
   position: absolute;
   &:hover,
@@ -78,20 +79,12 @@
 }
 .drawer-pf-toggle-expand {
   left: 0;
-  &:before {
-    content: "\f100";
-    font-family: "FontAwesome";
-  }
   &:hover {
     color: @link-color;
   }
 }
 .drawer-pf-close {
   right: 0;
-  &:before {
-    content: "\e60b";
-    font-family: "PatternFlyIcons-webfont";
-  }
 }
 
 

--- a/tests/pages/_includes/widgets/notification-drawer.html
+++ b/tests/pages/_includes/widgets/notification-drawer.html
@@ -1,7 +1,7 @@
 <div class="drawer-pf hide drawer-pf-notifications-non-clickable">
   <div class="drawer-pf-title">
-    <a class="drawer-pf-toggle-expand"></a>
-    <a  class="drawer-pf-close"></a>
+    <a class="drawer-pf-toggle-expand fa fa-angle-double-left"></a>
+    <a  class="drawer-pf-close pficon pficon-close"></a>
     <h3 class="text-center">Notifications Drawer</h3>
   </div>
   <div class="panel-group" id="notification-drawer-accordion">

--- a/tests/pages/_includes/widgets/notification-drawer.html
+++ b/tests/pages/_includes/widgets/notification-drawer.html
@@ -1,6 +1,7 @@
 <div class="drawer-pf hide drawer-pf-notifications-non-clickable">
   <div class="drawer-pf-title">
     <a class="drawer-pf-toggle-expand"></a>
+    <a  class="drawer-pf-close"></a>
     <h3 class="text-center">Notifications Drawer</h3>
   </div>
   <div class="panel-group" id="notification-drawer-accordion">
@@ -17,8 +18,22 @@
         <div class="panel-body">
           {% include widgets/notification-drawer-notifications.html id="1" %}
         </div>
+        <div class="blank-slate-pf hidden">
+          <div class="blank-slate-pf-icon">
+            <span class="pficon-info"></span>
+          </div>
+          <h1>There are no notifications to display.</h1>
+        </div>
         <div class="drawer-pf-action">
-          <button class="btn btn-link btn-block">Mark All Read</button>
+          <div class="drawer-pf-action-link" data-toggle="mark-all-read">
+            <button class="btn btn-link">Mark All Read</button>
+          </div>
+          <div class="drawer-pf-action-link" data-toggle="clear-all">
+            <button class="btn btn-link">
+              <span class="pficon pficon-close"></span>
+              Clear All
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -40,8 +55,22 @@
             <span class="spinner spinner-xs spinner-inline"></span> Loading More
           </div>
         </div>
+        <div class="blank-slate-pf hidden">
+          <div class="blank-slate-pf-icon">
+            <span class="pficon-info"></span>
+          </div>
+          <h1>There are no notifications to display.</h1>
+        </div>
         <div class="drawer-pf-action">
-          <button class="btn btn-link btn-block">Mark All Read</button>
+          <div class="drawer-pf-action-link" data-toggle="mark-all-read">
+            <button class="btn btn-link">Mark All Read</button>
+          </div>
+          <div class="drawer-pf-action-link" data-toggle="clear-all">
+            <button class="btn btn-link">
+              <span class="pficon pficon-close"></span>
+              Clear All
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -60,8 +89,22 @@
           {% include widgets/notification-drawer-notifications.html id="6" %}
           {% include widgets/notification-drawer-notifications.html id="7" %}
         </div>
+        <div class="blank-slate-pf hidden">
+          <div class="blank-slate-pf-icon">
+            <span class="pficon-info"></span>
+          </div>
+          <h1>There are no notifications to display.</h1>
+        </div>
         <div class="drawer-pf-action">
-          <button class="btn btn-link btn-block">Mark All Read</button>
+          <div class="drawer-pf-action-link" data-toggle="mark-all-read">
+            <button class="btn btn-link">Mark All Read</button>
+          </div>
+          <div class="drawer-pf-action-link" data-toggle="clear-all">
+            <button class="btn btn-link">
+              <span class="pficon pficon-close"></span>
+              Clear All
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -69,6 +112,9 @@
 </div>
 <script>
   $(document).ready(function() {
+    // Initialize to unread notifications
+    // TODO: add badge for unread notifications
+
     // Show/Hide Notifications Drawer
     $('.drawer-pf-trigger').click(function() {
       var $drawer = $('.drawer-pf');
@@ -89,6 +135,12 @@
         $drawer.addClass('hide');
       }
     });
+    $('.drawer-pf-close').click(function() {
+      var $drawer = $('.drawer-pf');
+
+      $('.drawer-pf-trigger').removeClass('open');
+      $drawer.addClass('hide');
+    });
     $('.drawer-pf-toggle-expand').click(function() {
       var $drawer = $('.drawer-pf');
       var $drawerNotifications = $drawer.find('.drawer-pf-notification');
@@ -102,12 +154,48 @@
       }
     });
 
-    // Mark All Read
+    // Mark All Read / Clear All
     $('.panel-collapse').each(function (index, panel) {
       var $panel = $(panel);
-      $panel.on('click', '.drawer-pf-action .btn', function() {
+      var unreadCount = $panel.find('.drawer-pf-notification.unread').length;
+      $(panel.parentElement).find('.panel-counter').text(unreadCount + ' New Event' + (unreadCount !== 1 ? 's' : ''));
+
+      if ($('.drawer-pf .panel-collapse .unread').length === 0) {
+        // TODO: remove badge for unread indicator
+      }
+
+      $panel.on('click', '.drawer-pf-action [data-toggle="mark-all-read"] .btn', function() {
         $panel.find('.unread').removeClass('unread');
+        $panel.find('.drawer-pf-action [data-toggle="mark-all-read"]').remove();
         $(panel.parentElement).find('.panel-counter').text('0 New Events');
+        if ($('.drawer-pf .panel-collapse .unread').length === 0) {
+          $('.drawer-pf-trigger').removeClass('unread');
+        }
+      });
+      $panel.on('click', '.drawer-pf-action [data-toggle="clear-all"] .btn', function() {
+        $panel.find('.panel-body .drawer-pf-notification').remove();
+        $panel.find('.drawer-pf-action').remove();
+        $panel.find('.blank-slate-pf').removeClass('hidden');
+        $panel.find('.drawer-pf-loading').addClass('hidden');
+        $(panel.parentElement).find('.panel-counter').text('0 New Events');
+        if ($('.drawer-pf .panel-collapse .unread').length === 0) {
+          // TODO: remove badge for unread indicator
+        }
+      });
+
+      $panel.find('.drawer-pf-notification').each(function (index, notification) {
+        var $notification = $(notification);
+        $notification.on('click', '.drawer-pf-notification-content', function() {
+          $notification.removeClass('unread');
+          var unreadCount = $panel.find('.drawer-pf-notification.unread').length;
+          $(panel.parentElement).find('.panel-counter').text(unreadCount + ' New Event' + (unreadCount !== 1 ? 's' : ''));
+          if (unreadCount === 0) {
+            $panel.find('.drawer-pf-action [data-toggle="mark-all-read"]').remove();
+            if ($('.drawer-pf .panel-collapse .unread').length === 0) {
+              // TODO: remove badge for unread indicator
+            }
+          }
+        });
       });
     });
 


### PR DESCRIPTION
Implementation of
https://github.com/patternfly/patternfly-design/pull/297

## Description
This PR add implementations for the notification drawer updates:
  - Close button for the notifications drawer
  - Mark All Read and Clear All in one horizontal area
  - Hide Mark All Read button when there are no unread notifications
  - Use the empty state pattern when there are no notifications

## View and test at:
  - http://rawgit.com/jeff-phillips-18/patternfly/notifications-dist/dist/tests/notification-drawer-horizontal-nav.html
  - http://rawgit.com/jeff-phillips-18/patternfly/notifications-dist/dist/tests/notification-drawer-vertical-nav.html

@beanh66 @serenamarie125 @jennyhaines
