### PR TITLE
fix: Fix wizard step label alignment

### DIFF
--- a/src/less/wizard.less
+++ b/src/less/wizard.less
@@ -155,6 +155,9 @@
         }
           .wizard-pf-step-title {
             margin-left: 10px;
+            @media(min-width: @screen-sm-min) {
+              margin-left: 0;
+            }
 
             &-substep {
               font-weight: normal;


### PR DESCRIPTION
Wizard step labels are off center by 10px at desktop

Fixes #818

