### PR TITLE
fix(sass): Fix relative path variables in less and sass

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -369,8 +369,14 @@ module.exports = function (grunt) {
             },
             {
               //
-              pattern: /^\$(img|font)-path:(\s*)(".*")(.*);$/mgi,
-              replacement: '\$$$1-path:$2if($pf-sass-asset-helper, "", $3)$4;',
+              pattern: /^\$(img|font)-path:(\s*)"(.*)"(.*);(.*)$/mgi,
+              replacement: '\$$$1-path:$2if($pf-sass-asset-helper, "", "$3/")$4;$5',
+              order: 1
+            },
+            {
+              //
+              pattern: /^\$icon-font-path:(\s*)"(.*)"(.*);(.*)$/mgi,
+              replacement: '\$icon-font-path:$1if($pf-sass-asset-helper, "", "$2")$3;$4',
               order: 1
             },
             {
@@ -443,13 +449,13 @@ module.exports = function (grunt) {
             },
             {
               pattern: /url\(\"\#\{\$font-path\}\/(.+?)\"\)/gi,
-              replacement: 'url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}/$1"), "#{$font-path}/$1"))',
-              order: 29
+              replacement: 'url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}$1"), "#{$font-path}$1"))',
+              order: 30
             },
             {
               pattern: /url\(\"\#\{\$img-path\}\/(.+?)\"\)/gi,
-              replacement: 'url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}/$1"), "#{$img-path}/$1"))',
-              order: 30
+              replacement: 'url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}$1"), "#{$img-path}$1"))',
+              order: 31
             },
           ]
         }

--- a/src/less/about-modal.less
+++ b/src/less/about-modal.less
@@ -4,7 +4,7 @@
 
 .about-modal-pf {
   background-color: @color-pf-black-900;
-  background-image: url("@{img-path}@{modal-about-pf-bg-img}");
+  background-image: url("@{img-path}/@{modal-about-pf-bg-img}");
   background-position: right bottom;
   background-repeat: no-repeat;
   background-size: 216px auto;

--- a/src/less/fonts.less
+++ b/src/less/fonts.less
@@ -6,119 +6,119 @@
   font-family: "Open Sans";
   font-style: normal;
   font-weight: 300;
-  src: url("@{font-path}OpenSans-Light-webfont.eot"); /* IE9 Compat Modes */
+  src: url("@{font-path}/OpenSans-Light-webfont.eot"); /* IE9 Compat Modes */
   src: local("Open Sans Light"), local("OpenSans-Light"),
-       url("@{font-path}OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("@{font-path}OpenSans-Light-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("@{font-path}OpenSans-Light-webfont.woff") format("woff"), /* Modern Browsers */
-       url("@{font-path}OpenSans-Light-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("@{font-path}OpenSans-Light-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url("@{font-path}/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+       url("@{font-path}/OpenSans-Light-webfont.woff2") format("woff2"), /* Super Modern Browsers */
+       url("@{font-path}/OpenSans-Light-webfont.woff") format("woff"), /* Modern Browsers */
+       url("@{font-path}/OpenSans-Light-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
+       url("@{font-path}/OpenSans-Light-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: normal;
   font-weight: 400;
-  src: url("@{font-path}OpenSans-Regular-webfont.eot"); /* IE9 Compat Modes */
+  src: url("@{font-path}/OpenSans-Regular-webfont.eot"); /* IE9 Compat Modes */
   src: local("Open Sans"), local("OpenSans"),
-       url("@{font-path}OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("@{font-path}OpenSans-Regular-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("@{font-path}OpenSans-Regular-webfont.woff") format("woff"), /* Modern Browsers */
-       url("@{font-path}OpenSans-Regular-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("@{font-path}OpenSans-Regular-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url("@{font-path}/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+       url("@{font-path}/OpenSans-Regular-webfont.woff2") format("woff2"), /* Super Modern Browsers */
+       url("@{font-path}/OpenSans-Regular-webfont.woff") format("woff"), /* Modern Browsers */
+       url("@{font-path}/OpenSans-Regular-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
+       url("@{font-path}/OpenSans-Regular-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: italic;
   font-weight: 300;
-  src: url("@{font-path}OpenSans-LightItalic-webfont.eot"); /* IE9 Compat Modes */
+  src: url("@{font-path}/OpenSans-LightItalic-webfont.eot"); /* IE9 Compat Modes */
   src: local("Open Sans Light Italic"), local("OpenSansLight-Italic"),
-       url("@{font-path}OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("@{font-path}OpenSans-LightItalic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("@{font-path}OpenSans-LightItalic-webfont.woff") format("woff"), /* Modern Browsers */
-       url("@{font-path}OpenSans-LightItalic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("@{font-path}OpenSans-LightItalic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url("@{font-path}/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+       url("@{font-path}/OpenSans-LightItalic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
+       url("@{font-path}/OpenSans-LightItalic-webfont.woff") format("woff"), /* Modern Browsers */
+       url("@{font-path}/OpenSans-LightItalic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
+       url("@{font-path}/OpenSans-LightItalic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: italic;
   font-weight: 400;
-  src: url("@{font-path}OpenSans-Italic-webfont.eot"); /* IE9 Compat Modes */
+  src: url("@{font-path}/OpenSans-Italic-webfont.eot"); /* IE9 Compat Modes */
   src: local("Open Sans Italic"), local("OpenSans-Italic"),
-       url("@{font-path}OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("@{font-path}OpenSans-Italic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("@{font-path}OpenSans-Italic-webfont.woff") format("woff"), /* Modern Browsers */
-       url("@{font-path}OpenSans-Italic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("@{font-path}OpenSans-Italic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url("@{font-path}/OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+       url("@{font-path}/OpenSans-Italic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
+       url("@{font-path}/OpenSans-Italic-webfont.woff") format("woff"), /* Modern Browsers */
+       url("@{font-path}/OpenSans-Italic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
+       url("@{font-path}/OpenSans-Italic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: normal;
   font-weight: 600;
-  src: url("@{font-path}OpenSans-Semibold-webfont.eot"); /* IE9 Compat Modes */
+  src: url("@{font-path}/OpenSans-Semibold-webfont.eot"); /* IE9 Compat Modes */
   src: local("Open Sans Semibold"), local("OpenSans-Semibold-webfont"),
-       url("@{font-path}OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("@{font-path}OpenSans-Semibold-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("@{font-path}OpenSans-Semibold-webfont.woff") format("woff"), /* Modern Browsers */
-       url("@{font-path}OpenSans-Semibold-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("@{font-path}OpenSans-Semibold-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url("@{font-path}/OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+       url("@{font-path}/OpenSans-Semibold-webfont.woff2") format("woff2"), /* Super Modern Browsers */
+       url("@{font-path}/OpenSans-Semibold-webfont.woff") format("woff"), /* Modern Browsers */
+       url("@{font-path}/OpenSans-Semibold-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
+       url("@{font-path}/OpenSans-Semibold-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: italic;
   font-weight: 600;
-  src: url("@{font-path}OpenSans-SemiboldItalic-webfont.eot"); /* IE9 Compat Modes */
+  src: url("@{font-path}/OpenSans-SemiboldItalic-webfont.eot"); /* IE9 Compat Modes */
   src: local("Open Sans Semibold Italic"), local("OpenSans-SemiboldItalic-webfont"),
-       url("@{font-path}OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("@{font-path}OpenSans-SemiboldItalic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("@{font-path}OpenSans-SemiboldItalic-webfont.woff") format("woff"), /* Modern Browsers */
-       url("@{font-path}OpenSans-SemiboldItalic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("@{font-path}OpenSans-SemiboldItalic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url("@{font-path}/OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+       url("@{font-path}/OpenSans-SemiboldItalic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
+       url("@{font-path}/OpenSans-SemiboldItalic-webfont.woff") format("woff"), /* Modern Browsers */
+       url("@{font-path}/OpenSans-SemiboldItalic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
+       url("@{font-path}/OpenSans-SemiboldItalic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: normal;
   font-weight: 700;
-  src: url("@{font-path}OpenSans-Bold-webfont.eot"); /* IE9 Compat Modes */
+  src: url("@{font-path}/OpenSans-Bold-webfont.eot"); /* IE9 Compat Modes */
   src: local("Open Sans Bold"), local("OpenSans-Bold"),
-       url("@{font-path}OpenSans-Bold-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("@{font-path}OpenSans-Bold-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("@{font-path}OpenSans-Bold-webfont.woff") format("woff"), /* Modern Browsers */
-       url("@{font-path}OpenSans-Bold-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("@{font-path}OpenSans-Bold-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url("@{font-path}/OpenSans-Bold-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+       url("@{font-path}/OpenSans-Bold-webfont.woff2") format("woff2"), /* Super Modern Browsers */
+       url("@{font-path}/OpenSans-Bold-webfont.woff") format("woff"), /* Modern Browsers */
+       url("@{font-path}/OpenSans-Bold-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
+       url("@{font-path}/OpenSans-Bold-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: italic;
   font-weight: 700;
-  src: url("@{font-path}OpenSans-BoldItalic-webfont.eot"); /* IE9 Compat Modes */
+  src: url("@{font-path}/OpenSans-BoldItalic-webfont.eot"); /* IE9 Compat Modes */
   src: local("Open Sans Bold Italic"), local("OpenSans-BoldItalic"),
-       url("@{font-path}OpenSans-BoldItalic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("@{font-path}OpenSans-BoldItalic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("@{font-path}OpenSans-BoldItalic-webfont.woff") format("woff"), /* Modern Browsers */
-       url("@{font-path}OpenSans-BoldItalic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("@{font-path}OpenSans-BoldItalic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url("@{font-path}/OpenSans-BoldItalic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+       url("@{font-path}/OpenSans-BoldItalic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
+       url("@{font-path}/OpenSans-BoldItalic-webfont.woff") format("woff"), /* Modern Browsers */
+       url("@{font-path}/OpenSans-BoldItalic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
+       url("@{font-path}/OpenSans-BoldItalic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: italic;
   font-weight: 800;
-  src: url("@{font-path}OpenSans-ExtraBoldItalic-webfont.eot"); /* IE9 Compat Modes */
+  src: url("@{font-path}/OpenSans-ExtraBoldItalic-webfont.eot"); /* IE9 Compat Modes */
   src: local("Open Sans Extrabold Italic"), local("OpenSans-ExtraboldItalic"),
-       url("@{font-path}OpenSans-ExtraBoldItalic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("@{font-path}OpenSans-ExtraBoldItalic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("@{font-path}OpenSans-ExtraBoldItalic-webfont.woff") format("woff"), /* Modern Browsers */
-       url("@{font-path}OpenSans-ExtraBoldItalic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("@{font-path}OpenSans-ExtraBoldItalic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url("@{font-path}/OpenSans-ExtraBoldItalic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+       url("@{font-path}/OpenSans-ExtraBoldItalic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
+       url("@{font-path}/OpenSans-ExtraBoldItalic-webfont.woff") format("woff"), /* Modern Browsers */
+       url("@{font-path}/OpenSans-ExtraBoldItalic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
+       url("@{font-path}/OpenSans-ExtraBoldItalic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: normal;
   font-weight: 800;
-  src: url("@{font-path}OpenSans-ExtraBold-webfont.eot"); /* IE9 Compat Modes */
+  src: url("@{font-path}/OpenSans-ExtraBold-webfont.eot"); /* IE9 Compat Modes */
   src: local("Open Sans Extrabold"), local("OpenSans-Extrabold"),
-       url("@{font-path}OpenSans-ExtraBold-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("@{font-path}OpenSans-ExtraBold-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("@{font-path}OpenSans-ExtraBold-webfont.woff") format("woff"), /* Modern Browsers */
-       url("@{font-path}OpenSans-ExtraBold-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("@{font-path}OpenSans-ExtraBold-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url("@{font-path}/OpenSans-ExtraBold-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+       url("@{font-path}/OpenSans-ExtraBold-webfont.woff2") format("woff2"), /* Super Modern Browsers */
+       url("@{font-path}/OpenSans-ExtraBold-webfont.woff") format("woff"), /* Modern Browsers */
+       url("@{font-path}/OpenSans-ExtraBold-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
+       url("@{font-path}/OpenSans-ExtraBold-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
 }

--- a/src/less/icons.less
+++ b/src/less/icons.less
@@ -5,11 +5,11 @@
 
 @font-face {
   font-family: "@{icon-font-name-pf}";
-  src:url("@{font-path}@{icon-font-name-pf}.eot");
-  src:url("@{font-path}@{icon-font-name-pf}.eot?#iefix") format("embedded-opentype"),
-    url("@{font-path}@{icon-font-name-pf}.ttf") format("truetype"),
-    url("@{font-path}@{icon-font-name-pf}.woff") format("woff"),
-    url("@{font-path}@{icon-font-name-pf}.svg#@{icon-font-name-pf}") format("svg");
+  src:url("@{font-path}/@{icon-font-name-pf}.eot");
+  src:url("@{font-path}/@{icon-font-name-pf}.eot?#iefix") format("embedded-opentype"),
+    url("@{font-path}/@{icon-font-name-pf}.ttf") format("truetype"),
+    url("@{font-path}/@{icon-font-name-pf}.woff") format("woff"),
+    url("@{font-path}/@{icon-font-name-pf}.svg#@{icon-font-name-pf}") format("svg");
   font-weight: normal;
   font-style: normal;
 }

--- a/src/less/login.less
+++ b/src/less/login.less
@@ -30,7 +30,7 @@
     }
   }
   body {
-    background: @login-bg-color url("@{img-path}@{img-bg-login}") repeat-x 50% 0;
+    background: @login-bg-color url("@{img-path}/@{img-bg-login}") repeat-x 50% 0;
     background-size: auto;
     @media (min-width: @screen-sm-min) {
       background-size: 100% auto;

--- a/src/less/spinner.less
+++ b/src/less/spinner.less
@@ -46,27 +46,27 @@
 }
 
 .ie9 .spinner {
-  background: url("@{img-path}@{img-spinner}") no-repeat;
+  background: url("@{img-path}/@{img-spinner}") no-repeat;
   border: 0;
   &.spinner-inverse {
-    background-image: url("@{img-path}@{img-spinner-inverse}");
+    background-image: url("@{img-path}/@{img-spinner-inverse}");
   }
   &.spinner-inverse-lg {
-    background-image: url("@{img-path}@{img-spinner-inverse-lg}");
+    background-image: url("@{img-path}/@{img-spinner-inverse-lg}");
   }
   &.spinner-inverse-sm {
-    background-image: url("@{img-path}@{img-spinner-inverse-sm}");
+    background-image: url("@{img-path}/@{img-spinner-inverse-sm}");
   }
   &.spinner-inverse-xs {
-    background-image: url("@{img-path}@{img-spinner-inverse-xs}");
+    background-image: url("@{img-path}/@{img-spinner-inverse-xs}");
   }
   &.spinner-lg {
-    background-image: url("@{img-path}@{img-spinner-lg}");
+    background-image: url("@{img-path}/@{img-spinner-lg}");
   }
   &.spinner-sm {
-    background-image: url("@{img-path}@{img-spinner-sm}");
+    background-image: url("@{img-path}/@{img-spinner-sm}");
   }
   &.spinner-xs {
-    background-image: url("@{img-path}@{img-spinner-xs}");
+    background-image: url("@{img-path}/@{img-spinner-xs}");
   }
 }

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -5,7 +5,7 @@
 
 // Sass compass/sprockets asset helper flag
 // ----------------------
-@pf-sass-asset-helper:                                      false;
+@pf-sass-asset-helper:                                              false;
 
 // PatternFly-specific
 // -------------------
@@ -50,7 +50,7 @@
 @dropdown-link-focus-color:                                         @color-pf-white;
 @flyout-transition-pf:                                              all 200ms cubic-bezier(.35, 0, .25, 1);
 @font-family-monospace:                                             Menlo, Monaco, Consolas, monospace;
-@font-path:                                                         "../fonts/";
+@font-path:                                                         "../fonts";
 @footer-pf-bg-color:                                                @color-pf-black;
 @footer-pf-padding-left:                                            25px;
 @footer-pf-padding-top:                                             10px;
@@ -61,7 +61,7 @@
 @icon-font-name-pf:                                                 "PatternFlyIcons-webfont";
 @icon-prefix:                                                       pficon;
 @img-bg-login:                                                      "bg-login.jpg";
-@img-path:                                                          "../img/";
+@img-path:                                                          "../img";
 @img-spinner:                                                       "spinner.gif";
 @img-spinner-inverse:                                               "spinner-inverse.gif";
 @img-spinner-inverse-lg:                                            "spinner-inverse-lg.gif";
@@ -157,7 +157,7 @@
 @nav-pf-vertical-secondary-link-height:                             63px;
 @nav-pf-vertical-secondary-link-padding:                            4px 0 2px 0;
 @nav-pf-vertical-secondary-list-header-margin:                      30px 20px 10px 20px;
-@nav-pf-vertical-tertiary-active-color:                            @color-pf-white;
+@nav-pf-vertical-tertiary-active-color:                             @color-pf-white;
 @nav-pf-vertical-tertiary-active-bg-color:                          @color-pf-black-800;
 @nav-pf-vertical-tertiary-indicator-padding:                        0;
 @nav-pf-vertical-tertiary-bg-color:                                 @color-pf-black-700;
@@ -398,7 +398,7 @@
 @gray-light:                                                        lighten(@color-pf-black, 60%);   // #999
 @gray-lighter:                                                      lighten(@color-pf-black, 93.5%); // #eee
 @grid-gutter-width:                                                 40px;
-@icon-font-path:                                                    @font-path;
+@icon-font-path:                                                    "../fonts/";
 @input-bg-disabled:                                                 @color-pf-black-150;
 @input-border:                                                      @color-pf-black-400;
 @line-height-base:                                                  1.66666667; // 20/12

--- a/src/sass/converted/patternfly/_about-modal.scss
+++ b/src/sass/converted/patternfly/_about-modal.scss
@@ -4,7 +4,7 @@
 
 .about-modal-pf {
   background-color: $color-pf-black-900;
-  background-image: url("#{$img-path}#{$modal-about-pf-bg-img}");
+  background-image: url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}#{$modal-about-pf-bg-img}"), "#{$img-path}#{$modal-about-pf-bg-img}"));
   background-position: right bottom;
   background-repeat: no-repeat;
   background-size: 216px auto;

--- a/src/sass/converted/patternfly/_fonts.scss
+++ b/src/sass/converted/patternfly/_fonts.scss
@@ -6,119 +6,119 @@
   font-family: "Open Sans";
   font-style: normal;
   font-weight: 300;
-  src: url("#{$font-path}OpenSans-Light-webfont.eot"); /* IE9 Compat Modes */
+  src: url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Light-webfont.eot"), "#{$font-path}OpenSans-Light-webfont.eot")); /* IE9 Compat Modes */
   src: local("Open Sans Light"), local("OpenSans-Light"),
-       url("#{$font-path}OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("#{$font-path}OpenSans-Light-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("#{$font-path}OpenSans-Light-webfont.woff") format("woff"), /* Modern Browsers */
-       url("#{$font-path}OpenSans-Light-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("#{$font-path}OpenSans-Light-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Light-webfont.eot?#iefix"), "#{$font-path}OpenSans-Light-webfont.eot?#iefix")) format("embedded-opentype"), /* IE6-IE8 */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Light-webfont.woff2"), "#{$font-path}OpenSans-Light-webfont.woff2")) format("woff2"), /* Super Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Light-webfont.woff"), "#{$font-path}OpenSans-Light-webfont.woff")) format("woff"), /* Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Light-webfont.ttf"), "#{$font-path}OpenSans-Light-webfont.ttf")) format("truetype"), /* Safari, Android, iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Light-webfont.svg#OpenSans"), "#{$font-path}OpenSans-Light-webfont.svg#OpenSans")) format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: normal;
   font-weight: 400;
-  src: url("#{$font-path}OpenSans-Regular-webfont.eot"); /* IE9 Compat Modes */
+  src: url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Regular-webfont.eot"), "#{$font-path}OpenSans-Regular-webfont.eot")); /* IE9 Compat Modes */
   src: local("Open Sans"), local("OpenSans"),
-       url("#{$font-path}OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("#{$font-path}OpenSans-Regular-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("#{$font-path}OpenSans-Regular-webfont.woff") format("woff"), /* Modern Browsers */
-       url("#{$font-path}OpenSans-Regular-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("#{$font-path}OpenSans-Regular-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Regular-webfont.eot?#iefix"), "#{$font-path}OpenSans-Regular-webfont.eot?#iefix")) format("embedded-opentype"), /* IE6-IE8 */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Regular-webfont.woff2"), "#{$font-path}OpenSans-Regular-webfont.woff2")) format("woff2"), /* Super Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Regular-webfont.woff"), "#{$font-path}OpenSans-Regular-webfont.woff")) format("woff"), /* Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Regular-webfont.ttf"), "#{$font-path}OpenSans-Regular-webfont.ttf")) format("truetype"), /* Safari, Android, iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Regular-webfont.svg#OpenSans"), "#{$font-path}OpenSans-Regular-webfont.svg#OpenSans")) format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: italic;
   font-weight: 300;
-  src: url("#{$font-path}OpenSans-LightItalic-webfont.eot"); /* IE9 Compat Modes */
+  src: url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-LightItalic-webfont.eot"), "#{$font-path}OpenSans-LightItalic-webfont.eot")); /* IE9 Compat Modes */
   src: local("Open Sans Light Italic"), local("OpenSansLight-Italic"),
-       url("#{$font-path}OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("#{$font-path}OpenSans-LightItalic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("#{$font-path}OpenSans-LightItalic-webfont.woff") format("woff"), /* Modern Browsers */
-       url("#{$font-path}OpenSans-LightItalic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("#{$font-path}OpenSans-LightItalic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-LightItalic-webfont.eot?#iefix"), "#{$font-path}OpenSans-LightItalic-webfont.eot?#iefix")) format("embedded-opentype"), /* IE6-IE8 */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-LightItalic-webfont.woff2"), "#{$font-path}OpenSans-LightItalic-webfont.woff2")) format("woff2"), /* Super Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-LightItalic-webfont.woff"), "#{$font-path}OpenSans-LightItalic-webfont.woff")) format("woff"), /* Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-LightItalic-webfont.ttf"), "#{$font-path}OpenSans-LightItalic-webfont.ttf")) format("truetype"), /* Safari, Android, iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-LightItalic-webfont.svg#OpenSans"), "#{$font-path}OpenSans-LightItalic-webfont.svg#OpenSans")) format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: italic;
   font-weight: 400;
-  src: url("#{$font-path}OpenSans-Italic-webfont.eot"); /* IE9 Compat Modes */
+  src: url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Italic-webfont.eot"), "#{$font-path}OpenSans-Italic-webfont.eot")); /* IE9 Compat Modes */
   src: local("Open Sans Italic"), local("OpenSans-Italic"),
-       url("#{$font-path}OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("#{$font-path}OpenSans-Italic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("#{$font-path}OpenSans-Italic-webfont.woff") format("woff"), /* Modern Browsers */
-       url("#{$font-path}OpenSans-Italic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("#{$font-path}OpenSans-Italic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Italic-webfont.eot?#iefix"), "#{$font-path}OpenSans-Italic-webfont.eot?#iefix")) format("embedded-opentype"), /* IE6-IE8 */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Italic-webfont.woff2"), "#{$font-path}OpenSans-Italic-webfont.woff2")) format("woff2"), /* Super Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Italic-webfont.woff"), "#{$font-path}OpenSans-Italic-webfont.woff")) format("woff"), /* Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Italic-webfont.ttf"), "#{$font-path}OpenSans-Italic-webfont.ttf")) format("truetype"), /* Safari, Android, iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Italic-webfont.svg#OpenSans"), "#{$font-path}OpenSans-Italic-webfont.svg#OpenSans")) format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: normal;
   font-weight: 600;
-  src: url("#{$font-path}OpenSans-Semibold-webfont.eot"); /* IE9 Compat Modes */
+  src: url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Semibold-webfont.eot"), "#{$font-path}OpenSans-Semibold-webfont.eot")); /* IE9 Compat Modes */
   src: local("Open Sans Semibold"), local("OpenSans-Semibold-webfont"),
-       url("#{$font-path}OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("#{$font-path}OpenSans-Semibold-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("#{$font-path}OpenSans-Semibold-webfont.woff") format("woff"), /* Modern Browsers */
-       url("#{$font-path}OpenSans-Semibold-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("#{$font-path}OpenSans-Semibold-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Semibold-webfont.eot?#iefix"), "#{$font-path}OpenSans-Semibold-webfont.eot?#iefix")) format("embedded-opentype"), /* IE6-IE8 */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Semibold-webfont.woff2"), "#{$font-path}OpenSans-Semibold-webfont.woff2")) format("woff2"), /* Super Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Semibold-webfont.woff"), "#{$font-path}OpenSans-Semibold-webfont.woff")) format("woff"), /* Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Semibold-webfont.ttf"), "#{$font-path}OpenSans-Semibold-webfont.ttf")) format("truetype"), /* Safari, Android, iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Semibold-webfont.svg#OpenSans"), "#{$font-path}OpenSans-Semibold-webfont.svg#OpenSans")) format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: italic;
   font-weight: 600;
-  src: url("#{$font-path}OpenSans-SemiboldItalic-webfont.eot"); /* IE9 Compat Modes */
+  src: url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-SemiboldItalic-webfont.eot"), "#{$font-path}OpenSans-SemiboldItalic-webfont.eot")); /* IE9 Compat Modes */
   src: local("Open Sans Semibold Italic"), local("OpenSans-SemiboldItalic-webfont"),
-       url("#{$font-path}OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("#{$font-path}OpenSans-SemiboldItalic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("#{$font-path}OpenSans-SemiboldItalic-webfont.woff") format("woff"), /* Modern Browsers */
-       url("#{$font-path}OpenSans-SemiboldItalic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("#{$font-path}OpenSans-SemiboldItalic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-SemiboldItalic-webfont.eot?#iefix"), "#{$font-path}OpenSans-SemiboldItalic-webfont.eot?#iefix")) format("embedded-opentype"), /* IE6-IE8 */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-SemiboldItalic-webfont.woff2"), "#{$font-path}OpenSans-SemiboldItalic-webfont.woff2")) format("woff2"), /* Super Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-SemiboldItalic-webfont.woff"), "#{$font-path}OpenSans-SemiboldItalic-webfont.woff")) format("woff"), /* Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-SemiboldItalic-webfont.ttf"), "#{$font-path}OpenSans-SemiboldItalic-webfont.ttf")) format("truetype"), /* Safari, Android, iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-SemiboldItalic-webfont.svg#OpenSans"), "#{$font-path}OpenSans-SemiboldItalic-webfont.svg#OpenSans")) format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: normal;
   font-weight: 700;
-  src: url("#{$font-path}OpenSans-Bold-webfont.eot"); /* IE9 Compat Modes */
+  src: url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Bold-webfont.eot"), "#{$font-path}OpenSans-Bold-webfont.eot")); /* IE9 Compat Modes */
   src: local("Open Sans Bold"), local("OpenSans-Bold"),
-       url("#{$font-path}OpenSans-Bold-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("#{$font-path}OpenSans-Bold-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("#{$font-path}OpenSans-Bold-webfont.woff") format("woff"), /* Modern Browsers */
-       url("#{$font-path}OpenSans-Bold-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("#{$font-path}OpenSans-Bold-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Bold-webfont.eot?#iefix"), "#{$font-path}OpenSans-Bold-webfont.eot?#iefix")) format("embedded-opentype"), /* IE6-IE8 */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Bold-webfont.woff2"), "#{$font-path}OpenSans-Bold-webfont.woff2")) format("woff2"), /* Super Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Bold-webfont.woff"), "#{$font-path}OpenSans-Bold-webfont.woff")) format("woff"), /* Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Bold-webfont.ttf"), "#{$font-path}OpenSans-Bold-webfont.ttf")) format("truetype"), /* Safari, Android, iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-Bold-webfont.svg#OpenSans"), "#{$font-path}OpenSans-Bold-webfont.svg#OpenSans")) format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: italic;
   font-weight: 700;
-  src: url("#{$font-path}OpenSans-BoldItalic-webfont.eot"); /* IE9 Compat Modes */
+  src: url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-BoldItalic-webfont.eot"), "#{$font-path}OpenSans-BoldItalic-webfont.eot")); /* IE9 Compat Modes */
   src: local("Open Sans Bold Italic"), local("OpenSans-BoldItalic"),
-       url("#{$font-path}OpenSans-BoldItalic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("#{$font-path}OpenSans-BoldItalic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("#{$font-path}OpenSans-BoldItalic-webfont.woff") format("woff"), /* Modern Browsers */
-       url("#{$font-path}OpenSans-BoldItalic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("#{$font-path}OpenSans-BoldItalic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-BoldItalic-webfont.eot?#iefix"), "#{$font-path}OpenSans-BoldItalic-webfont.eot?#iefix")) format("embedded-opentype"), /* IE6-IE8 */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-BoldItalic-webfont.woff2"), "#{$font-path}OpenSans-BoldItalic-webfont.woff2")) format("woff2"), /* Super Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-BoldItalic-webfont.woff"), "#{$font-path}OpenSans-BoldItalic-webfont.woff")) format("woff"), /* Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-BoldItalic-webfont.ttf"), "#{$font-path}OpenSans-BoldItalic-webfont.ttf")) format("truetype"), /* Safari, Android, iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-BoldItalic-webfont.svg#OpenSans"), "#{$font-path}OpenSans-BoldItalic-webfont.svg#OpenSans")) format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: italic;
   font-weight: 800;
-  src: url("#{$font-path}OpenSans-ExtraBoldItalic-webfont.eot"); /* IE9 Compat Modes */
+  src: url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-ExtraBoldItalic-webfont.eot"), "#{$font-path}OpenSans-ExtraBoldItalic-webfont.eot")); /* IE9 Compat Modes */
   src: local("Open Sans Extrabold Italic"), local("OpenSans-ExtraboldItalic"),
-       url("#{$font-path}OpenSans-ExtraBoldItalic-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("#{$font-path}OpenSans-ExtraBoldItalic-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("#{$font-path}OpenSans-ExtraBoldItalic-webfont.woff") format("woff"), /* Modern Browsers */
-       url("#{$font-path}OpenSans-ExtraBoldItalic-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("#{$font-path}OpenSans-ExtraBoldItalic-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-ExtraBoldItalic-webfont.eot?#iefix"), "#{$font-path}OpenSans-ExtraBoldItalic-webfont.eot?#iefix")) format("embedded-opentype"), /* IE6-IE8 */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-ExtraBoldItalic-webfont.woff2"), "#{$font-path}OpenSans-ExtraBoldItalic-webfont.woff2")) format("woff2"), /* Super Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-ExtraBoldItalic-webfont.woff"), "#{$font-path}OpenSans-ExtraBoldItalic-webfont.woff")) format("woff"), /* Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-ExtraBoldItalic-webfont.ttf"), "#{$font-path}OpenSans-ExtraBoldItalic-webfont.ttf")) format("truetype"), /* Safari, Android, iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-ExtraBoldItalic-webfont.svg#OpenSans"), "#{$font-path}OpenSans-ExtraBoldItalic-webfont.svg#OpenSans")) format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Open Sans";
   font-style: normal;
   font-weight: 800;
-  src: url("#{$font-path}OpenSans-ExtraBold-webfont.eot"); /* IE9 Compat Modes */
+  src: url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-ExtraBold-webfont.eot"), "#{$font-path}OpenSans-ExtraBold-webfont.eot")); /* IE9 Compat Modes */
   src: local("Open Sans Extrabold"), local("OpenSans-Extrabold"),
-       url("#{$font-path}OpenSans-ExtraBold-webfont.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-       url("#{$font-path}OpenSans-ExtraBold-webfont.woff2") format("woff2"), /* Super Modern Browsers */
-       url("#{$font-path}OpenSans-ExtraBold-webfont.woff") format("woff"), /* Modern Browsers */
-       url("#{$font-path}OpenSans-ExtraBold-webfont.ttf") format("truetype"), /* Safari, Android, iOS */
-       url("#{$font-path}OpenSans-ExtraBold-webfont.svg#OpenSans") format("svg"); /* Legacy iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-ExtraBold-webfont.eot?#iefix"), "#{$font-path}OpenSans-ExtraBold-webfont.eot?#iefix")) format("embedded-opentype"), /* IE6-IE8 */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-ExtraBold-webfont.woff2"), "#{$font-path}OpenSans-ExtraBold-webfont.woff2")) format("woff2"), /* Super Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-ExtraBold-webfont.woff"), "#{$font-path}OpenSans-ExtraBold-webfont.woff")) format("woff"), /* Modern Browsers */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-ExtraBold-webfont.ttf"), "#{$font-path}OpenSans-ExtraBold-webfont.ttf")) format("truetype"), /* Safari, Android, iOS */
+       url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}OpenSans-ExtraBold-webfont.svg#OpenSans"), "#{$font-path}OpenSans-ExtraBold-webfont.svg#OpenSans")) format("svg"); /* Legacy iOS */
 }

--- a/src/sass/converted/patternfly/_icons.scss
+++ b/src/sass/converted/patternfly/_icons.scss
@@ -5,11 +5,11 @@
 
 @font-face {
   font-family: "#{$icon-font-name-pf}";
-  src:url("#{$font-path}#{$icon-font-name-pf}.eot");
-  src:url("#{$font-path}#{$icon-font-name-pf}.eot?#iefix") format("embedded-opentype"),
-    url("#{$font-path}#{$icon-font-name-pf}.ttf") format("truetype"),
-    url("#{$font-path}#{$icon-font-name-pf}.woff") format("woff"),
-    url("#{$font-path}#{$icon-font-name-pf}.svg##{$icon-font-name-pf}") format("svg");
+  src:url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}#{$icon-font-name-pf}.eot"), "#{$font-path}#{$icon-font-name-pf}.eot"));
+  src:url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}#{$icon-font-name-pf}.eot?#iefix"), "#{$font-path}#{$icon-font-name-pf}.eot?#iefix")) format("embedded-opentype"),
+    url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}#{$icon-font-name-pf}.ttf"), "#{$font-path}#{$icon-font-name-pf}.ttf")) format("truetype"),
+    url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}#{$icon-font-name-pf}.woff"), "#{$font-path}#{$icon-font-name-pf}.woff")) format("woff"),
+    url(if($bootstrap-sass-asset-helper, twbs-font-path("#{$font-path}#{$icon-font-name-pf}.svg##{$icon-font-name-pf}"), "#{$font-path}#{$icon-font-name-pf}.svg##{$icon-font-name-pf}")) format("svg");
   font-weight: normal;
   font-style: normal;
 }

--- a/src/sass/converted/patternfly/_login.scss
+++ b/src/sass/converted/patternfly/_login.scss
@@ -30,7 +30,7 @@
     }
   }
   body {
-    background: $login-bg-color url("#{$img-path}#{$img-bg-login}") repeat-x 50% 0;
+    background: $login-bg-color url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}#{$img-bg-login}"), "#{$img-path}#{$img-bg-login}")) repeat-x 50% 0;
     background-size: auto;
     @media (min-width: $screen-sm-min) {
       background-size: 100% auto;

--- a/src/sass/converted/patternfly/_spinner.scss
+++ b/src/sass/converted/patternfly/_spinner.scss
@@ -46,27 +46,27 @@
 }
 
 .ie9 .spinner {
-  background: url("#{$img-path}#{$img-spinner}") no-repeat;
+  background: url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}#{$img-spinner}"), "#{$img-path}#{$img-spinner}")) no-repeat;
   border: 0;
   &.spinner-inverse {
-    background-image: url("#{$img-path}#{$img-spinner-inverse}");
+    background-image: url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}#{$img-spinner-inverse}"), "#{$img-path}#{$img-spinner-inverse}"));
   }
   &.spinner-inverse-lg {
-    background-image: url("#{$img-path}#{$img-spinner-inverse-lg}");
+    background-image: url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}#{$img-spinner-inverse-lg}"), "#{$img-path}#{$img-spinner-inverse-lg}"));
   }
   &.spinner-inverse-sm {
-    background-image: url("#{$img-path}#{$img-spinner-inverse-sm}");
+    background-image: url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}#{$img-spinner-inverse-sm}"), "#{$img-path}#{$img-spinner-inverse-sm}"));
   }
   &.spinner-inverse-xs {
-    background-image: url("#{$img-path}#{$img-spinner-inverse-xs}");
+    background-image: url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}#{$img-spinner-inverse-xs}"), "#{$img-path}#{$img-spinner-inverse-xs}"));
   }
   &.spinner-lg {
-    background-image: url("#{$img-path}#{$img-spinner-lg}");
+    background-image: url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}#{$img-spinner-lg}"), "#{$img-path}#{$img-spinner-lg}"));
   }
   &.spinner-sm {
-    background-image: url("#{$img-path}#{$img-spinner-sm}");
+    background-image: url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}#{$img-spinner-sm}"), "#{$img-path}#{$img-spinner-sm}"));
   }
   &.spinner-xs {
-    background-image: url("#{$img-path}#{$img-spinner-xs}");
+    background-image: url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}#{$img-spinner-xs}"), "#{$img-path}#{$img-spinner-xs}"));
   }
 }

--- a/src/sass/converted/patternfly/_variables.scss
+++ b/src/sass/converted/patternfly/_variables.scss
@@ -5,7 +5,7 @@
 
 // Sass compass/sprockets asset helper flag
 // ----------------------
-$pf-sass-asset-helper:                                      false !default;
+$pf-sass-asset-helper:                                              false !default;
 
 // PatternFly-specific
 // -------------------
@@ -157,7 +157,7 @@ $nav-pf-vertical-secondary-item-padding:                            0 0 5px 0 !d
 $nav-pf-vertical-secondary-link-height:                             63px !default;
 $nav-pf-vertical-secondary-link-padding:                            4px 0 2px 0 !default;
 $nav-pf-vertical-secondary-list-header-margin:                      30px 20px 10px 20px !default;
-$nav-pf-vertical-tertiary-active-color:                            $color-pf-white !default;
+$nav-pf-vertical-tertiary-active-color:                             $color-pf-white !default;
 $nav-pf-vertical-tertiary-active-bg-color:                          $color-pf-black-800 !default;
 $nav-pf-vertical-tertiary-indicator-padding:                        0 !default;
 $nav-pf-vertical-tertiary-bg-color:                                 $color-pf-black-700 !default;
@@ -398,7 +398,7 @@ $gray-darker:                                                       lighten($col
 $gray-light:                                                        lighten($color-pf-black, 60%) !default;   // #999
 $gray-lighter:                                                      lighten($color-pf-black, 93.5%) !default; // #eee
 $grid-gutter-width:                                                 40px !default;
-$icon-font-path:                                                    $font-path !default;
+$icon-font-path:                                                    if($pf-sass-asset-helper, "", "../fonts/") !default;
 $input-bg-disabled:                                                 $color-pf-black-150 !default;
 $input-border:                                                      $color-pf-black-400 !default;
 $line-height-base:                                                  1.66666667 !default; // 20/12


### PR DESCRIPTION
## Description
PR #840 introduced a breaking change related to relative paths defined by Less variables. This change was reverted and the Sass conversion rules were adjusted to ensure the necessary changes are only present in Sass.

## Changes
### Less
* Revert changes to `@font-path`, `@img-path`, and `@icon-font-path` variables in Less
* Revert changes to Less where forward slashes were removed from url's using the above variables.

### Sass
* Add Sass conversion rule that appends a forward slash to these variables as needed.
* Adjust Sass conversion rule for urls that use these Sass variables to remove extra forward slash.
* Adjust Sass conversion rule to add conditional Compass/Sprockets asset helper functions in `url()` statements.

## PR checklist

- [X] **Cross browser**: works in Chrome
- [X] **Responsive**: works in extra small, small, medium and large view ports.
- [X] **Less Visual Regression Tests**: Less changes pass all relevant visual regression tests
- [X] **Sass Conversion**: Sass conversion step has been completed and committed
- [X] **Sass Visual Regression Tests**: Sass changes pass all relevant visual regression tests