### PR TITLE
bumped patternfly-eng-release to allow bower.json push

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "matchdep": "~1.0.1",
     "mz": "^2.6.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "^3.26.27",
+    "patternfly-eng-release": "^3.26.28",
     "pixrem": "^3.0.1",
     "table": "3.7.9",
     "semantic-release": "^6.3.6"


### PR DESCRIPTION
bumped patternfly-eng-release. 

A small change was necessary to allow patternfly-eng-release scripts to push bower.json to master-dist.
