### PR TITLE
fix(sass): Fix conversion rule for fade() to rgba()

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -384,7 +384,7 @@ module.exports = function (grunt) {
           }
         ],
         options: {
-          excludes: ['variables', 'default'],
+          excludes: ['variables', 'default', 'rgba'],
           replacements: [
             {
               // Customize variable conversion to include newer css reserved words.
@@ -414,6 +414,12 @@ module.exports = function (grunt) {
               // Include mixins with no arguments
               pattern: /(\s+)\.([\w\-]+)\(\)/gi,
               replacement: '$1@include $2()',
+              order: 3
+            },
+            // Original fade -> rgba conversion did not account for decimal percentages
+            {
+              pattern: /fade\((.*),\s?([\d\.]+)\%\)/gmi,
+              replacement: 'rgba($1, ($2/100))',
               order: 3
             },
             {

--- a/src/sass/converted/patternfly/_bootstrap-datepicker.scss
+++ b/src/sass/converted/patternfly/_bootstrap-datepicker.scss
@@ -6,11 +6,11 @@
   background-color: $input-bg;
   border-color: $input-border !important;
   color: $input-color;
-  @include box-shadow(inset 0 1px 1px fade($color-pf-black, 7.5%));
+  @include box-shadow(inset 0 1px 1px rgba($color-pf-black, (7.5/100)));
   @include form-control-outline();
   &:focus {
     // TODO Create global variables for validation box shadows?
-    $input-validation-focus-box-shadow: fade($color-pf-black, 7.5%);
+    $input-validation-focus-box-shadow: rgba($color-pf-black, (7.5/100));
     border-color: $input-border-focus !important;
     .has-error & {
       // TODO Create global variables for validation box shadows?

--- a/src/sass/converted/patternfly/_bootstrap-select.scss
+++ b/src/sass/converted/patternfly/_bootstrap-select.scss
@@ -8,7 +8,7 @@
   }
   .btn {
     // TODO Create global variable for validation state box shadows?
-    $input-validation-focus-box-shadow: fade($color-pf-black, 7.5%);
+    $input-validation-focus-box-shadow: rgba($color-pf-black, (7.5/100));
     &:hover {
       border-color: $input-border-hover;
     }

--- a/src/sass/converted/patternfly/_cards.scss
+++ b/src/sass/converted/patternfly/_cards.scss
@@ -5,7 +5,7 @@
 .card-pf {
   background: $card-pf-bg-color;
   border-top: 2px solid $card-pf-border-top-color;
-  @include box-shadow(0 1px 1px fade($color-pf-black, 17.5%));
+  @include box-shadow(0 1px 1px rgba($color-pf-black, (17.5/100)));
   margin: 0 (-($grid-gutter-width / 4)) ($grid-gutter-width / 2);
   padding: 0 ($grid-gutter-width / 2);
   &.card-pf-accented {

--- a/src/sass/converted/patternfly/_datatables.scss
+++ b/src/sass/converted/patternfly/_datatables.scss
@@ -22,7 +22,7 @@
   background-color: $dropdown-bg;
   border: 1px solid $dropdown-border;
   border-radius: $border-radius-base;
-  @include box-shadow(0 6px 12px fade($color-pf-black, 17.5%));
+  @include box-shadow(0 6px 12px rgba($color-pf-black, (17.5/100)));
   background-clip: padding-box;
   list-style: none;
   margin: -1px 0 0 0;
@@ -139,7 +139,7 @@
     text-align: right;
     .paginate_input {
       border: 1px solid $color-pf-black-300;
-      @include box-shadow(inset 0 1px 1px fade($color-pf-black, 7.5%));
+      @include box-shadow(inset 0 1px 1px rgba($color-pf-black, (7.5/100)));
       font-size: $font-size-base;
       font-weight: 600;
       height: 19px;

--- a/src/sass/converted/patternfly/_notifications-drawer.scss
+++ b/src/sass/converted/patternfly/_notifications-drawer.scss
@@ -6,7 +6,7 @@
 .drawer-pf {
   background-color: $color-pf-black-100;
   border: 1px solid $card-pf-border-color;
-  @include box-shadow(0 6px 12px fade($color-pf-black, 17.5%));
+  @include box-shadow(0 6px 12px rgba($color-pf-black, (17.5/100)));
   overflow-y: auto;
   position: absolute;
   right: 0;

--- a/src/sass/converted/patternfly/_pager.scss
+++ b/src/sass/converted/patternfly/_pager.scss
@@ -19,7 +19,7 @@
     }
     a:active {
       background-image: none;
-      @include box-shadow(inset 0 3px 5px fade($color-pf-black, 12.5%));
+      @include box-shadow(inset 0 3px 5px rgba($color-pf-black, (12.5/100)));
       outline: 0;
     }
   }

--- a/src/sass/converted/patternfly/_toolbar.scss
+++ b/src/sass/converted/patternfly/_toolbar.scss
@@ -5,7 +5,7 @@
 .toolbar-pf {
   background: $color-pf-white;
   border-bottom: 1px solid $sidebar-pf-border-color;
-  box-shadow: 0 1px 0px fade($color-pf-black, 4.5%);
+  box-shadow: 0 1px 0px rgba($color-pf-black, (4.5/100));
   padding-top: ($grid-gutter-width/4);
   .form-group {
     margin-bottom: ($grid-gutter-width/4);

--- a/src/sass/converted/patternfly/_variables.scss
+++ b/src/sass/converted/patternfly/_variables.scss
@@ -85,7 +85,7 @@ $list-view-divider:                                                 $color-pf-bl
 $list-view-hover-bg:                                                $color-pf-blue-25 !default;
 $list-group-top-border:                                             $color-pf-black-200 !default;
 $login-bg-color:                                                    $color-pf-black !default;
-$login-container-bg-color-rgba:                                     fade($color-pf-white, 5.5%) !default;
+$login-container-bg-color-rgba:                                     rgba($color-pf-white, (5.5/100)) !default;
 $modal-about-pf-bg-img:                                             "bg-modal-about-pf.png" !default;
 $modal-title-padding-horizontal:                                    18px !default;
 $modal-title-padding-vertical:                                      10px !default;


### PR DESCRIPTION
## Description
Add new custom Sass conversion rule that converts less fade() function with equivalent sass rgba() function, and properly handles decimal percentages.

Fixes Issue #879, replaces PR #880