### PR TITLE
fix(notification drawer): Improve alignment of pficon-close

### DIFF
--- a/src/less/notifications-drawer.less
+++ b/src/less/notifications-drawer.less
@@ -106,6 +106,10 @@
     .pficon, .fa {
       margin-right: 3px;
     }
+    .pficon-close {
+      position: relative;
+      top: 1px;
+    }
 
     &:hover { color: @link-hover-color; }
   }


### PR DESCRIPTION
Improve alignment of pficon-close so it sits on the same baseline as "Clear All".  Fixes #782.

## Description

In the notification drawer, the pficon-close button was 1px higher than the "Clear All" text next to it.

## Changes

Write a list of changes the PR introduces

* Adjust positioning of pficon-close so that it sits on the same baseline as "Clear All"

## Link to rawgit and/or image

![screen shot 2017-10-17 at 3 53 03 pm](https://user-images.githubusercontent.com/895728/31686803-513b7f5c-b355-11e7-8848-4396c4e089cc.PNG)

## PR checklist (if relevant)

- [x] **Cross browser**: works in IE9
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [x] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
