### PR TITLE
fix(forms): Fixes static form control

### DIFF
--- a/src/less/forms.less
+++ b/src/less/forms.less
@@ -93,3 +93,9 @@ span.required-pf {
     width: @font-size-large;
   }
 }
+
+.form-group-lg, .form-group-sm {
+  .form-control-static {
+    line-height: @line-height-base;
+  }
+}


### PR DESCRIPTION
This PR fixes static form control line-height for a correct alignment to labels

Closes #752

@vkrizan can you please confirm that this fixes the issue?
