### PR TITLE
Travis: patternfly-eng-release updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,11 @@ before_install:
   - rvm install 2.3.1
   - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
   - npm install -g bower grunt-cli
-  - npm install
   - npm install patternfly-eng-release
 
 install: true
 
 script:
-  - npm run regressions
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -p
 
 after_success:
@@ -35,7 +33,9 @@ after_success:
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_bump.sh -p;
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-npm.sh || travis_terminate 0;
        npm run semantic-release-post;
-       - sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-webjar.sh -p;
+       sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-webjar.sh -p;
+       sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_release-all.sh -o;
+       sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_release-all.sh -r;
      fi'
 
 branches:

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "npm-check-updates": "^2.12.1",
     "nsp": "^2.6.1",
     "open": "0.0.5",
-    "patternfly-eng-release": "^3.26.35",
+    "patternfly-eng-release": "^3.26.43",
     "pixrem": "^3.0.1",
     "require-all": "^2.2.0",
     "semantic-release": "^6.3.6",


### PR DESCRIPTION
Updated patternfly-eng-release to run regression tests and automated RCUE release.

Changes:

1. I created a new patternfly-eng-release script to kick off the automated RCUE and patternfly-org release in order to sync with PatternFly. The release notes must be added to Github manually, but adding a semantic release there would fix that.

2. The patternfly-eng-release scripts now run the regression tests if 'backstop/test.js' is available. This ensures that "npm install" (if run too early) does not inadvertently install old/out-of-date dependencies prior to running the build, build test, and Shrinkwrap security vulnerability test. This also ensures that the regression tests are not run multiple times during a semantic release; once for the master branch and twice for master-dist.

Changes to patternfly-eng-release can be found here: https://github.com/patternfly/patternfly-eng-release/pull/56