### PR TITLE
Bump patternfly-eng-release version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "matchdep": "~1.0.1",
     "mz": "^2.6.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "3.26.2",
+    "patternfly-eng-release": "^3.26.6",
     "pixrem": "^3.0.1",
     "table": "3.7.9"
   },


### PR DESCRIPTION
Changes were made to the patternfly-eng-release scripts to support semantic releases. Until the PR is merged, Travis will fail because it does not have the latest scripts.

See: https://github.com/patternfly/patternfly/pull/701