### PR TITLE
fix(sass): added missing lib folder into gemspec

### DIFF
--- a/lib/patternfly-sass/version.rb
+++ b/lib/patternfly-sass/version.rb
@@ -1,5 +1,8 @@
 module Patternfly
-  require 'json'
-  path = File.join(File.dirname(__FILE__), '../../package.json')
-  VERSION = JSON.parse(File.read(path))['version']
+  VERSION = begin
+    # Retrieve the version number from the package.json
+    require 'json'
+    path = File.join(File.dirname(__FILE__), '../../package.json')
+    JSON.parse(File.read(path))['version']
+  end
 end

--- a/patternfly-sass.gemspec
+++ b/patternfly-sass.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
     'CODE_OF_CONDUCT.md',
     'QUICKSTART.md',
     'OPEN_SOURCE_LICENCES.txt',
+    Dir.glob('lib/**/*'),
     Dir.glob('dist/sass/**/*'),
     Dir.glob('dist/js/**/*'),
     Dir.glob('dist/fonts/**/*'),


### PR DESCRIPTION
Without this folder the gem can not be included in Rails, I missed it ... sorry.
Also simplified the version detection for future automation.