### PR TITLE
Bump patternfly-eng-release version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ before_install:
 
 install: true
 
-before_script:
- # If this command fails and you can't fix it, file an issue and add an exception to .nsprc
- - npm run nsp-check
-
 script:
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -p
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "matchdep": "~1.0.1",
     "mz": "^2.6.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "^3.26.29",
+    "patternfly-eng-release": "^3.26.35",
     "pixrem": "^3.0.1",
     "semantic-release": "^6.3.6",
     "table": "3.7.9"
@@ -78,7 +78,6 @@
     }
   },
   "scripts": {
-    "nsp-check": "nsp check",
     "test": "grunt karma",
     "build": "grunt build",
     "jekyll": "ruby --version || echo \"Ruby required\"; bundler -v || gem install bundler; bundle check || bundle install; set -e",


### PR DESCRIPTION
Backed out the recently added nsp check, which requires an npm install. Instead, the nsp check has been added back to the build scripts, which already handle the npm install.
