### PR TITLE
feat(dependencies): Update older dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.7",
-    "bootstrap-datepicker": "~1.6.4",
+    "bootstrap-datepicker": "^1.7.1",
     "bootstrap-sass": "^3.3.7",
     "bootstrap-select": "~1.12.2",
     "bootstrap-switch": "<=3.3.3",
@@ -29,7 +29,7 @@
     "c3": "~0.4.11",
     "d3": "~3.5.17",
     "datatables": "~1.10.15",
-    "datatables-colreorder": "~1.3.2",
+    "datatables-colreorder": "^1.4.1",
     "datatables-colvis": "~1.1.2",
     "eonasdan-bootstrap-datetimepicker": "~4.17.47",
     "font-awesome": "~4.7.0",
@@ -37,7 +37,7 @@
     "google-code-prettify": "~1.0.5",
     "jquery": "~3.2.1",
     "matchHeight": "~0.7.2",
-    "moment": "~2.18.1",
+    "moment": "^2.19.1",
     "patternfly-bootstrap-combobox": "~1.1.7",
     "patternfly-bootstrap-treeview": "~2.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "table": "3.7.9"
   },
   "optionalDependencies": {
-    "bootstrap-datepicker": "~1.6.4",
+    "bootstrap-datepicker": "^1.7.1",
     "bootstrap-sass": "^3.3.7",
     "bootstrap-select": "^1.12.2",
     "bootstrap-slider": "^9.9.0",
@@ -72,7 +72,7 @@
     "c3": "~0.4.11",
     "d3": "~3.5.17",
     "datatables.net": "^1.10.15",
-    "datatables.net-colreorder": "~1.3.2",
+    "datatables.net-colreorder": "^1.4.1",
     "datatables.net-colreorder-bs": "~1.3.2",
     "datatables.net-select": "~1.2.0",
     "drmonty-datatables-colvis": "~1.1.2",
@@ -80,7 +80,7 @@
     "font-awesome-sass": "^4.7.0",
     "google-code-prettify": "~1.0.5",
     "jquery-match-height": "^0.7.2",
-    "moment": "~2.14.1",
+    "moment": "^2.19.1",
     "moment-timezone": "^0.4.1",
     "patternfly-bootstrap-combobox": "~1.1.7",
     "patternfly-bootstrap-treeview": "~2.1.0"


### PR DESCRIPTION
## Description
Updates out of date dependencies for:
- moment
- bootstrap-datepicker
- datatables.net-colreorder

Fixes #892 

Regression tests passed.
Test pages for table and time picker, forms with data picker.