### PR TITLE
Broken NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,8 @@
     }
   },
   "files": [
-    "dist/"
+    "dist/",
+    "tests/",
+    "npm-shrinkwrap.json"
   ]
 }


### PR DESCRIPTION
Restored tests directory and npm-shrinkwrap for published npm package. RCUE cannot build properly without the test files.

Fixes: https://github.com/patternfly/patternfly/issues/843