### PR TITLE
Add .less suffix to @import application-launcher for SASS compat

### DIFF
--- a/src/less/patternfly-additions.less
+++ b/src/less/patternfly-additions.less
@@ -24,7 +24,7 @@
 @import "variables.less";
 @import "mixins.less";
 @import "about-modal.less";
-@import "application-launcher";
+@import "application-launcher.less";
 @import "blank-slate.less";
 @import "bootstrap-combobox.less";
 @import "bootstrap-datepicker.less";


### PR DESCRIPTION
The absence of the suffix is making the automated conversion cry. It's also inconsistent with the other import calls.