### PR TITLE
fix(kebab): adjust position of kebab callout

### DIFF
--- a/src/less/dropdowns.less
+++ b/src/less/dropdowns.less
@@ -170,6 +170,7 @@
 
 // Kebab dropmenu
 .dropdown-kebab-pf {
+  &.btn-group > .btn:first-child,
   .btn-link {
     color: @gray-darker;
     font-size: (@font-size-base + 4);
@@ -183,6 +184,7 @@
       color: @link-color;
     }
   }
+  &.btn-group { margin-left: (@grid-gutter-width/4); }
   .dropdown-menu {
     left: -15px;
     margin-top: 11px;

--- a/src/less/toolbar.less
+++ b/src/less/toolbar.less
@@ -37,11 +37,6 @@
       &:focus,
       &:hover { color: @link-color; }
     }
-    .dropdown-kebab-pf .btn-link {
-        padding: 4px (@grid-gutter-width/4);
-        margin-left: (@grid-gutter-width/(-4));
-        margin-right: (@grid-gutter-width/(-4));
-    }
   }
 }
 .toolbar-pf-actions {

--- a/src/less/toolbar.less
+++ b/src/less/toolbar.less
@@ -37,6 +37,11 @@
       &:focus,
       &:hover { color: @link-color; }
     }
+    .dropdown-kebab-pf .btn-link {
+      padding: 4px (@grid-gutter-width/4);
+      margin-left: (@grid-gutter-width/(-4));
+      margin-right: (@grid-gutter-width/(-4));
+    }
   }
 }
 .toolbar-pf-actions {

--- a/tests/pages/dropdowns.html
+++ b/tests/pages/dropdowns.html
@@ -46,4 +46,18 @@ resource: true
           {% include widgets/kebab.html dropmenuType="dropup" dropmenuPosition="pull-right" dropmenuId="dropupKebabRight1" dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
         </div>
       </div>
-
+      <h2>Dropdown Kebab with Buttons</h2>
+      <div class="row">
+        <div class="col-xs-6 col-sm-4 col-md-2">
+          <button type="button" class="btn btn-default">Button</button>
+          <button type="button" class="btn btn-default">Button</button>
+          {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="btn-group" dropmenuId="dropdownKebabGroup" dropmenuVariation="dropdown-kebab-pf" %}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-6 col-sm-4 col-md-2">
+          <button type="button" class="btn btn-default">Button</button>
+          <button type="button" class="btn btn-default">Button</button>
+          {% include widgets/kebab.html dropmenuType="dropdown" dropmenuPosition="btn-group" dropmenuId="dropdownKebabGroupRight" dropdownPosition="dropdown-menu-right" dropmenuVariation="dropdown-kebab-pf" %}
+        </div>
+      </div>


### PR DESCRIPTION
Fixes an issue that occurs when a combination of buttons and kebab display outside the context of a
toolbar and the menu is left-aligned, so that the callout of the menu is better aligned with the
kebab.

#663 
Jira story: https://patternfly.atlassian.net/browse/PTNFLY-2605

## Changes

These changes are based on the following use cases: 

* A combination of buttons and kebab could display in other places besides a list view row or a toolbar
* The html used in the toolbar for the combination of buttons and a kebab would be reused when displaying a combination of buttons and kebab in other locations.

To support these use cases, the following changes were made:

* Move the css that correctly renders the combination of buttons and kebab on the toolbar from toolbar.less to dropdowns.less
* Include an example of a combination of buttons and kebab on the Dropdowns test page.

## Link to rawgit and/or image
Nope.

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [ ] **Responsive**: works in extra small, small, medium and large view ports.
- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
