### PR TITLE
fix(app launcher): rename inclusion variables

### DIFF
--- a/tests/pages/_includes/widgets/framework/application-launcher.html
+++ b/tests/pages/_includes/widgets/framework/application-launcher.html
@@ -1,4 +1,4 @@
-<li class="applauncher-pf {% if include.launcher-grid %} applauncher-pf-block-list {% endif %} dropdown dropdown-kebab-pf">
+<li class="applauncher-pf {% if include.grid %} applauncher-pf-block-list {% endif %} dropdown dropdown-kebab-pf">
   <a class="dropdown-toggle nav-item-iconic" data-toggle="dropdown" href="#">
     <i class="fa fa-th applauncher-pf-icon" aria-hidden="true"></i>
           <span class="applauncher-pf-title">
@@ -9,7 +9,7 @@
   <ul class="dropdown-menu dropdown-menu-right" role="menu">
     <li class="applauncher-pf-item" role="menuitem">
       <a class="applauncher-pf-link" href="#">
-        {% if include.launcher-icons %}
+        {% if include.icons %}
         <i class="applauncher-pf-link-icon pficon pficon-storage-domain" aria-hidden="true"></i>
         {% endif %}
         <span class="applauncher-pf-link-title">Recteque</span>
@@ -17,7 +17,7 @@
     </li>
     <li class="applauncher-pf-item" role="menuitem">
       <a class="applauncher-pf-link" href="#">
-        {% if include.launcher-icons %}
+        {% if include.icons %}
         <i class="applauncher-pf-link-icon pficon pficon-virtual-machine" aria-hidden="true"></i>
         {% endif %}
         <span class="applauncher-pf-link-title">Ipsum</span>
@@ -25,7 +25,7 @@
     </li>
     <li class="applauncher-pf-item" role="menuitem">
       <a class="applauncher-pf-link" href="#">
-        {% if include.launcher-icons %}
+        {% if include.icons %}
         <!-- Placeholder left to maintain spacing -->
         <i class="applauncher-pf-link-icon" aria-hidden="true"></i>
         {% endif %}
@@ -34,7 +34,7 @@
     </li>
     <li class="applauncher-pf-item" role="menuitem">
       <a class="applauncher-pf-link" href="#">
-        {% if include.launcher-icons %}
+        {% if include.icons %}
         <i class="applauncher-pf-link-icon pficon pficon-domain" aria-hidden="true"></i>
         {% endif %}
         <span class="applauncher-pf-link-title">Lorem</span>
@@ -42,7 +42,7 @@
     </li>
     <li class="applauncher-pf-item" role="menuitem">
       <a class="applauncher-pf-link" href="#">
-        {% if include.launcher-icons %}
+        {% if include.icons %}
         <i class="applauncher-pf-link-icon pficon pficon-home" aria-hidden="true"></i>
         {% endif %}
         <span class="applauncher-pf-link-title">Home</span>

--- a/tests/pages/_includes/widgets/layouts/navbar-vertical.html
+++ b/tests/pages/_includes/widgets/layouts/navbar-vertical.html
@@ -1,3 +1,5 @@
+{% assign launchergrid = include.launchergrid %}
+{% assign launchericons = include.launchericons %}
 <nav class="navbar navbar-pf-vertical">
   <div class="navbar-header">
     <button type="button" class="navbar-toggle">
@@ -13,7 +15,7 @@
   <nav class="collapse navbar-collapse">
     <ul class="nav navbar-nav navbar-right navbar-iconic navbar-utility">
       {% if page.applauncher %}
-      {% include widgets/framework/application-launcher.html launcher-icons=include.launcher-icons launcher-grid=include.launcher-grid %}
+      {% include widgets/framework/application-launcher.html icons=launchericons grid=launchergrid %}
       {% endif %}
       <li class="dropdown">
         <a href="#0" class="dropdown-toggle nav-item-iconic" id="dropdownMenu1{{include.navindex}}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">

--- a/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar.html
+++ b/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar.html
@@ -1,3 +1,5 @@
+{% assign launchergrid = include.launchergrid %}
+{% assign launchericons = include.launchericons %}
 <nav class="navbar navbar-default navbar-pf" role="navigation">
   <div class="navbar-header">
     <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
@@ -13,7 +15,7 @@
   <div class="collapse navbar-collapse navbar-collapse-1">
     <ul class="nav navbar-nav navbar-utility">
       {% if page.applauncher %}
-      {% include widgets/framework/application-launcher.html launcher-icons=include.launcher-icons launcher-grid=include.launcher-grid %}
+      {% include widgets/framework/application-launcher.html icons=launchericons grid=launchergrid %}
       {% endif %}
       <li class="dropdown">
         <a href="#0" class="nav-item-iconic" id="horizontalDropdownMenu1{{include.navindex}}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">

