### PR TITLE
vertical nav: fix close-on-click hover bug

### DIFF
--- a/src/js/patternfly-functions-vertical-nav.js
+++ b/src/js/patternfly-functions-vertical-nav.js
@@ -48,6 +48,10 @@
         navElement.find('.mobile-nav-item-pf').each(function (index, item) {
           $(item).removeClass('mobile-nav-item-pf');
         });
+
+        navElement.find('.is-hover').each(function (index, item) {
+          $(item).removeClass('is-hover');
+        });
       },
 
       hideTertiaryMenu = function () {
@@ -60,6 +64,10 @@
 
         navElement.find('.mobile-nav-item-pf').each(function (index, item) {
           $(item).removeClass('mobile-nav-item-pf');
+        });
+
+        navElement.find('.is-hover').each(function (index, item) {
+          $(item).removeClass('is-hover');
         });
       },
 
@@ -449,7 +457,8 @@
           if ($this[0].navHoverTimeout !== undefined) {
             clearTimeout($this[0].navHoverTimeout);
             $this[0].navHoverTimeout = undefined;
-          } else if ($this[0].navUnHoverTimeout === undefined) {
+          } else if ($this[0].navUnHoverTimeout === undefined &&
+              navElement.find('.secondary-nav-item-pf.is-hover').length > 0) {
             $this[0].navUnHoverTimeout = setTimeout(function () {
               if (navElement.find('.secondary-nav-item-pf.is-hover').length <= 1) {
                 navElement.removeClass('hover-secondary-nav-pf');


### PR DESCRIPTION
Fix close-on-click hover bug. Previously, secondary level
nav wouldn't open on the currently selected primary option.
For example, if you selected Option One > Sub-Option One,
and then hovered again over Option One, the secondary menu
wasn't opening. Hovering over Option Two and then Option One
was a workaround.

The cause is that the navUnHoverTimeout was being started up
after a menu was closed on click. navUnHoverTimeout not being
'undefined' then prevented the secondary menu from opening.

## Description
Fixes #742 

## Changes
Only run the navUnHoverTimeout function if a secondary
menu is visible.
