### PR TITLE
Empty state test page and styling

### DIFF
--- a/src/less/blank-slate.less
+++ b/src/less/blank-slate.less
@@ -26,4 +26,10 @@
   .blank-slate-pf-secondary-action {
     margin-top: @line-height-computed;
   }
+  button {
+    margin-right: 5px;
+    &:last-of-type {
+      margin-right: 0;
+    }
+  }
 }

--- a/src/sass/converted/patternfly/_blank-slate.scss
+++ b/src/sass/converted/patternfly/_blank-slate.scss
@@ -26,4 +26,10 @@
   .blank-slate-pf-secondary-action {
     margin-top: $line-height-computed;
   }
+  button {
+    margin-right: 5px;
+    &:last-of-type {
+      margin-right: 0;
+    }
+  }
 }

--- a/tests/pages/_includes/widgets/communication/blank-slate.html
+++ b/tests/pages/_includes/widgets/communication/blank-slate.html
@@ -15,6 +15,7 @@
     <button class="btn btn-primary btn-lg"> Main Action </button>
   </div>
   <div class="blank-slate-pf-secondary-action">
-    <button class="btn btn-default"> Secondary Action </button> <button class="btn btn-default"> Secondary Action </button> <button class="btn btn-default"> Secondary Action </button>
+    <button class="btn btn-default">Secondary Action</button>
+    <button class="btn btn-default">Secondary Action</button>
   </div>
 </div>


### PR DESCRIPTION
## Description
Empty state test page and styling updates. This is related to [AngularPF](http://www.patternfly.org/angular-patternfly/#/api/patternfly.views.component:pfEmptyState) and [React Empty State components](https://github.com/patternfly/patternfly-react/pull/141)

Relates to the closed issue #699 around spacing on the secondary actions.

## Changes

* Test page for Empty State
* Change to make spacing consistent along the secondary action links/buttons and non-dependent on new line breaks
  * _input needed on the spacing between links/buttons... as of now it's similar what was used in AngularPf and called out in #699_

## Link to rawgit and/or image

https://rawgit.com/cdcabrera/patternfly/feature/empty-state-dist/dist/tests/blank-slate.html

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.

  
  