### PR TITLE
fix(card variations): fixes typo

### DIFF
--- a/tests/pages/_includes/widgets/cards/status-inline-actions-xs.html
+++ b/tests/pages/_includes/widgets/cards/status-inline-actions-xs.html
@@ -8,7 +8,7 @@
     </div>
     <div class="progress-pf-legend">
       {% include widgets/charts/utilization-bar.html id="utilizationBarChart" %}
-      <p><span class="pficon pficon-warning-triangle-o"></span> <strong>10%</strong> in use</p>
+      <p><span class="pficon pficon-warning-triangle-o"></span> <strong>25%</strong> in use</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
mini card with status now has "25% in use" to match tool tip value.

fixes #476 


## Link to rawgit and/or image
https://rawgit.com/matthewcarleton/patternfly/cards-476-dist/dist/tests/card-view-card-variations.html