### PR TITLE
fix(drawer): Make bottom border color of drawer-pf-action consistent

### DIFF
--- a/src/less/notifications-drawer.less
+++ b/src/less/notifications-drawer.less
@@ -100,6 +100,8 @@
 
 .drawer-pf-action {
   display: flex;
+  border-bottom: 1px solid @card-pf-border-color;
+  
   .btn-link {
     color: @link-color;
     padding: 10px 0;


### PR DESCRIPTION
The bottom border if the drawer-pf-action block is softer than other bottom borders.  This minor
change makes the line stronger, consistent with the empty state message, etc.

before:
![screen shot 2017-10-18 at 11 05 09 pm](https://user-images.githubusercontent.com/280512/31752592-b2765d8c-b459-11e7-80ea-ad71582c0987.png)

after:
![screen shot 2017-10-18 at 11 04 31 pm](https://user-images.githubusercontent.com/280512/31752591-b26cc308-b459-11e7-95c1-73fc925f1fe5.png)

Issue originally opened in [origin-web-console 2298](https://github.com/openshift/origin-web-console/issues/2298)