### PR TITLE
chore(tests): Update JS references to use https

### DIFF
--- a/tests/pages/_includes/head.html
+++ b/tests/pages/_includes/head.html
@@ -27,8 +27,8 @@
     {% else if site.url-css-extra %}
       <link href="{{ site.url-css-extra }}" rel="stylesheet" media="screen, print">
     {% endif %}
-    <script src="http://code.jquery.com/jquery-3.2.1.min.js"></script>
-    <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
     {% if page.url-js-extra %}{% for urlextrajs in page.url-js-extra %}
     <script src="{{ urlextrajs, site.url-components }}"></script>
     {% endfor %}{% endif %}


### PR DESCRIPTION
## Description
jQuery wasn't loading on the test pages. As a result, the wizard was throwing errors and failing to launch the modals.

Ticket: https://patternfly.atlassian.net/browse/PTNFLY-2672