### PR TITLE
Added DIST_BRANCH flag to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ notifications:
 
 env:
   global:
+  - DIST_BRANCH=true
   - PF_PAGE_BUILDER: jekyll
   - secure: KFSt/cOAh8+v9Mz9AroDg+YYGwkuXyC96ZtOMbcWxVAQzplrrpCD9zI0ZuOtKYg/YHu5mscLWbnXOzBug2J162/V9MyicETmXCdFx5ovu/5rTtbxQ6maoRWQQfcKmQVWNdUDF5rJJ7PU9H/gyXWKvbEpkfNRk6Wr7Oc3D8mYtgI=
   - secure: SBD8QHLUy1/kCZiLV2OYpqdFTQUWUfkWLx1bdtKFQhWt+aUYBTBdbbb/A7otm+LbBNe5NWWOX1lkciubEs9XlRUdQfS/WqId3c99+457NXeEPtIX6fC92/hrQITFb6vvv7T71ltUs3Q1X2CL82nCas+2LNYlB1/WxKgB8Tr7qPQ=

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "matchdep": "~1.0.1",
     "mz": "^2.6.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "^3.26.37",
+    "patternfly-eng-release": "^3.26.38",
     "pixrem": "^3.0.1",
     "rxjs": "^5.4.2",
     "semantic-release": "^6.3.6",


### PR DESCRIPTION
Bumped patternfly-eng-release version to support a more elegant DIST_BRANCH flag. 

When added to the travis.yml, this forces the *-dist branch to be created. This works for all branches, instead of hard-coding a branch name in the build scripts.