### PR TITLE
Add css generated icon for drawer-pf-toggle-expand

### DIFF
--- a/src/less/notifications-drawer.less
+++ b/src/less/notifications-drawer.less
@@ -79,6 +79,10 @@
 }
 .drawer-pf-toggle-expand {
   left: 0;
+  &:before {
+    content: "\f100";
+    font-family: "FontAwesome";
+  }
   &:hover {
     color: @link-color;
   }


### PR DESCRIPTION
Removal of this caused a backward compatibility issue where applications would have to add ‘fa fa-angle-double-left’ when not expanded, expanded still worked fine.

@bleathem Please consider this for patch release