### PR TITLE
RCUE fix: Remove relative paths for bootstrap-slider

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -99,6 +99,8 @@ module.exports = function (grunt) {
           {expand: true, cwd: 'node_modules/bootstrap-datepicker/less/', src: ['**'], dest: 'dist/less/dependencies/bootstrap-datepicker/'},
           // copy Bootstrap-Select less files
           {expand: true, cwd: 'node_modules/bootstrap-select/less/', src: ['**'], dest: 'dist/less/dependencies/bootstrap-select/'},
+          // copy Bootstrap-Slider less files
+          {expand: true, cwd: 'node_modules/bootstrap-slider/src/less', src: ['**'], dest: 'dist/less/dependencies/bootstrap-slider/'},
           // Bootstrap Switch less files must be manually copied because of edits made to source less for strict-math purposes
           // manually copy 'node_modules/bootstrap-switch/src/less/bootstrap3/' and make sure any math is wrapped with parentheses
           // copy Bootstrap Touchspin css file

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@commitlint/cli": "^3.2.0",
     "autoprefixer": "^6.4.0",
     "backstopjs": "^3.0.0",
-    "bootstrap-slider": "^9.9.0",
     "chromy": "^0.5.5",
     "commitizen": "^2.9.6",
     "commitlint-config-cz": "^0.5.0",
@@ -64,6 +63,7 @@
   "optionalDependencies": {
     "bootstrap-datepicker": "~1.6.4",
     "bootstrap-select": "^1.12.2",
+    "bootstrap-slider": "^9.9.0",
     "bootstrap-switch": "~3.3.4",
     "bootstrap-touchspin": "~3.1.1",
     "c3": "~0.4.11",

--- a/src/less/patternfly-additions.less
+++ b/src/less/patternfly-additions.less
@@ -7,10 +7,11 @@
 @import "font-awesome/less/variables.less";
 
 // Bootstrap-Slider
-@import "/bootstrap-slider/src/less/bootstrap-slider.less";
+@import "bootstrap-slider/src/less/variables.less";
+@import "bootstrap-slider/src/less/rules.less";
 
 // Bootstrap-Combobox
-@import "/patternfly-bootstrap-combobox/less/combobox.less";
+@import "patternfly-bootstrap-combobox/less/combobox.less";
 // Bootstrap-Datepicker
 @import "bootstrap-datepicker/less/datepicker3.less";
 // Bootstrap-Select


### PR DESCRIPTION
## Description
The RCUE build is currently breaking because the bootstrap-slider uses relative paths to import LESS.

Fixes https://github.com/patternfly/patternfly/issues/853

## Changes

- Replaces bootstrap-slider.less less file with files that do not include relative paths
- Adds missing less dependencies to dist folder
- Move bootstrap-slider under optionalDependencies Vs devDependencies

Note that an alternative solution is to rename RCUE’s less dir as src/less in order to build CSS from a similar directory hierarchy.

## Link to rawgit and/or image

https://rawgit.com/dlabrecq/patternfly/bootstrap-slider-dist/dist/tests/
