### PR TITLE
fix(list-pf): stop horizontal shift when list item is expanded

### DIFF
--- a/src/less/list-pf.less
+++ b/src/less/list-pf.less
@@ -45,6 +45,10 @@
   }
 }
 
+.list-pf-chevron {
+  min-width: 1.2em; // ensures that the width does not shift when the chevron is sideways
+}
+
 .list-pf-chevron,
 .list-pf-select {
   margin-right: 10px;


### PR DESCRIPTION
## Description

Sets a min-width on the chevron so that when it is turned sideways when expanded, it does not cause a horizontal shift in the line

## Changes

Adds a min-width to the .list-pf-chevron class

## Link to rawgit and/or image

See it (still broken) on the [List test page on rawgit](https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/list-pf.html)
No rawgit available showing the fix since no html file was checked in :-(

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
