### PR TITLE
fix(package.json): No default jsDelivr CDN file set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "patternfly",
   "version": "0.0.0-semantically-released",
+  "main": "dist/js/patternfly.js",
   "author": "Red Hat",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## Description
This PR is targeted to fix the [issue](https://github.com/patternfly/patternfly/issues/901)

## Changes
The following warning message will disappear:
<img width="803" alt="screen shot 2018-01-16 at 2 19 46 pm" src="https://user-images.githubusercontent.com/5689075/34974620-0c2d05c8-fac9-11e7-84ce-b182f6d43778.png">