### PR TITLE
fix(wizard): fixes wizard close button style

### DIFF
--- a/src/less/close.less
+++ b/src/less/close.less
@@ -2,6 +2,7 @@
 // Close icons
 // --------------------------------------------------
 
+//this should no longer be needed and be replaced with pficon-close. This is here for legacy. For further info see https://github.com/patternfly/patternfly/pull/781
 
 .close {
   text-shadow: none;

--- a/tests/pages/_includes/widgets/communication/wizard.html
+++ b/tests/pages/_includes/widgets/communication/wizard.html
@@ -3,8 +3,9 @@
   <div class="modal-dialog modal-lg wizard-pf">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close wizard-pf-dismiss" aria-label="Close"><span
-          aria-hidden="true">&times;</span></button>
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true" aria-label="Close">
+          <span class="pficon pficon-close"></span>
+        </button>
         <dt class="modal-title">Wizard Title</dt>
       </div>
       <div class="modal-body wizard-pf-body clearfix">

--- a/tests/pages/modals.html
+++ b/tests/pages/modals.html
@@ -9,7 +9,7 @@ resource: true
         <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
+              <button type="button" class="close" data-dismiss="modal" aria-hidden="true" aria-label="Close">
                 <span class="pficon pficon-close"></span>
               </button>
               <h4 class="modal-title" id="myModalLabel">Modal Title</h4>

--- a/tests/pages/wizard.html
+++ b/tests/pages/wizard.html
@@ -15,8 +15,8 @@ resource: true
   <div class="modal-dialog modal-lg wizard-pf">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true" aria-label="Close">
+          <span class="pficon pficon-close"></span>
         </button>
         <dt class="modal-title">Wizard Title</dt>
       </div>
@@ -95,8 +95,8 @@ state
   <div class="modal-dialog modal-lg wizard-pf">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true" aria-label="Close">
+          <span class="pficon pficon-close"></span>
         </button>
         <dt class="modal-title">Wizard Title</dt>
       </div>


### PR DESCRIPTION
wizard close button now matches the modal button style. I also added the aria label tag from the
wizard to the modal.

In the issue you'll see the modal has the larger "x". I went with this because it uses the pf-icon and it makes more sense to use a larger icon.

closes #775 

## Here is the modal
https://rawgit.com/matthewcarleton/patternfly/wizard-close-button-dist/dist/tests/modals.html

## Here is the wizard
https://rawgit.com/matthewcarleton/patternfly/wizard-close-button-dist/dist/tests/wizard.html
