### PR TITLE
adds href to vertical nav

### DIFF
--- a/src/less/vertical-nav.less
+++ b/src/less/vertical-nav.less
@@ -72,7 +72,6 @@
       font-weight: @nav-pf-vertical-font-weight;
       height: @nav-pf-vertical-link-height;
       line-height: 26px;
-      outline: 0;
       padding: @nav-pf-vertical-link-padding;
       position: relative;
       white-space: nowrap;

--- a/tests/pages/_includes/widgets/navigation/secondary-nav-amet.html
+++ b/tests/pages/_includes/widgets/navigation/secondary-nav-amet.html
@@ -1,11 +1,11 @@
 <div id="amet-secondary" class="nav-pf-secondary-nav">
   <div class="nav-item-pf-header">
-    <a class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
+    <a href="#0" class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
     <span>Amet</span>
   </div>
   <ul class="list-group">
     <li class="list-group-item {% if page.nav-tertiary %}tertiary-nav-item-pf{% endif %}" data-target="#amet-detracto-tertiary">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Detracto Suscipiantur</span>
         {% if page.nav-tertiary %}{% else %}
         {% if page.nav-badges %}
@@ -27,7 +27,7 @@
       {% endif %}
     </li>
     <li class="list-group-item {% if page.nav-tertiary %}tertiary-nav-item-pf{% endif %}" data-target="#amet-mediocrem-tertiary">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Mediocrem</span>
         {% if page.nav-tertiary %}{% else %}
         {% if page.nav-badges %}
@@ -45,7 +45,7 @@
       {% endif %}
     </li>
     <li class="list-group-item {% if page.nav-tertiary %}tertiary-nav-item-pf{% endif %}" data-target="#amet-corrumpit-tertiary">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Corrumpit Cupidatat Proident Deserunt</span>
         {% if page.nav-tertiary %}{% else %}
         {% if page.nav-badges %}
@@ -67,7 +67,7 @@
     </li>
     {% if page.nav-tertiary %}
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Urbanitas Habitant Morbi Tristique</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">

--- a/tests/pages/_includes/widgets/navigation/secondary-nav-ipsum.html
+++ b/tests/pages/_includes/widgets/navigation/secondary-nav-ipsum.html
@@ -1,11 +1,11 @@
 <div id="-secondary" class="nav-pf-secondary-nav">
   <div class="nav-item-pf-header">
-    <a class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
+    <a href="#0" class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
     <span>Ipsum</span>
   </div>
   <ul class="list-group">
     <li class="list-group-item active {% if page.nav-tertiary %}tertiary-nav-item-pf{% endif %}" data-target="#ipsum-intellegam-tertiary">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Intellegam</span>
       </a>
       {% if page.nav-tertiary %}
@@ -13,7 +13,7 @@
       {% endif %}
     </li>
     <li class="list-group-item {% if page.nav-tertiary %}tertiary-nav-item-pf{% endif %}" data-target="#ipsum-copiosae-tertiary">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Copiosae</span>
       </a>
       {% if page.nav-tertiary %}
@@ -21,7 +21,7 @@
       {% endif %}
     </li>
     <li class="list-group-item {% if page.nav-tertiary %}tertiary-nav-item-pf{% endif %}" data-target="#ipsum-patrioque-tertiary">
-      <a>
+      <a href="#0" >
         <span class="list-group-item-value">Patrioque</span>
       </a>
       {% if page.nav-tertiary %}
@@ -30,7 +30,7 @@
     </li>
     {% if page.nav-tertiary %}
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Accumsan</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">

--- a/tests/pages/_includes/widgets/navigation/tertiary-amet-corrumpit.html
+++ b/tests/pages/_includes/widgets/navigation/tertiary-amet-corrumpit.html
@@ -1,11 +1,11 @@
 <div id="amet-corrumpit-tertiary" class="nav-pf-tertiary-nav">
   <div class="nav-item-pf-header">
-    <a class="tertiary-collapse-toggle-pf" data-toggle="collapse-tertiary-nav"></a>
+    <a href="#0" class="tertiary-collapse-toggle-pf" data-toggle="collapse-tertiary-nav"></a>
     <span>Corrumpit</span>
   </div>
   <ul class="list-group">
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Aeque</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -15,7 +15,7 @@
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Delenit</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -25,7 +25,7 @@
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Qualisque</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">

--- a/tests/pages/_includes/widgets/navigation/tertiary-amet-detracto.html
+++ b/tests/pages/_includes/widgets/navigation/tertiary-amet-detracto.html
@@ -1,11 +1,11 @@
 <div id="amet-detracto-tertiary" class="nav-pf-tertiary-nav">
   <div class="nav-item-pf-header">
