### PR TITLE
Fix(notifications): enhancement:

### DIFF
--- a/src/less/navbar-vertical.less
+++ b/src/less/navbar-vertical.less
@@ -54,11 +54,16 @@
         cursor: pointer;
         font-size: (@font-size-base - 3);
         font-weight: 700;
-        margin-top: -15px;
-        margin-left: -12px;
+        left: 20px;
+        margin: 0;
         padding: 2px 4px;
+        position: absolute;
         min-width: 10px;
         min-height: 10px;
+        top: 18px;
+        &.badge-pf-bordered {
+          border: 1px solid @navbar-pf-vertical-bg-color;
+        }
       }
 
       .caret,

--- a/src/less/navbar.less
+++ b/src/less/navbar.less
@@ -58,15 +58,25 @@
  .badge {
     background-color: @notification-badge-color;
     border-radius: 20px;
-    border:1px solid @navbar-pf-bg-color; //improves visibilty at smaller size
     color: @navbar-pf-vertical-active-color;
     cursor: pointer;
     font-size: (@font-size-base - 3);
     font-weight: 700;
+    left: 26px;
+    margin: 0;
     padding: 2px 4px;
-    margin-top:-12px;
-    margin-left:-9px;
+    position: absolute;
+    min-width: 10px;
     min-height: 10px;
+    top: 6px;
+    @media(min-width: @screen-sm-min) {
+      left: auto;
+      right: 6px;
+      top: 3px;
+    }
+    &.badge-pf-bordered {
+      border: 1px solid @navbar-pf-bg-color;
+    }
 }
 
     @media (max-width: @grid-float-breakpoint-max) {

--- a/tests/pages/_includes/widgets/layouts/nav-horizontal-notification-drawer.html
+++ b/tests/pages/_includes/widgets/layouts/nav-horizontal-notification-drawer.html
@@ -15,7 +15,7 @@
       <li class="drawer-pf-trigger dropdown">
         <a class="nav-item-iconic drawer-pf-trigger-icon">
           <span class="fa fa-bell" title="Notifications"></span>
-          <span class="badge"> </span><!-- in order to show the empty badge this requires a space, otherwise add a value -->
+          <span class="badge badge-pf-bordered"> </span><!-- in order to show the empty badge this requires a space, otherwise add a value -->
         </a>
       </li>
       <li class="dropdown">

--- a/tests/pages/_includes/widgets/layouts/nav-vertical-notification-drawer.html
+++ b/tests/pages/_includes/widgets/layouts/nav-vertical-notification-drawer.html
@@ -13,7 +13,7 @@
       <li class="drawer-pf-trigger">
         <a class="nav-item-iconic">
           <span class="fa fa-bell" title="Notifications"></span>
-          <span class="badge"> </span><!-- in order to show the empty badge this requires a space, otherwise add a value -->
+          <span class="badge badge-pf-bordered"> </span><!-- in order to show the empty badge this requires a space, otherwise add a value -->
         </a>
       </li>
     </ul>
@@ -26,7 +26,7 @@
       <li class="drawer-pf-trigger">
         <a class="nav-item-iconic">
           <span class="fa fa-bell" title="Notifications"></span>
-          <span class="badge"> </span><!-- in order to show the empty badge this requires a space, otherwise add a value -->
+          <span class="badge badge-pf-bordered"> </span><!-- in order to show the empty badge this requires a space, otherwise add a value -->
         </a>
       </li>
       <li class="dropdown">


### PR DESCRIPTION
add border around notification icon badge to help distinguish when unread notifications are present by increasing contrast between icon and badge.

<img width="36" alt="screen shot 2017-09-12 at 12 46 34 pm" src="https://user-images.githubusercontent.com/1874151/30339807-3d43ba9e-97be-11e7-8f76-ba87e7bc68e1.png">

Related discussion https://github.com/openshift/origin-web-console/pull/1997#discussion_r136642925
