### PR TITLE
Bumped version number to 3.30.0-beta

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "patternfly",
-  "version": "0.0.0-semantically-released",
+  "version": "3.30.0-beta",
   "authors": "Red Hat",
   "license": "Apache-2.0",
   "homepage": "https://www.patternfly.org",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,139 @@
+{
+  "name": "patternfly",
+  "version": "3.30.0-beta",
+  "dependencies": {
+    "bootstrap": {
+      "version": "3.3.7",
+      "from": "bootstrap@>=3.3.7 <3.4.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz"
+    },
+    "bootstrap-datepicker": {
+      "version": "1.6.4",
+      "from": "bootstrap-datepicker@>=1.6.4 <1.7.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.6.4.tgz",
+      "optional": true
+    },
+    "bootstrap-sass": {
+      "version": "3.3.7",
+      "from": "bootstrap-sass@>=3.3.7 <4.0.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
+      "optional": true
+    },
+    "bootstrap-select": {
+      "version": "1.12.4",
+      "from": "bootstrap-select@>=1.12.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-select/-/bootstrap-select-1.12.4.tgz",
+      "optional": true
+    },
+    "bootstrap-switch": {
+      "version": "3.3.4",
+      "from": "bootstrap-switch@>=3.3.4 <3.4.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-switch/-/bootstrap-switch-3.3.4.tgz",
+      "optional": true
+    },
+    "bootstrap-touchspin": {
+      "version": "3.1.1",
+      "from": "bootstrap-touchspin@>=3.1.1 <3.2.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-touchspin/-/bootstrap-touchspin-3.1.1.tgz",
+      "optional": true
+    },
+    "c3": {
+      "version": "0.4.18",
+      "from": "c3@>=0.4.11 <0.5.0",
+      "resolved": "https://registry.npmjs.org/c3/-/c3-0.4.18.tgz",
+      "optional": true
+    },
+    "d3": {
+      "version": "3.5.17",
+      "from": "d3@>=3.5.17 <3.6.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+      "optional": true
+    },
+    "datatables.net": {
+      "version": "1.10.16",
+      "from": "datatables.net@>=1.10.15 <2.0.0",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.16.tgz"
+    },
+    "datatables.net-bs": {
+      "version": "1.10.16",
+      "from": "datatables.net-bs@>=1.10.9",
+      "resolved": "https://registry.npmjs.org/datatables.net-bs/-/datatables.net-bs-1.10.16.tgz",
+      "optional": true
+    },
+    "datatables.net-colreorder": {
+      "version": "1.3.3",
+      "from": "datatables.net-colreorder@>=1.3.2 <1.4.0",
+      "resolved": "https://registry.npmjs.org/datatables.net-colreorder/-/datatables.net-colreorder-1.3.3.tgz",
+      "optional": true
+    },
+    "datatables.net-colreorder-bs": {
+      "version": "1.3.3",
+      "from": "datatables.net-colreorder-bs@>=1.3.2 <1.4.0",
+      "resolved": "https://registry.npmjs.org/datatables.net-colreorder-bs/-/datatables.net-colreorder-bs-1.3.3.tgz",
+      "optional": true
+    },
+    "datatables.net-select": {
+      "version": "1.2.3",
+      "from": "datatables.net-select@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/datatables.net-select/-/datatables.net-select-1.2.3.tgz",
+      "optional": true
+    },
+    "drmonty-datatables-colvis": {
+      "version": "1.1.2",
+      "from": "drmonty-datatables-colvis@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/drmonty-datatables-colvis/-/drmonty-datatables-colvis-1.1.2.tgz",
+      "optional": true
+    },
+    "eonasdan-bootstrap-datetimepicker": {
+      "version": "4.17.47",
+      "from": "eonasdan-bootstrap-datetimepicker@>=4.17.47 <5.0.0",
+      "resolved": "https://registry.npmjs.org/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.47.tgz",
+      "optional": true
+    },
+    "font-awesome": {
+      "version": "4.7.0",
+      "from": "font-awesome@>=4.7.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz"
+    },
+    "google-code-prettify": {
+      "version": "1.0.5",
+      "from": "google-code-prettify@>=1.0.5 <1.1.0",
+      "resolved": "https://registry.npmjs.org/google-code-prettify/-/google-code-prettify-1.0.5.tgz",
+      "optional": true
+    },
+    "jquery": {
+      "version": "3.2.1",
+      "from": "jquery@>=3.2.1 <3.3.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz"
+    },
+    "jquery-match-height": {
+      "version": "0.7.2",
+      "from": "jquery-match-height@>=0.7.2 <0.8.0",
+      "resolved": "https://registry.npmjs.org/jquery-match-height/-/jquery-match-height-0.7.2.tgz",
+      "optional": true
+    },
+    "moment": {
+      "version": "2.14.1",
+      "from": "moment@>=2.14.1 <2.15.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz"
+    },
+    "moment-timezone": {
+      "version": "0.4.1",
+      "from": "moment-timezone@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
+      "optional": true
+    },
+    "patternfly-bootstrap-combobox": {
+      "version": "1.1.7",
+      "from": "patternfly-bootstrap-combobox@>=1.1.7 <1.2.0",
+      "resolved": "https://registry.npmjs.org/patternfly-bootstrap-combobox/-/patternfly-bootstrap-combobox-1.1.7.tgz",
+      "optional": true
+    },
+    "patternfly-bootstrap-treeview": {
+      "version": "2.1.5",
+      "from": "patternfly-bootstrap-treeview@>=2.1.0 <2.2.0",
+      "resolved": "https://registry.npmjs.org/patternfly-bootstrap-treeview/-/patternfly-bootstrap-treeview-2.1.5.tgz",
+      "optional": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patternfly",
-  "version": "0.0.0-semantically-released",
+  "version": "3.30.0-beta",
   "author": "Red Hat",
   "license": "Apache-2.0",
   "dependencies": {

--- a/src/js/patternfly-settings-base.js
+++ b/src/js/patternfly-settings-base.js
@@ -2,7 +2,7 @@
   'use strict';
 
   var patternfly = {
-    version: "3.26.1",
+    version: "3.30.0-beta",
   };
 
   // definition of breakpoint sizes for tablet and desktop modes


### PR DESCRIPTION
Bumped version number to 3.30.0-beta.

There are two issues regarding this PR:

1. The current build deletes everything under src/saas/converted. Was that was intentional?
2. There were 4 regression test failures. However, the test does not fail with a proper exit code, so the build continues normally instead of stopping upon failure