-    <a class="tertiary-collapse-toggle-pf" data-toggle="collapse-tertiary-nav"></a>
+    <a href="#0" class="tertiary-collapse-toggle-pf" data-toggle="collapse-tertiary-nav"></a>
     <span>Detracto</span>
   </div>
   <ul class="list-group">
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Delicatissimi</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -15,7 +15,7 @@
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Aliquam</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -25,7 +25,7 @@
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Principes</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">

--- a/tests/pages/_includes/widgets/navigation/tertiary-amet-mediocrem.html
+++ b/tests/pages/_includes/widgets/navigation/tertiary-amet-mediocrem.html
@@ -1,11 +1,11 @@
 <div id="amet-mediocrem-tertiary" class="nav-pf-tertiary-nav">
   <div class="nav-item-pf-header">
-    <a class="tertiary-collapse-toggle-pf" data-toggle="collapse-tertiary-nav"></a>
+    <a href="#0" class="tertiary-collapse-toggle-pf" data-toggle="collapse-tertiary-nav"></a>
     <span>Mediocrem</span>
   </div>
   <ul class="list-group">
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Convenire</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -15,7 +15,7 @@
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Nonumy</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -25,7 +25,7 @@
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Deserunt</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">

--- a/tests/pages/_includes/widgets/navigation/tertiary-ipsum-copiosae.html
+++ b/tests/pages/_includes/widgets/navigation/tertiary-ipsum-copiosae.html
@@ -1,11 +1,11 @@
 <div id="compute-infrastructure-tertiary" class="nav-pf-tertiary-nav">
   <div class="nav-item-pf-header">
-    <a class="tertiary-collapse-toggle-pf" data-toggle="collapse-tertiary-nav"></a>
+    <a href="#0" class="tertiary-collapse-toggle-pf" data-toggle="collapse-tertiary-nav"></a>
     <span>Copiosae</span>
   </div>
   <ul class="list-group">
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Exerci</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -15,7 +15,7 @@
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Quaeque</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -25,7 +25,7 @@
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Utroque</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">

--- a/tests/pages/_includes/widgets/navigation/tertiary-ipsum-intellegam.html
+++ b/tests/pages/_includes/widgets/navigation/tertiary-ipsum-intellegam.html
@@ -1,11 +1,11 @@
 <div id="compute-containers-tertiary" class="nav-pf-tertiary-nav">
   <div class="nav-item-pf-header">
-    <a class="tertiary-collapse-toggle-pf" data-toggle="collapse-tertiary-nav"></a>
+    <a href="#0" class="tertiary-collapse-toggle-pf" data-toggle="collapse-tertiary-nav"></a>
     <span>Intellegam</span>
   </div>
   <ul class="list-group">
     <li class="list-group-item active">
-      <a>
+      <a href="#0">
         <span id="compute-containers-users-nav-item" class="list-group-item-value">Recteque</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -22,7 +22,7 @@
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span id="compute-containers-groups-nav-item" class="list-group-item-value">Suavitate</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -39,7 +39,7 @@
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span id="compute-containers-roles-nav-item" class="list-group-item-value">Vituperatoribus</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">

--- a/tests/pages/_includes/widgets/navigation/tertiary-ipsum-patrioque.html
+++ b/tests/pages/_includes/widgets/navigation/tertiary-ipsum-patrioque.html
@@ -1,11 +1,11 @@
 <div id="compute-clouds-tertiary" class="nav-pf-tertiary-nav">
   <div class="nav-item-pf-header">
-    <a class="tertiary-collapse-toggle-pf" data-toggle="collapse-tertiary-nav"></a>
+    <a href="#0" class="tertiary-collapse-toggle-pf" data-toggle="collapse-tertiary-nav"></a>
     <span>Patrioque</span>
   </div>
   <ul class="list-group">
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Novum</span>
         {% if page.nav-badges %}
         <div class="badge-container-pf">
@@ -15,12 +15,12 @@
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Pericula</span>
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="list-group-item-value">Gubergren</span>
       </a>
     </li>

--- a/tests/pages/_includes/widgets/navigation/vertical-navigation.html
+++ b/tests/pages/_includes/widgets/navigation/vertical-navigation.html
@@ -10,13 +10,13 @@
      {% if page.nav-badges %}nav-pf-vertical-with-badges{% endif %}">
   <ul class="list-group">
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="fa fa-dashboard" data-toggle="tooltip" title="Dashboard"></span>
         <span class="list-group-item-value">Dashboard</span>
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="fa fa-shield" data-toggle="tooltip" title="Dolor"></span>
         <span class="list-group-item-value">Dolor</span>
         {% if page.nav-badges %}
@@ -27,7 +27,7 @@
       </a>
     </li>
     <li class="list-group-item active {% if page.submenus %}secondary-nav-item-pf{% endif %}" data-target="#ipsum-secondary">
