### PR TITLE
feat(chart): Utilization Donut Chart Component

### DIFF
--- a/src/less/charts.less
+++ b/src/less/charts.less
@@ -95,3 +95,31 @@
     stroke-width: 1px;
   }
 }
+
+.pct-donut-chart-pf {
+
+  .pct-donut-chart-pf-label {
+    display: block;
+  }
+
+  &.pct-donut-chart-pf-left,
+  &.pct-donut-chart-pf-right,
+  .pct-donut-chart-pf-left,
+  .pct-donut-chart-pf-right {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &.pct-donut-chart-pf-left,
+  &.pct-donut-chart-pf-right {
+    display: inline-flex;
+  }
+
+  &.pct-donut-chart-pf-left,
+  .pct-donut-chart-pf-left {
+    flex-direction: row-reverse;
+  }
+}
+

--- a/tests/pages/_includes/widgets/charts/donut-utilization.html
+++ b/tests/pages/_includes/widgets/charts/donut-utilization.html
@@ -1,9 +1,71 @@
-<div id="{{include.id}}" class="example-donut-chart-utilization"></div>
+<div id="{{include.id1}}" class="example-donut-chart-utilization"></div>
+
+<div class="pct-donut-chart-pf example-donut-chart-utilization">
+  <span class="pct-donut-chart-pf-chart">
+    <span id="{{include.id2}}"></span>
+  </span>
+  <span class="pct-donut-chart-pf-label">
+    60 MHz of 100 MHz used
+  </span>
+</div>
+
+<div class="example-donut-chart-utilization">
+  <span class="pct-donut-chart-pf pct-donut-chart-pf-left">
+    <span class="pct-donut-chart-pf-chart">
+      <span id="{{include.id3}}"></span>
+    </span>
+    <span class="pct-donut-chart-pf-label text-right">
+      60 MHz of 100 MHz used
+    </span>
+  </span>
+</div>
+
+<div class="example-donut-chart-utilization">
+  <span class="pct-donut-chart-pf pct-donut-chart-pf-right">
+    <span class="pct-donut-chart-pf-chart">
+      <span id="{{include.id4}}"></span>
+    </span>
+    <span class="pct-donut-chart-pf-label text-left">
+      60 MHz of 100 MHz
+    </span>
+  </span>
+</div>
+
 <script>
   var c3ChartDefaults = $().c3ChartDefaults();
-  var utilizationDonutChartConfig = c3ChartDefaults.getDefaultDonutConfig('A');
-  utilizationDonutChartConfig.bindto = '#{{include.id}}';
-  utilizationDonutChartConfig.data = {
+
+  // Donut configuration 1
+  var donutConfig1 = c3ChartDefaults.getDefaultDonutConfig('A');
+
+  donutConfig1.bindto = '#{{include.id1}}';
+  donutConfig1.data = {
+    type: "donut",
+    columns: [
+      ["Used", 60],
+      ["Available", 40],
+    ],
+    groups: [
+      ["used", "available"]
+    ],
+    order: null
+  };
+  donutConfig1.size = {
+    width: 180,
+    height: 180
+  };
+
+  donutConfig1.tooltip = {
+    contents: $().pfGetUtilizationDonutTooltipContentsFn('MHz')
+  };
+
+  c3.generate(donutConfig1);
+  $().pfSetDonutChartTitle("#{{include.id1}}", "60", "MHz Used");
+
+  // Donut configuration 2
+  var donutConfig2 = c3ChartDefaults.getDefaultDonutConfig('A');
+
+  donutConfig2.bindto = '#{{include.id2}}';
+  donutConfig2.data = {
     type: "donut",
     columns: [
       ["Used", 60],
@@ -14,14 +76,69 @@
     ],
     order: null
   };
-  utilizationDonutChartConfig.size = {
-    width: 200,
-    height: 171
+  donutConfig2.size = {
+    width: 180,
+    height: 180
   };
 
-  utilizationDonutChartConfig.tooltip = {
+  donutConfig2.tooltip = {
     contents: $().pfGetUtilizationDonutTooltipContentsFn('MHz')
   };
-  var utilizationDonutChart = c3.generate(utilizationDonutChartConfig);
-  $().pfSetDonutChartTitle("#{{include.id}}", "60", "MHz Used");
+
+  c3.generate(donutConfig2);
+  $().pfSetDonutChartTitle("#{{include.id2}}", "60", "MHz Used");
+
+  // Donut configuration 3
+  var donutConfig3 = c3ChartDefaults.getDefaultDonutConfig('A');
+
+  donutConfig3.bindto = '#{{include.id3}}';
+  donutConfig3.data = {
+    type: "donut",
+    columns: [
+      ["Used", 60],
+      ["Available", 40]
+    ],
+    groups: [
+      ["used", "available"]
+    ],
+    order: null
+  };
+  donutConfig3.size = {
+    width: 140,
+    height: 140
+  };
+
+  donutConfig3.tooltip = {
+    contents: $().pfGetUtilizationDonutTooltipContentsFn('MHz')
+  };
+
+  c3.generate(donutConfig3);
+  $().pfSetDonutChartTitle("#{{include.id3}}", "60", "MHz Used");
+
+  // Donut configuration 4
+  var donutConfig4 = c3ChartDefaults.getDefaultDonutConfig('A');
+
+  donutConfig4.bindto = '#{{include.id4}}';
+  donutConfig4.data = {
+    type: "donut",
+    columns: [
+      ["Used", 60],
+      ["Available", 40]
+    ],
+    groups: [
+      ["used", "available"]
+    ],
+    order: null
+  };
+  donutConfig4.size = {
+    width: 140,
+    height: 140
+  };
+
+  donutConfig4.tooltip = {
+    contents: $().pfGetUtilizationDonutTooltipContentsFn('MHz')
+  };
+
+  c3.generate(donutConfig4);
+  $().pfSetDonutChartTitle("#{{include.id4}}", "60", "MHz Used");
 </script>

--- a/tests/pages/donut-charts.html
+++ b/tests/pages/donut-charts.html
@@ -29,8 +29,8 @@ url-js-extra: ['//cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.js', '//cdnjs.
 </style>
 <div>
   <h2>Donut Chart - Utilization</h2>
-  <div>
-    {% include widgets/charts/donut-utilization.html id="utilizationDonutChart" %}
+  <div class="text-center">
+    {% include widgets/charts/donut-utilization.html id1="utilizationDonutChart" id2="utilizationDonutChart2" id3="utilizationDonutChart3" id4="utilizationDonutChart4" %}
   </div>
   <h2>Donut Chart - Relationship to a Whole</h2>
   <div>


### PR DESCRIPTION
## Description
Enhancement for utilization donut chart component. 

Related to [Angular Pf PR 570](https://github.com/patternfly/angular-patternfly/pull/570), closes #718 

## Changes

List of updates

* Removes the Pct Donut Less from Angular Pf, and adds it into ```charts.less```

## Link to rawgit and/or image

[Display within core Patternfly with RawGit](https://rawgit.com/cdcabrera/patternfly/feature-utilization-dist/dist/tests/donut-charts.html)

Display within Angular Pf
![Angular Pf](https://user-images.githubusercontent.com/3761375/29289937-62512542-810c-11e7-8d80-c13b92adb79a.png)

## PR checklist (if relevant)

- ~~[ ] **Cross browser**: works in IE9~~ EDIT: Use of flexbox
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
