### PR TITLE
fix(sass): Release the gem with the standard Travis way

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ after_success:
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_bump.sh -p;
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-npm.sh || travis_terminate 0;
        npm run semantic-release-post;
-       sh -x ./scripts/gem_release.sh;
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-webjar.sh -p;
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_release-all.sh -o;
        sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_release-all.sh -r;
@@ -45,3 +44,15 @@ after_success:
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
+
+# Automated RubyGems.org deployment
+before_deploy: "sh -x ./scripts/gem_release.sh"
+deploy:
+  skip_cleanup: true
+  provider: rubygems
+  api_key:
+    secure: RP2UsRAyz1+D5e/Mt4C8c3kfq9nzPunQ3QGSTFMkhCmH0dcyBNqGLaIWbrOtRPIeYXpcneoj4SfBvgdmixhi06NMkjw5Vcn213VUZAdafMthAkB3RaQexuzqyz8F8NVTdtXm15zBz/XDZtm42AkOlotoctNUeChFhyhzq3WG9uw=
+  gem: patternfly-sass
+  on:
+    branch: master-dist
+    repo: patternfly/patternfly

--- a/scripts/gem_release.sh
+++ b/scripts/gem_release.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# Set the API key for rubygems.org
-mkdir -p ~/.gem
-echo -e "---\n:rubygems_api_key: $RUBYGEMS_TOKEN" > ~/.gem/credentials
-chmod 600 ~/.gem/credentials
-
 # Hardcode the package version
 ruby -r ./lib/patternfly-sass/version.rb <<-END
   version = Patternfly::VERSION
@@ -13,7 +8,3 @@ ruby -r ./lib/patternfly-sass/version.rb <<-END
     f.write(file)
   end
 END
-
-# Build and push the gem
-gem build patternfly-sass.gemspec
-gem push patternfly-sass-*.gem


### PR DESCRIPTION
It seems like Travis doesn't like us for [writing an ENV var to a file](https://travis-ci.org/patternfly/patternfly/builds/317710350#L5533). Travis has a standard way of deploying to Rubygems.org. I was not using this before as here we can't control when the deploy script will run. However, it seems like there's no other way...