### PR TITLE
fix(pagination): minor css for react-bootstrap pagination dropdown

### DIFF
--- a/src/less/pagination.less
+++ b/src/less/pagination.less
@@ -88,10 +88,17 @@
         float: none;
       }
     }
-    .pagination-pf-pagesize.bootstrap-select.btn-group {
+    .pagination-pf-pagesize.bootstrap-select.btn-group, 
+    .pagination-pf-pagesize.btn-group {
       display: flex;
+      float: none;
+      margin-bottom: 0;
+      margin-left: 0;
       margin-right: 5px;
       width: auto;
+    }
+    .dropdown-menu {
+      min-width: auto;
     }
   }
   .pagination-pf-page {

--- a/src/sass/converted/patternfly/_pagination.scss
+++ b/src/sass/converted/patternfly/_pagination.scss
@@ -88,10 +88,17 @@
         float: none;
       }
     }
-    .pagination-pf-pagesize.bootstrap-select.btn-group {
+    .pagination-pf-pagesize.bootstrap-select.btn-group, 
+    .pagination-pf-pagesize.btn-group {
       display: flex;
+      float: none;
+      margin-bottom: 0;
+      margin-left: 0;
       margin-right: 5px;
       width: auto;
+    }
+    .dropdown-menu {
+      min-width: auto;
     }
   }
   .pagination-pf-page {


### PR DESCRIPTION
## Description
This PR attempts to address a minor issue using the React Bootstrap DropdownButton instead of bootstrap-select. The DOM rendered is a tad bit different from bootstrap-select and customizing this via a few minor CSS tweaks seems to be the easier option.

Link to OSUX story:
https://patternfly.atlassian.net/browse/OSUX-339

PF-React PR:
https://github.com/patternfly/patternfly-react/pull/143

[Link to React Storybook](https://rawgit.com/priley86/patternfly-react/reactabular-storybook/index.html?knob-Label=Well%20done%21%20You%20successfully%20read%20this%20important%20alert%20message.&selectedKind=DataTable&selectedStory=Paginated%20Table&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)

Note: I am ignoring the bootstrap-select paddings added to the `dropdown-toggle` and would prefer to just leave it at `min-width:auto` as to not introduce more CSS.

## Changes

* minor tweaks to pagination `btn-group` selector as to ensure React Bootstrap button-group is styled closely w/o the `bootstrap-select` class
* ensures the React Bootstrap dropdown-menu is `min-width:auto`

## Link to rawgit and/or image

For example: Here is a [link to Alerts on rawgit](https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/alerts.html)

This is an image:

![Image description](http://placehold.it/350x150)

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [ ] **Cross browser**: works in Chrome
- [ ] **Cross browser**: works in Firefox
- [ ] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [ ] **Responsive**: works in extra small, small, medium and large view ports.
- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