-      <a>
+      <a href="#0">
         <span class="fa fa-space-shuttle" data-toggle="tooltip" title="Ipsum"></span>
         <span class="list-group-item-value">Ipsum</span>
       </a>
@@ -36,7 +36,7 @@
       {% endif %}
     </li>
     <li class="list-group-item {% if page.submenus %}secondary-nav-item-pf{% endif %}" data-target="#amet-secondary">
-      <a>
+      <a href="#0">
         <span class="fa fa-paper-plane" data-toggle="tooltip" title="Amet"></span>
         <span class="list-group-item-value">Amet</span>
       </a>
@@ -45,51 +45,51 @@
       {% endif %}
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="fa fa-graduation-cap" data-toggle="tooltip" title="Adipscing"></span>
         <span class="list-group-item-value">Adipscing</span>
       </a>
     </li>
     <li class="list-group-item">
-      <a>
+      <a href="#0">
         <span class="fa fa-gamepad" data-toggle="tooltip" title="Lorem"></span>
         <span class="list-group-item-value">Lorem</span>
       </a>
     </li>
     {% if page.applauncher %}
     <li class="list-group-item secondary-nav-item-pf mobile-nav-item-pf visible-xs-block">
-      <a>
+      <a href="#0">
         <span class="fa fa-th applauncher-pf-icon" data-toggle="tooltip" title="" data-original-title="App Launcher"></span>
         <span class="list-group-item-value">App Launcher</span>
       </a>
       <div id="applauncher-secondary" class="nav-pf-secondary-nav">
         <div class="nav-item-pf-header">
-          <a class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
+          <a href="#0" class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
           <span>App Launcher</span>
         </div>
         <ul class="list-group">
           <li class="list-group-item">
-            <a>
+            <a href="#0">
               <span class="list-group-item-value">Recteque</span>
             </a>
           </li>
           <li class="list-group-item">
-            <a>
+            <a href="#0">
               <span class="list-group-item-value">Recteque</span>
             </a>
           </li>
           <li class="list-group-item">
-            <a>
+            <a href="#0">
               <span class="list-group-item-value">Suavitate</span>
             </a>
           </li>
           <li class="list-group-item">
-            <a>
+            <a href="#0">
               <span class="list-group-item-value">Lorem</span>
             </a>
           </li>
           <li class="list-group-item">
-            <a>
+            <a href="#0">
               <span class="list-group-item-value">Home</span>
             </a>
           </li>
@@ -98,25 +98,25 @@
     </li>
     {% endif %}
     <li class="list-group-item secondary-nav-item-pf mobile-nav-item-pf visible-xs-block">
-      <a>
+      <a href="#0">
         <span class="pficon pficon-user" data-toggle="tooltip" title="" data-original-title="User"></span>
         <span class="list-group-item-value">User</span>
       </a>
       <div id="user-secondary" class="nav-pf-secondary-nav">
         <div class="nav-item-pf-header">
-          <a class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
+          <a href="#0" class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
           <span>User</span>
         </div>
 
         <ul class="list-group">
           <li class="list-group-item">
-            <a>
+            <a href="#0">
               <span class="list-group-item-value">Preferences</span>
             </a>
           </li>
 
           <li class="list-group-item">
-            <a>
+            <a href="#0">
               <span class="list-group-item-value">Logout</span>
             </a>
           </li>
@@ -124,23 +124,23 @@
       </div>
     </li>
     <li class="list-group-item secondary-nav-item-pf mobile-nav-item-pf visible-xs-block" data-target="#amet-secondary">
-      <a>
+      <a href="#0">
         <span class="pficon pficon-help" data-toggle="tooltip" title="" data-original-title="Help"></span>
         <span class="list-group-item-value">Help</span>
       </a>
       <div id="help-secondary" class="nav-pf-secondary-nav">
         <div class="nav-item-pf-header">
-          <a class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
+          <a href="#0" class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
           <span>Help</span>
         </div>
         <ul class="list-group">
           <li class="list-group-item">
-            <a>
+            <a href="#0">
               <span class="list-group-item-value">Help</span>
             </a>
           </li>
           <li class="list-group-item">
-            <a>
+            <a href="#0">
               <span class="list-group-item-value">About</span>
             </a>
           </li>


### PR DESCRIPTION
## Description
This addresses the issue of vertical nav accessibility issues raised here:

https://github.com/patternfly/patternfly/issues/723#event-1226278712

https://patternfly.atlassian.net/browse/PTNFLY-2533

This PR is only for the primary this story exist for secondary/tertiary:

https://patternfly.atlassian.net/browse/PTNFLY-2537

## Changes

This adds href="#" to all <a> tags. 

## Link to rawgit and/or image

https://rawgit.com/matthewcarleton/patternfly/vertical-nav-href-dist/dist/tests/vertical-navigation-primary-only.html

@rhamilto further testing may be required on this to ensure it meets accessibility requirements.