### PR TITLE
Adds focus ring back to dropdown toggle

### DIFF
--- a/src/less/dropdowns.less
+++ b/src/less/dropdowns.less
@@ -29,6 +29,11 @@
   }
 }
 
+// Bootstrap removes the focus ring on dropdowns; this replaces it for better accessibility
+.dropdown-toggle:focus {
+  .tab-focus();
+}
+
 // The dropdown menu (ul)
 .dropdown-menu {
   // Dividers (basically an hr) within the dropdown


### PR DESCRIPTION
## Description
Bootstrap removes the focus ring from dropdown-toggle. For keyboard users, the indication of focus is then extremely subtle or non-existent. 

The tradeoff is that if the mouse user clicks the dropdown toggle a second time to dismiss the dropdown, the focus ring remains (in Chrome but not in Safari according to my tests). Some may not like the visual aspect of this.

Another possible consideration for better accessibility is to add JS that manages moving the focus to the first item in the dropdown as described [in this article](https://medium.com/@mariusc23/making-bootstrap-dropdowns-more-accessible-27b2566abdda) 

## Changes

* Dropdown toggle now shows the focus ring

## Link to rawgit and/or image

Rawgit tbd

Focus ring on dropdown toggle
![image](https://user-images.githubusercontent.com/19825616/28626652-9e0dd838-71ed-11e7-86d0-a989c430012d.png)

Focus ring on expanded dropdown
![image](https://user-images.githubusercontent.com/19825616/28626689-c1972f48-71ed-11e7-87f0-1b5a8b8ca940.png)

Focus ring on kebab
![image](https://user-images.githubusercontent.com/19825616/28626952-687eb5e2-71ee-11e7-90aa-c8e492304c6c.png)

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [ ] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
