### PR TITLE
fix(wizard): Updates wizard to use flex box

### DIFF
--- a/src/less/wizard.less
+++ b/src/less/wizard.less
@@ -2,12 +2,6 @@
 // Wizard
 // --------------------------------------------------
 .wizard-pf {
-  @media (max-width: @screen-xs-min) {
-    min-height: 100vh;
-  }
-  @media (min-width: @screen-xs-min) {
-    height:100%;
-  }
   margin: 0 auto;
   max-height: 900px;
   padding: 10px;
@@ -33,12 +27,9 @@
   @media (min-width: @screen-xs-min) {
     background: @color-pf-black-100;
     border-right: 1px solid @color-pf-black-300;
-    bottom: 0;
-    left: 0;
+    flex:0 0 auto;
     overflow-x: hidden;
     overflow-y: auto;
-    position: absolute;
-    top: 0;
     .list-group {
       border-top: 0;
       margin-bottom: 0;
@@ -266,17 +257,13 @@
   height: 100%;
   overflow: auto;
   vertical-align: top;
-
   @media (min-width: @screen-xs-min) {
     padding:3em;
-    margin-left: 253px; /* this value is updated by js */
+    flex:1 1 auto;
   }
   @media (max-width: @screen-xs-min) {
     padding:1em;
     width:100%;
-    &[style] {
-      margin-left: 0!important; // this is to override any margin from JS
-    }
   }
   // width: 10000px;
   .blank-slate-pf {
@@ -413,12 +400,6 @@
   margin-top: 0;
   padding-bottom: 17px;
   background:@color-pf-white;
-    @media (min-width: @screen-xs-min) {
-      right: 0;
-      bottom: 0;
-      left: 0;
-      position: absolute;//this is removed for mobile to allow for pages with longer content.
-    }
   .btn-cancel {
     margin-right:25px;
   }
@@ -427,14 +408,11 @@
 .wizard-pf-row {
 
     @media (min-width: @screen-xs-min) {
-      bottom: 58px; /* this value is updated by js */
-      position: absolute;
-      overflow: hidden;
-      top: 172px; /* this value is updated by js */
       width:100%;
-
+      display: flex;
+      height: 900px;
+      max-height: 65vh;
     }
-
 }
 
 // Scale up the modal

--- a/tests/pages/_includes/widgets/communication/wizard.html
+++ b/tests/pages/_includes/widgets/communication/wizard.html
@@ -305,8 +305,7 @@
 
       // open modal
       $(self.modal).modal('show');
-      // adjust height of contents row (while steps and sidebar are hidden and loading message displays)
-      self.updateWizardLayout();
+
 
       // assign data attribute to all tabs
       $(self.modal + " .wizard-pf-sidebar .list-group-item").each(function() {
@@ -343,8 +342,7 @@
       $(self.modal + " .wizard-pf-sidebar .list-group-item.active").removeClass("active");
       // apply active class to new current tab and associated contents
       self.updateActiveTab();
-      // adjust height of contents row (while steps and sidebar and tab contents are visible)
-      self.updateWizardLayout();
+
       self.updateWizardFooterDisplay();
 
       //initialize click listeners
@@ -355,9 +353,7 @@
       self.finishBtnClick();
       self.cancelBtnClick();
 
-      $( window ).resize(function() {
-        self.updateWizardLayout();
-      });
+      
     };
 
     // update which tab group is active
@@ -411,15 +407,7 @@
       self.updateNextBtnDisplay();
     };
 
-    // adjust layout of panels in wizard
-    this.updateWizardLayout = function() {
-      var top = ($(self.modal + " .modal-header").outerHeight() + $(self.modal + " .wizard-pf-steps").outerHeight()) + "px",
-          bottom = $(self.modal + " .modal-footer").outerHeight() + "px",
-          sidebarwidth = $(self.modal + " .wizard-pf-sidebar").outerWidth() + "px";
-      $(self.modal + " .wizard-pf-row").css("top", top);
-      $(self.modal + " .wizard-pf-row").css("bottom", bottom);
-      $(self.modal + " .wizard-pf-main").css("margin-left", sidebarwidth);
-    };
+
 
     // when the user clicks a step, then the tab group for that step is displayed
     this.tabGroupSelect = function() {


### PR DESCRIPTION
## Description
This changes the Wizard layout to use flex box instead of positioning. It removes the need for JS for page layout.

https://github.com/patternfly/patternfly/issues/734


## Link to rawgit and/or image

https://rawgit.com/matthewcarleton/patternfly/wizard-flexbox-dist/dist/tests/wizard.html

## PR checklist (if relevant)

- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [x] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.