### PR TITLE
Exposed the local grunt command via an npm run script

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "test": "grunt karma",
     "build": "grunt build",
     "jekyll": "ruby --version || echo \"Ruby required\"; bundler -v || gem install bundler; bundle check || bundle install; set -e",
-    "start": "npm run build; grunt server & open http://localhost:9000"
+    "start": "npm run build; grunt server & open http://localhost:9000",
+    "grunt": "grunt"
   },
   "description": "This reference implementation of PatternFly is based on [Bootstrap v3](http://getbootstrap.com/).  Think of PatternFly as a \"skinned\" version of Bootstrap with additional components and customizations.",
   "repository": {


### PR DESCRIPTION
Exposed the local grunt command via an npm run script.  This allows one to invoke arbitrary grunt tasks without a globally installed grunt.  eg.:
`npm run grunt -- build server`
