### PR TITLE
Semantic release: bump patternfly-eng-release to skip npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "matchdep": "~1.0.1",
     "mz": "^2.6.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "^3.26.28",
+    "patternfly-eng-release": "^3.26.29",
     "pixrem": "^3.0.1",
     "table": "3.7.9",
     "semantic-release": "^6.3.6"


### PR DESCRIPTION
Modified patternfly-eng-release to add an indicator when bower.json is bumped. This ensures Travis skips 'npm publish' and runs that only during the next master-dist build.
