### PR TITLE
fix(login): Replaces invalid fade for valid sass mixin, rbga

### DIFF
--- a/src/sass/converted/patternfly/_variables.scss
+++ b/src/sass/converted/patternfly/_variables.scss
@@ -85,7 +85,7 @@ $list-view-divider:                                                 $color-pf-bl
 $list-view-hover-bg:                                                $color-pf-blue-25 !default;
 $list-group-top-border:                                             $color-pf-black-200 !default;
 $login-bg-color:                                                    $color-pf-black !default;
-$login-container-bg-color-rgba:                                     fade($color-pf-white, 5.5%) !default;
+$login-container-bg-color-rgba:                                     fade_out($color-pf-white, 0.945) !default;
 $modal-about-pf-bg-img:                                             "bg-modal-about-pf.png" !default;
 $modal-title-padding-horizontal:                                    18px !default;
 $modal-title-padding-vertical:                                      10px !default;


### PR DESCRIPTION
closes #879

this is for da sass

OK SO less variable in place calculates to: `background-color: rgba(255,255,255,.055);`
This work calculates to: `background-color: rgba(255, 255, 255, 0.055);`

close enough right?  😏 

🔪 🍍 