### PR TITLE
fix(notification drawer): fix inconsistency with close and expand

### DIFF
--- a/src/less/notifications-drawer.less
+++ b/src/less/notifications-drawer.less
@@ -72,14 +72,14 @@
   }
 }
 .drawer-pf-close, .drawer-pf-toggle-expand {
-  color: inherit;
+  color: @gray-darker;
   cursor: pointer;
   line-height: inherit;
   padding: 2px 10px;
   position: absolute;
   &:hover,
   &:focus {
-    color: inherit;
+    color: @color-pf-blue-400;
     text-decoration: none;
   }
 }


### PR DESCRIPTION
there was inconsistency with the close and expand buttons. They are now the same colour and have a
hover applied.

closes #774

The design doc doesn't explicitly state hover state so I took direction from the Kebab interaction.
*Adds hover state to "x"
* Changes colour of expand to match "x" 

https://rawgit.com/matthewcarleton/patternfly/notification-drawer-774-dist/dist/tests/notification-drawer-vertical-nav.html
