### PR TITLE
fix(vertical-nav): fix list group item width

### DIFF
--- a/src/less/vertical-nav.less
+++ b/src/less/vertical-nav.less
@@ -129,6 +129,8 @@
       line-height: 25px;
       max-width: 120px;
       // If flexbox is supported, do not set max-width, take all space with just some right padding
+      // This generates a known issue on IE11:
+      // https://github.com/patternfly/patternfly/pull/810
       @supports (display: flex) {
         flex: 1;
         max-width: none;


### PR DESCRIPTION
Closes #807 

@jeff-phillips-18 Maybe I am missing something, but it seems like the code I removed it's not necessary. I've tested on IE9, 10 and 11 and it works fine.

@rhamilto when you have time, can you please confirm if this Pr fixes your issue?

Thanks a lot!