### PR TITLE
feat(sass): Automated gem release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ after_success:
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_bump.sh -p;
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-npm.sh || travis_terminate 0;
        npm run semantic-release-post;
+       sh -x ./scripts/gem_release.sh;
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-webjar.sh -p;
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_release-all.sh -o;
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_release-all.sh -r;

--- a/scripts/gem_release.sh
+++ b/scripts/gem_release.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Set the API key for rubygems.org
+mkdir -p ~/.gem
+echo -e "---\n:rubygems_api_key: $RUBYGEMS_TOKEN" > ~/.gem/credentials
+chmod 600 ~/.gem/credentials
+
+# Hardcode the package version
+ruby -r ./lib/patternfly-sass/version.rb <<-END
+  version = Patternfly::VERSION
+  file = File.read('./lib/patternfly-sass/version.rb').sub(/begin(.*?)end/m, "'#{version}'")
+  File.open('./lib/patternfly-sass/version.rb', 'w') do |f|
+    f.write(file)
+  end
+END
+
+# Build and push the gem
+gem build patternfly-sass.gemspec
+gem push patternfly-sass-*.gem


### PR DESCRIPTION
I created a shell script that releases patternfly-sass as a rubygem. I'm not sure if I'm calling it on the right line in the `.travis.yml` but it seemed logical after the `npm publish`. It is necessary to have the right version set in the `package.json` and all the js/sass/font/image files in the `dist` folder. 