### PR TITLE
fix(drawer-pf-notifications): increase horizontal padding around drawer-pf-toggle-expand and drawer-pf-close controls

### DIFF
--- a/src/less/notifications-drawer.less
+++ b/src/less/notifications-drawer.less
@@ -75,7 +75,7 @@
   color: inherit;
   cursor: pointer;
   line-height: inherit;
-  padding: 2px 5px;
+  padding: 2px 10px;
   position: absolute;
   &:hover,
   &:focus {


### PR DESCRIPTION
The click target on these controls are quite small and somewhat tight next to edge of the drawer. It would be beneficial to make these slightly larger.

This commit makes the click targets 26px and moves the icons from 5px to 10px from the drawer edges.

Related discussion https://github.com/openshift/origin-web-console/pull/1997#discussion_r136642322

**Before:**
<img width="326" alt="screen shot 2017-09-12 at 1 47 10 pm" src="https://user-images.githubusercontent.com/1874151/30341969-17c91ac2-97c6-11e7-823a-1f838807dbe9.png">

<img width="366" alt="screen shot 2017-09-12 at 2 27 05 pm" src="https://user-images.githubusercontent.com/1874151/30342111-8d045266-97c6-11e7-9396-bee8f89c1c15.png">

**After:**
<img width="327" alt="screen shot 2017-09-12 at 1 46 45 pm" src="https://user-images.githubusercontent.com/1874151/30341980-200922ea-97c6-11e7-802b-e610081853bc.png">

<img width="350" alt="screen shot 2017-09-12 at 2 27 26 pm" src="https://user-images.githubusercontent.com/1874151/30342110-8cfe7fb2-97c6-11e7-9b16-1dfd38e6ca63.png">




