### PR TITLE
fix(build): Only clean converted Sass files on Sass build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -558,7 +558,7 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('build:less', [
-    'clean',
+    'clean:build',
     'concat',
     'copy',
     'pages',


### PR DESCRIPTION
## Description
Less build task no longer runs `clean:sass` which removes the `src/sass/converted` directory.