--- a/tests/pages/_includes/widgets/navigation/vertical-navigation.html
+++ b/tests/pages/_includes/widgets/navigation/vertical-navigation.html
@@ -1,7 +1,8 @@
+{% assign launchericons = include.icons %}
 {% if page.notification-drawer %}
-  {% include widgets/layouts/nav-vertical-notification-drawer.html launcher-icons=include.launcher-icons %}
+  {% include widgets/layouts/nav-vertical-notification-drawer.html icons=launchericons %}
 {% else %}
-  {% include widgets/layouts/navbar-vertical.html notification-drawer=true launcher-icons=include.launcher-icons %}
+  {% include widgets/layouts/navbar-vertical.html notification-drawer=true icons=launchericons %}
 {% endif %}
 <div class="nav-pf-vertical nav-pf-vertical-with-sub-menus
      {% if page.persistent-secondary %}nav-pf-persistent-secondary{% endif %}

--- a/tests/pages/application-launcher-nav-horizontal.html
+++ b/tests/pages/application-launcher-nav-horizontal.html
@@ -8,7 +8,7 @@ applauncher: true
 title: Application Launcher for Horizontal Navigation
 ---
 
-{% include widgets/navigation/horizontal-primary-nav-bar-page.html launcher-icons=true %}
+{% include widgets/navigation/horizontal-primary-nav-bar-page.html icons=true %}
 <script>
   $(document).ready(function() {
     $('.applauncher-pf .dropdown-toggle').eq(0).click();

--- a/tests/pages/application-launcher-nav-vertical.html
+++ b/tests/pages/application-launcher-nav-vertical.html
@@ -9,4 +9,4 @@ submenus: true
 title: Application Launcher for Vertical Navigation
 url-js-extra: ['//cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.2/jquery.matchHeight-min.js', '//cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.js', '//cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js']
 ---
-{% include widgets/navigation/vertical-navigation.html launcher-icons=true %}
+{% include widgets/navigation/vertical-navigation.html icons=true %}

--- a/tests/pages/application-launcher.html
+++ b/tests/pages/application-launcher.html
@@ -13,17 +13,17 @@ title: Application Launcher
 <h3>Grid Menu</h3>
 
 <h4>Icons</h4>
-{% include widgets/navigation/horizontal-primary-nav-bar.html launcher-icons=true launcher-grid=true navindex=1 %}
+{% include widgets/navigation/horizontal-primary-nav-bar.html launchericons=true launchergrid=true navindex=1 %}
 <h4>No Icons</h4>
-{% include widgets/navigation/horizontal-primary-nav-bar.html launcher-icons=false launcher-grid=true navindex=2 %}
+{% include widgets/navigation/horizontal-primary-nav-bar.html launchericons=false launchergrid=true navindex=2 %}
 
 <h3>List Menu</h3>
 
 <h4>Icons</h4>
-{% include widgets/navigation/horizontal-primary-nav-bar.html launcher-icons=true launcher-grid=false navindex=3 %}
+{% include widgets/navigation/horizontal-primary-nav-bar.html launchericons=true launchergrid=false navindex=3 %}
 
 <h4>No Icons</h4>
-{% include widgets/navigation/horizontal-primary-nav-bar.html launcher-icons=false launcher-grid=false navindex=4 %}
+{% include widgets/navigation/horizontal-primary-nav-bar.html launchericons=false launchergrid=false navindex=4 %}
 
 <br>
 <br>
@@ -32,18 +32,18 @@ title: Application Launcher
 <h3>Grid Menu</h3>
 
 <h4>Icons</h4>
-{% include widgets/layouts/navbar-vertical.html launcher-grid=true launcher-icons=true navindex=5 %}
+{% include widgets/layouts/navbar-vertical.html launchergrid=true launchericons=true navindex=5 %}
 
 <h4>No Icons</h4>
-{% include widgets/layouts/navbar-vertical.html launcher-grid=true launcher-icons=false navndex=6 %}
+{% include widgets/layouts/navbar-vertical.html launchergrid=true launchericons=false navndex=6 %}
 
 <h3>List Menu</h3>
 
 <h4>Icons</h4>
-{% include widgets/layouts/navbar-vertical.html launcher-grid=false launcher-icons=true navindex=7 %}
+{% include widgets/layouts/navbar-vertical.html launchergrid=false launchericons=true navindex=7 %}
 
 <h4>No Icons</h4>
-{% include widgets/layouts/navbar-vertical.html launcher-grid=false launcher-icons=false navindex=8 %}
+{% include widgets/layouts/navbar-vertical.html launchergrid=false launchericons=false navindex=8 %}
 
 <script>
   $(document).ready(function() {


### PR DESCRIPTION
Rename variables used in application launcher pages. 
Variable names must not contain a hyphen, must be unique across the whole include chain and an include variable must not be referenced in another include tag (in the latter two cases `grunt build` will short-circuit without any explanation).

Closes #738 
