### PR TITLE
adds page for app launcher example in vertical navigation

### DIFF
--- a/src/less/application-launcher.less
+++ b/src/less/application-launcher.less
@@ -98,17 +98,19 @@
 
 }//.applauncher-pf
 
+.navbar-utility .applauncher-pf {
+    .dropdown-menu {
+      border-width: @applauncher-pf-menu-link-border-width !important;
+      @media (min-width: @screen-sm-min) {
+              margin-top: 3px;
+              right:0;
+            }
+    }//.dropdown-menu
+}
 
 .navbar-pf, .navbar-pf-alt {
 
   .navbar-utility .applauncher-pf, .applauncher-pf {
-    .dropdown-menu {
-      border-width: @applauncher-pf-menu-link-border-width !important;
-      @media (min-width: @screen-sm-min) {
-              margin-top: 11px;
-            }
-
-    }//.dropdown-menu
 
     &.open > a,
         &.open > a:focus {
@@ -199,7 +201,7 @@
     .dropdown-toggle {
 
       @media (min-width: @screen-sm-min) {
-        padding: 15px;
+        padding: 22px 10px;
         line-height: inherit;
       }
     }

--- a/tests/pages/_includes/widgets/layouts/navbar-vertical.html
+++ b/tests/pages/_includes/widgets/layouts/navbar-vertical.html
@@ -12,7 +12,9 @@
   </div>
   <nav class="collapse navbar-collapse">
     <ul class="nav navbar-nav navbar-right navbar-iconic navbar-utility">
-      
+      {% if page.applauncher %}
+        {% include widgets/navigation/application-launcher-vertical.html %}
+      {% endif %}
       <li class="dropdown">
         <a class="dropdown-toggle nav-item-iconic" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
           <span title="Help" class="fa pficon-help"></span>

--- a/tests/pages/_includes/widgets/navigation/application-launcher-horizontal.html
+++ b/tests/pages/_includes/widgets/navigation/application-launcher-horizontal.html
@@ -1,0 +1,421 @@
+<h2>Grid Menu</h2>
+
+<h3>Icons</h3>
+
+<nav class="navbar navbar-default navbar-pf" role="navigation">
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+    <a class="navbar-brand" href="/">
+      <img src="{{site.baseurl}}/{{site.navbar-brand-icon}}" alt="{{ site.title-product }}" />
+    </a>
+  </div>
+  <div class="collapse navbar-collapse navbar-collapse-1">
+    <ul class="nav navbar-nav navbar-utility">
+
+      <li class="applauncher-pf applauncher-pf-block-list dropdown dropdown-kebab-pf">
+        <a class="dropdown-toggle drawer-pf-trigger-icon" data-toggle="dropdown" href="#">
+          <i class="fa fa-th applauncher-pf-icon" aria-hidden="true"></i>
+          <span class="applauncher-pf-title">
+            Application Launcher
+            <span class="caret" aria-hidden="true"></span>
+          </span>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-right" role="menu">
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <i class="applauncher-pf-link-icon pficon pficon-storage-domain" aria-hidden="true"></i>
+              <span class="applauncher-pf-link-title">Recteque</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <i class="applauncher-pf-link-icon pficon pficon-storage-domain" aria-hidden="true"></i>
+              <span class="applauncher-pf-link-title">Recteque</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <i class="applauncher-pf-link-icon pficon pficon-build" aria-hidden="true"></i>
+              <span class="applauncher-pf-link-title">Suavitate</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <i class="applauncher-pf-link-icon pficon pficon-domain" aria-hidden="true"></i>
+              <span class="applauncher-pf-link-title">Lorem</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <i class="applauncher-pf-link-icon pficon pficon-home" aria-hidden="true"></i>
+              <span class="applauncher-pf-link-title">Home</span>
+            </a>
+          </li>
+        </ul>
+      </li>
+
+      <li>
+        <a href="#">Status</a>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          <span class="pficon pficon-user"></span>
+          Brian Johnson <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li>
+            <a href="#">Link</a>
+          </li>
+          <li>
+            <a href="#">Another link</a>
+          </li>
+          <li>
+            <a href="#">Something else here</a>
+          </li>
+          <li class="divider"></li>
+          <li class="dropdown-submenu">
+            <a tabindex="-1" href="#">More options</a>
+            <ul class="dropdown-menu">
+              <li>
+                <a href="#">Link</a>
+              </li>
+              <li>
+                <a href="#">Another link</a>
+              </li>
+              <li>
+                <a href="#">Something else here</a>
+              </li>
+              <li class="divider"></li>
+              <li class="dropdown-header">Nav header</li>
+              <li>
+                <a href="#">Separated link</a>
+              </li>
+              <li class="divider"></li>
+              <li>
+                <a href="#">One more separated link</a>
+              </li>
+            </ul>
+          </li>
+          <li class="divider"></li>
+          <li>
+            <a href="#">One more separated link</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+<h3>No Icons</h3>
+
+<nav class="navbar navbar-default navbar-pf" role="navigation">
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+    <a class="navbar-brand" href="/">
+      <img src="{{site.baseurl}}/{{site.navbar-brand-icon}}" alt="{{ site.title-product }}" />
+    </a>
+  </div>
+  <div class="collapse navbar-collapse navbar-collapse-1">
+    <ul class="nav navbar-nav navbar-utility">
+
+      <li class="applauncher-pf applauncher-pf-block-list dropdown dropdown-kebab-pf">
+        <a class="dropdown-toggle drawer-pf-trigger-icon" data-toggle="dropdown" href="#">
+          <i class="fa fa-th applauncher-pf-icon" aria-hidden="true"></i>
+          <span class="applauncher-pf-title">
+            Application Launcher
+            <span class="caret" aria-hidden="true"></span>
+          </span>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-right" role="menu">
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <span class="applauncher-pf-link-title">Recteque</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <span class="applauncher-pf-link-title">Suavitate</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <span class="applauncher-pf-link-title">Lorem</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <span class="applauncher-pf-link-title">Home</span>
+            </a>
+          </li>
+        </ul>
+      </li>
+
+      <li>
+        <a href="#">Status</a>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          <span class="pficon pficon-user"></span>
+          Brian Johnson <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li>
+            <a href="#">Link</a>
+          </li>
+          <li>
+            <a href="#">Another link</a>
+          </li>
+          <li>
+            <a href="#">Something else here</a>
+          </li>
+          <li class="divider"></li>
+          <li class="dropdown-submenu">
+            <a tabindex="-1" href="#">More options</a>
+            <ul class="dropdown-menu">
+              <li>
+                <a href="#">Link</a>
+              </li>
+              <li>
+                <a href="#">Another link</a>
+              </li>
+              <li>
+                <a href="#">Something else here</a>
+              </li>
+              <li class="divider"></li>
+              <li class="dropdown-header">Nav header</li>
+              <li>
+                <a href="#">Separated link</a>
+              </li>
+              <li class="divider"></li>
+              <li>
+                <a href="#">One more separated link</a>
+              </li>
+            </ul>
+          </li>
+          <li class="divider"></li>
+          <li>
+            <a href="#">One more separated link</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+<h2>List Menu</h2>
+<h3>Icons</h3>
+
+<nav class="navbar navbar-default navbar-pf" role="navigation">
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+    <a class="navbar-brand" href="/">
+      <img src="{{site.baseurl}}/{{site.navbar-brand-icon}}" alt="{{ site.title-product }}" />
+    </a>
+  </div>
+  <div class="collapse navbar-collapse navbar-collapse-1">
+    <ul class="nav navbar-nav navbar-utility">
+
+      <li class="applauncher-pf dropdown dropdown-kebab-pf">
+        <a class="dropdown-toggle drawer-pf-trigger-icon" data-toggle="dropdown" href="#">
+          <i class="fa fa-th applauncher-pf-icon" aria-hidden="true"></i>
+          <span class="applauncher-pf-title">
+            Application Launcher
+            <span class="caret" aria-hidden="true"></span>
+          </span>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-right" role="menu">
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <i class="applauncher-pf-link-icon pficon pficon-storage-domain" aria-hidden="true"></i>
+              <span class="applauncher-pf-link-title">Recteque</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <!-- Placeholder left to maintain spacing -->
+              <i class="applauncher-pf-link-icon" aria-hidden="true"></i>
+              <span class="applauncher-pf-link-title">Suavitate</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <i class="applauncher-pf-link-icon pficon pficon-domain" aria-hidden="true"></i>
+              <span class="applauncher-pf-link-title">Lorem</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <i class="applauncher-pf-link-icon pficon pficon-home" aria-hidden="true"></i>
+              <span class="applauncher-pf-link-title">Home</span>
+            </a>
+          </li>
+        </ul>
+      </li>
+
+      <li>
+        <a href="#">Status</a>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          <span class="pficon pficon-user"></span>
+          Brian Johnson <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li>
+            <a href="#">Link</a>
+          </li>
+          <li>
+            <a href="#">Another link</a>
+          </li>
+          <li>
+            <a href="#">Something else here</a>
+          </li>
+          <li class="divider"></li>
+          <li class="dropdown-submenu">
+            <a tabindex="-1" href="#">More options</a>
+            <ul class="dropdown-menu">
+              <li>
+                <a href="#">Link</a>
+              </li>
+              <li>
+                <a href="#">Another link</a>
+              </li>
+              <li>
+                <a href="#">Something else here</a>
+              </li>
+              <li class="divider"></li>
+              <li class="dropdown-header">Nav header</li>
+              <li>
+                <a href="#">Separated link</a>
+              </li>
+              <li class="divider"></li>
+              <li>
+                <a href="#">One more separated link</a>
+              </li>
+            </ul>
+          </li>
+          <li class="divider"></li>
+          <li>
+            <a href="#">One more separated link</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+<h3>No Icons</h3>
+
+<nav class="navbar navbar-default navbar-pf" role="navigation">
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+    <a class="navbar-brand" href="/">
+      <img src="{{site.baseurl}}/{{site.navbar-brand-icon}}" alt="{{ site.title-product }}" />
+    </a>
+  </div>
+  <div class="collapse navbar-collapse navbar-collapse-1">
+    <ul class="nav navbar-nav navbar-utility">
+
+      <li class="applauncher-pf dropdown dropdown-kebab-pf">
+        <a class="dropdown-toggle drawer-pf-trigger-icon" data-toggle="dropdown" href="#">
+          <i class="fa fa-th applauncher-pf-icon" aria-hidden="true"></i>
+          <span class="applauncher-pf-title">
+            Application Launcher
+            <span class="caret" aria-hidden="true"></span>
+          </span>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-right" role="menu">
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <span class="applauncher-pf-link-title">Recteque</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <span class="applauncher-pf-link-title">Suavitate</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <span class="applauncher-pf-link-title">Lorem</span>
+            </a>
+          </li>
+          <li class="applauncher-pf-item" role="menuitem">
+            <a class="applauncher-pf-link" href="#">
+              <span class="applauncher-pf-link-title">Home</span>
+            </a>
+          </li>
+        </ul>
+      </li>
+
+      <li>
+        <a href="#">Status</a>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          <span class="pficon pficon-user"></span>
+          Brian Johnson <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li>
+            <a href="#">Link</a>
+          </li>
+          <li>
+            <a href="#">Another link</a>
+          </li>
+          <li>
+            <a href="#">Something else here</a>
+          </li>
+          <li class="divider"></li>
+          <li class="dropdown-submenu">
+            <a tabindex="-1" href="#">More options</a>
+            <ul class="dropdown-menu">
+              <li>
+                <a href="#">Link</a>
+              </li>
+              <li>
+                <a href="#">Another link</a>
+              </li>
+              <li>
+                <a href="#">Something else here</a>
+              </li>
+              <li class="divider"></li>
+              <li class="dropdown-header">Nav header</li>
+              <li>
+                <a href="#">Separated link</a>
+              </li>
+              <li class="divider"></li>
+              <li>
+                <a href="#">One more separated link</a>
+              </li>
+            </ul>
+          </li>
+          <li class="divider"></li>
+          <li>
+            <a href="#">One more separated link</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>

--- a/tests/pages/_includes/widgets/navigation/application-launcher-page.html
+++ b/tests/pages/_includes/widgets/navigation/application-launcher-page.html
@@ -1,7 +1,9 @@
-{% include widgets/navigation/application-launcher.html %}
+{% include widgets/navigation/application-launcher-horizontal.html %}
 <script>
   $(document).ready(function() {
 
     $('.applauncher-pf .dropdown-toggle').eq(0).click();
+    // Initialize the vertical navigation
+    $().setupVerticalNavigation(true);
   });
 </script>

--- a/tests/pages/_includes/widgets/navigation/application-launcher-vertical.html
+++ b/tests/pages/_includes/widgets/navigation/application-launcher-vertical.html
@@ -1,0 +1,41 @@
+<li class="applauncher-pf applauncher-pf-block-list dropdown dropdown-kebab-pf">
+  <a class="dropdown-toggle nav-item-iconic" data-toggle="dropdown" href="#">
+    <i class="fa fa-th applauncher-pf-icon" aria-hidden="true"></i>
+    <span class="applauncher-pf-title">
+      Application Launcher
+      <span class="caret" aria-hidden="true"></span>
+    </span>
+  </a>
+  <ul class="dropdown-menu dropdown-menu-right" role="menu">
+    <li class="applauncher-pf-item" role="menuitem">
+      <a class="applauncher-pf-link" href="#">
+        <i class="applauncher-pf-link-icon pficon pficon-storage-domain" aria-hidden="true"></i>
+        <span class="applauncher-pf-link-title">Recteque</span>
+      </a>
+    </li>
+    <li class="applauncher-pf-item" role="menuitem">
+      <a class="applauncher-pf-link" href="#">
+        <i class="applauncher-pf-link-icon pficon pficon-storage-domain" aria-hidden="true"></i>
+        <span class="applauncher-pf-link-title">Recteque</span>
+      </a>
+    </li>
+    <li class="applauncher-pf-item" role="menuitem">
+      <a class="applauncher-pf-link" href="#">
+        <i class="applauncher-pf-link-icon pficon pficon-build" aria-hidden="true"></i>
+        <span class="applauncher-pf-link-title">Suavitate</span>
+      </a>
+    </li>
+    <li class="applauncher-pf-item" role="menuitem">
+      <a class="applauncher-pf-link" href="#">
+        <i class="applauncher-pf-link-icon pficon pficon-domain" aria-hidden="true"></i>
+        <span class="applauncher-pf-link-title">Lorem</span>
+      </a>
+    </li>
+    <li class="applauncher-pf-item" role="menuitem">
+      <a class="applauncher-pf-link" href="#">
+        <i class="applauncher-pf-link-icon pficon pficon-home" aria-hidden="true"></i>
+        <span class="applauncher-pf-link-title">Home</span>
+      </a>
+    </li>
+  </ul>
+</li>

--- a/tests/pages/_includes/widgets/navigation/vertical-navigation.html
+++ b/tests/pages/_includes/widgets/navigation/vertical-navigation.html
@@ -56,7 +56,47 @@
         <span class="list-group-item-value">Lorem</span>
       </a>
     </li>
-
+    {% if page.applauncher %}
+    <li class="list-group-item secondary-nav-item-pf mobile-nav-item-pf visible-xs-block" data-target="#amet-secondary">
+      <a>
+        <span class="fa fa-th applauncher-pf-icon" data-toggle="tooltip" title="" data-original-title="Amet"></span>
+        <span class="list-group-item-value">App Launcher</span>
+      </a>
+      <div id="applauncher-secondary" class="nav-pf-secondary-nav">
+        <div class="nav-item-pf-header">
+          <a class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
+          <span>App Launcher</span>
+        </div>
+        <ul class="list-group">
+          <li class="list-group-item">
+            <a>
+              <span class="list-group-item-value">Recteque</span>
+            </a>
+          </li>
+          <li class="list-group-item">
+            <a>
+              <span class="list-group-item-value">Recteque</span>
+            </a>
+          </li>
+          <li class="list-group-item">
+            <a>
+              <span class="list-group-item-value">Suavitate</span>
+            </a>
+          </li>
+          <li class="list-group-item">
+            <a>
+              <span class="list-group-item-value">Lorem</span>
+            </a>
+          </li>
+          <li class="list-group-item">
+            <a>
+              <span class="list-group-item-value">Home</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </li>
+    {% endif %}
     <li class="list-group-item secondary-nav-item-pf mobile-nav-item-pf visible-xs-block" data-target="#amet-secondary">
       <a>
         <span class="pficon pficon-user" data-toggle="tooltip" title="" data-original-title="User"></span>
@@ -83,7 +123,6 @@
         </ul>
       </div>
     </li>
-
     <li class="list-group-item secondary-nav-item-pf mobile-nav-item-pf visible-xs-block" data-target="#amet-secondary">
       <a>
         <span class="pficon pficon-help" data-toggle="tooltip" title="" data-original-title="Amet"></span>

--- a/tests/pages/application-launcher-nav-horizontal.html
+++ b/tests/pages/application-launcher-nav-horizontal.html
@@ -3,6 +3,7 @@ categories: [Navigation]
 css-extra: false
 layout: page
 resource: true
+horizontal : true
 title: Application Launcher for Horizontal Navigation
 ---
 

--- a/tests/pages/application-launcher-nav-vertical.html
+++ b/tests/pages/application-launcher-nav-vertical.html
@@ -1,0 +1,12 @@
+---
+categories: [Navigation]
+css-extra: false
+layout: layout-fixed
+resource: true
+full-page: true
+applauncher: true
+submenus: true
+title: Application Launcher for Vertical Navigation
+url-js-extra: ['//cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.2/jquery.matchHeight-min.js', '//cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.js', '//cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js']
+---
+{% include widgets/navigation/vertical-navigation.html %}


### PR DESCRIPTION
## Description

This adds an example of what the application launcher would look like with the vertical navigation.

The one thing to note is with the vertical nav example I did not include variations of the app launcher. This didn't seem necessary considering the layout required with pages showing vertical navigation examples.

It is related to the original work done for the app launcher here:
https://patternfly.atlassian.net/browse/PTNFLY-2372

## Changes

I've created horizontal and vertical specific pages where as before it was defaulted to horizontal but was not specifically named that way.

## Link to rawgit and/or image

https://rawgit.com/matthewcarleton/patternfly/app-launcher-vertical-dist/dist/tests/application-launcher-nav-vertical.html


## PR checklist (if relevant)

- [x] **Cross browser**: works in IE9
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [x] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.