### PR TITLE
fix(skip link): skip link only on component page

### DIFF
--- a/tests/pages/_includes/head.html
+++ b/tests/pages/_includes/head.html
@@ -34,7 +34,6 @@
     {% endfor %}{% endif %}
     <script src="{{site.baseurl}}/{{site.url-js}}"></script>
   </head>{% if page.full-page %}
-  <a class="skiplink-pf btn btn-primary" href="#main">Skip to main content</a>
   <div class="toast-notifications-list-pf">
     <div class="toast-pf alert alert-warning alert-dismissable">
       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">


### PR DESCRIPTION
I'm removing the skip to content link from other test pages. I did have it in the head.html file but that is too global. It shows up in odd places on some pages due to tab order.  Rather than introduce more conditional logic I think it makes sense to just show this on the Skip to content component page.

closes #813

## Link to rawgit and/or image
https://rawgit.com/matthewcarleton/patternfly/skip-link-813-dist/dist/tests/skip-to-content.html