### PR TITLE
fix(wizard): replaced dt with h4

### DIFF
--- a/tests/pages/_includes/widgets/communication/wizard.html
+++ b/tests/pages/_includes/widgets/communication/wizard.html
@@ -6,7 +6,7 @@
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true" aria-label="Close">
           <span class="pficon pficon-close"></span>
         </button>
-        <dt class="modal-title">Wizard Title</dt>
+        <h4 class="modal-title">Wizard Title</h4>
       </div>
       <div class="modal-body wizard-pf-body clearfix">
         <div class="wizard-pf-steps hidden">

--- a/tests/pages/wizard.html
+++ b/tests/pages/wizard.html
@@ -18,7 +18,7 @@ resource: true
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true" aria-label="Close">
           <span class="pficon pficon-close"></span>
         </button>
-        <dt class="modal-title">Wizard Title</dt>
+        <h4 class="modal-title">Wizard Title</h4>
       </div>
       <div class="modal-body wizard-pf-body clearfix">
         <div class="wizard-pf-steps hidden">
@@ -98,7 +98,7 @@ state
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true" aria-label="Close">
           <span class="pficon pficon-close"></span>
         </button>
-        <dt class="modal-title">Wizard Title</dt>
+        <h4 class="modal-title">Wizard Title</h4>
       </div>
       <div class="modal-body wizard-pf-body clearfix">
         <div class="wizard-pf-steps">


### PR DESCRIPTION
for semantic reasons replaced wizard title with an h4

773

## Changes

* Replaces ```<dt>``` with ```<h4>```

https://rawgit.com/matthewcarleton/patternfly/wizard-773-dist/dist/tests/wizard.html
