### PR TITLE
Include only the necessary files in the rubygem specification

### DIFF
--- a/patternfly-sass.gemspec
+++ b/patternfly-sass.gemspec
@@ -15,6 +15,16 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'bootstrap-sass', '~> 3.3.7'
   s.add_runtime_dependency 'font-awesome-sass', '~> 4.6.2'
 
-  s.files      = `git ls-files`.split("\n")
-  s.test_files = `git ls-files -- tests/*`.split("\n")
+  s.files = [
+    'patternfly-sass.gemspec',
+    'LICENSE.txt',
+    'README.md',
+    'CODE_OF_CONDUCT.md',
+    'QUICKSTART.md',
+    'OPEN_SOURCE_LICENCES.txt',
+    Dir.glob('dist/sass/**/*'),
+    Dir.glob('dist/js/**/*'),
+    Dir.glob('dist/fonts/**/*'),
+    Dir.glob('dist/img/**/*')
+  ].flatten
 end


### PR DESCRIPTION
We don't need the LESS files, the source, tests and other NPM/bower-related files in the gem.