### PR TITLE
Semantic release: bump patternfly-eng-release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "matchdep": "~1.0.1",
     "mz": "^2.6.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "^3.26.26",
+    "patternfly-eng-release": "^3.26.27",
     "pixrem": "^3.0.1",
     "table": "3.7.9",
     "semantic-release": "^6.3.6"


### PR DESCRIPTION
Bump patternfly-eng-release version. 

Need the latest script fixes to correctly pull the version from package.json in order to update bower.json and patternfly-settings-base.json.