### PR TITLE
fix(accessibility): skip to content link

### DIFF
--- a/src/less/patternfly-additions.less
+++ b/src/less/patternfly-additions.less
@@ -54,6 +54,7 @@
 @import "notifications-drawer.less";
 @import "search.less";
 @import "sidebar.less";
+@import "skip-to-content.less";
 @import "spinner.less";
 @import "syntax-highlighting.less";
 @import "table-view.less";

--- a/src/less/skip-to-content.less
+++ b/src/less/skip-to-content.less
@@ -1,0 +1,12 @@
+//
+// Skip to content
+// --------------------------------------------------
+.skiplink-pf {
+position: absolute;
+top: 12px;
+left: 100%; /* moves off screen */
+z-index: @zindex-modal;
+}
+.skiplink-pf:focus {
+  left: 10px;
+}

--- a/tests/pages/_includes/head.html
+++ b/tests/pages/_includes/head.html
@@ -34,6 +34,7 @@
     {% endfor %}{% endif %}
     <script src="{{site.baseurl}}/{{site.url-js}}"></script>
   </head>{% if page.full-page %}
+  <a class="skiplink-pf btn btn-primary" href="#main">Skip to main content</a>
   <div class="toast-notifications-list-pf">
     <div class="toast-pf alert alert-warning alert-dismissable">
       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">

--- a/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar-page.html
+++ b/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar-page.html
@@ -3,7 +3,7 @@
 {% else %}
   {% include widgets/navigation/horizontal-primary-nav-bar.html %}
 {% endif %}
-<div class="container-fluid container-cards-pf">
+<div class="container-fluid container-cards-pf" id="main">
 {% include widgets/layouts/cards-alt.html %}
 </div>
 <script>

--- a/tests/pages/skip-to-content.html
+++ b/tests/pages/skip-to-content.html
@@ -1,0 +1,8 @@
+---
+categories: [Widgets]
+layout: page
+title: Skip to content link
+resource: true
+---
+    <a class="skiplink-pf btn btn-primary" href="#main">Skip to main content</a>
+    <p>When tabbing through the page this link should appear first in order to skip straight to the main content.</p>


### PR DESCRIPTION
## Description
This adds a skip to content link. This is most useful when skipping navigation. As you tab through the page you will see the link appear and disappear when you tab off it. 

I've added this to the navigation pages as well, which can be seen here:

https://rawgit.com/matthewcarleton/patternfly/nav-787-dist/dist/tests/horizontal-navigation.html

Note: If you are using safari you must enable tabbing in your preferences.

closes #787 

## Link to rawgit

https://rawgit.com/matthewcarleton/patternfly/nav-787-dist/dist/tests/skip-to-content.html