### PR TITLE
fix(navbar-vertical): Set line-height for .navbar-brand-txt and max-height for .navbar-brand-icon

### DIFF
--- a/src/less/navbar-vertical.less
+++ b/src/less/navbar-vertical.less
@@ -114,6 +114,11 @@
     .navbar-brand-icon {
       display: inline-block;
       margin: @navbar-pf-vertical-navbar-brand-icon-margin;
+      max-height: @navbar-pf-vertical-navbar-brand-max-height;
+    }
+
+    .navbar-brand-txt {
+      line-height: @navbar-pf-vertical-navbar-brand-line-height;
     }
   }
 

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -116,6 +116,8 @@
 @navbar-pf-vertical-navbar-brand-icon-margin:                       0 15px 0 0;
 @navbar-pf-vertical-navbar-brand-margin:                            0 0 0 25px;
 @navbar-pf-vertical-navbar-brand-min-height:                        35px;
+@navbar-pf-vertical-navbar-brand-max-height:                        35px;
+@navbar-pf-vertical-navbar-brand-line-height:                       34px;
 @navbar-pf-vertical-navbar-brand-name-breakpoint:                   480px;
 @navbar-pf-vertical-navbar-brand-name-margin:                       0 15px 0 0;
 @navbar-pf-vertical-navbar-brand-padding:                           11px 0 12px;

--- a/src/sass/converted/patternfly/_navbar-vertical.scss
+++ b/src/sass/converted/patternfly/_navbar-vertical.scss
@@ -114,6 +114,11 @@
     .navbar-brand-icon {
       display: inline-block;
       margin: $navbar-pf-vertical-navbar-brand-icon-margin;
+      max-height: $navbar-pf-vertical-navbar-brand-max-height;
+    }
+
+    .navbar-brand-txt {
+      line-height: $navbar-pf-vertical-navbar-brand-line-height;
     }
   }
 

--- a/src/sass/converted/patternfly/_variables.scss
+++ b/src/sass/converted/patternfly/_variables.scss
@@ -116,6 +116,8 @@ $navbar-pf-vertical-navbar-brand-color:                             $color-pf-wh
 $navbar-pf-vertical-navbar-brand-icon-margin:                       0 15px 0 0 !default;
 $navbar-pf-vertical-navbar-brand-margin:                            0 0 0 25px !default;
 $navbar-pf-vertical-navbar-brand-min-height:                        35px !default;
+$navbar-pf-vertical-navbar-brand-max-height:                        35px !default;
+$navbar-pf-vertical-navbar-brand-line-height:                       34px !default;
 $navbar-pf-vertical-navbar-brand-name-breakpoint:                   480px !default;
 $navbar-pf-vertical-navbar-brand-name-margin:                       0 15px 0 0 !default;
 $navbar-pf-vertical-navbar-brand-padding:                           11px 0 12px !default;


### PR DESCRIPTION
## Description
As per a discussion in https://github.com/patternfly/patternfly-react/pull/88, I needed this bit of CSS for the example titles in VerticalNavigationMasthead to align correctly, and I was told that it should be moved to patternfly core.

## Changes

Title says it all. Applies these style rules using some new variables, to make sure images used in the masthead are sized correctly and text positioned correctly.

## Link to rawgit and/or image

Here's what the text looks like before:

<img width="210" alt="screen shot 2018-01-21 at 5 58 20 pm" src="https://user-images.githubusercontent.com/811963/35200026-f07cbc28-fed4-11e7-8da6-c2676e58c226.png">

And after:

<img width="213" alt="screen shot 2018-01-21 at 5 59 17 pm" src="https://user-images.githubusercontent.com/811963/35200027-f4c8a54e-fed4-11e7-840a-597977258e40.png">