### PR TITLE
fix(sass): Fix sass deprecation warn message

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -384,7 +384,7 @@ module.exports = function (grunt) {
           }
         ],
         options: {
-          excludes: ['variables', 'default', 'rgba'],
+          excludes: ['variables', 'default', 'rgba', 'important'],
           replacements: [
             {
               // Customize variable conversion to include newer css reserved words.
@@ -393,13 +393,13 @@ module.exports = function (grunt) {
               order: 0
             },
             {
-              //
+              // Asset paths are already relative to their respective folder when using compass/sprockets
               pattern: /^\$(img|font)-path:(\s*)"(.*)"(.*);(.*)$/mgi,
               replacement: '\$$$1-path:$2if($pf-sass-asset-helper, "", "$3/")$4;$5',
               order: 1
             },
             {
-              //
+              // Asset paths are already relative to their respective folder when using compass/sprockets
               pattern: /^\$icon-font-path:(\s*)"(.*)"(.*);(.*)$/mgi,
               replacement: '\$icon-font-path:$1if($pf-sass-asset-helper, "", "$2")$3;$4',
               order: 1
@@ -418,7 +418,7 @@ module.exports = function (grunt) {
             },
             // Original fade -> rgba conversion did not account for decimal percentages
             {
-              pattern: /fade\((.*),\s?([\d\.]+)\%\)/gmi,
+              pattern: /fade\((.*),\s?([\d\.]+)\%\)/mgi,
               replacement: 'rgba($1, ($2/100))',
               order: 3
             },
@@ -471,12 +471,6 @@ module.exports = function (grunt) {
                 return p1+p2+p3.replace(/;/g, ',')+p4;
               },
               order: 70
-            },
-            {
-              // Fix bug in grunt-less-to-sass that puts "!important" inside mixin and css function parens.
-              pattern: /^(\s*[\w\-]*:\s*[\w\-]*)\((.*?)\s*!important.*\)(.*);(.*)$/mgi,
-              replacement: '$1($2) !important$3;$4',
-              order: 80
             },
             {
               pattern: /\&:extend\((.*)\)/gi,

--- a/src/sass/converted/patternfly/_bootstrap-select.scss
+++ b/src/sass/converted/patternfly/_bootstrap-select.scss
@@ -68,7 +68,7 @@
       border-color: $dropdown-link-active-border-color !important;
       color: $color-pf-white !important;
       small {
-        color: fade($color-pf-white, 50%) !important;
+        color: rgba($color-pf-white, (50/100)) !important;
       }
     }
     .divider {
@@ -86,7 +86,7 @@
       }
       & a {
         &:active small {
-          color: fade($color-pf-white, 50%) !important;
+          color: rgba($color-pf-white, (50/100)) !important;
         }
         &:hover,
         &:focus {

--- a/src/sass/converted/patternfly/_cards.scss
+++ b/src/sass/converted/patternfly/_cards.scss
@@ -90,7 +90,7 @@
 .card-pf-footer {
   background-color: $card-pf-footer-bg-color;
   border-top: 1px solid $card-pf-border-color;
-  margin: 0 (-($grid-gutter-width / 2) !important);
+  margin: 0 (-($grid-gutter-width / 2)) !important;
   padding: ($grid-gutter-width / 2) ($grid-gutter-width / 2) ($grid-gutter-width / 4);
   a > {
     .fa,

--- a/src/sass/converted/patternfly/_navbar.scss
+++ b/src/sass/converted/patternfly/_navbar.scss
@@ -193,7 +193,7 @@
               border-color: $dropdown-link-active-border-color !important;
               color: $color-pf-white !important;
               small {
-                color: fade($color-pf-white, 50%) !important;
+                color: rgba($color-pf-white, (50/100)) !important;
               }
             }
           }
@@ -207,7 +207,7 @@
             }
             & a {
               &:active small {
-                color: fade($color-pf-white, 50%) !important;
+                color: rgba($color-pf-white, (50/100)) !important;
               }
               &:hover,
               &:focus {


### PR DESCRIPTION
## Description
Adjust conversion rules so that all instances of Less fade() function are converted to Sass rgba()

Fixes https://github.com/patternfly/patternfly/issues/852

## Changes

Grunt lessToSass conversion changes:

* Add less to sass `important` conversion rule to exclude list
* Remove custom `important` rule
* Add missing comments for a few rules

## PR checklist
- [X] **Cross browser**: works in IE10
- [X] **Cross browser**: works in IE11
- [X] **Cross browser**: works in Edge
- [X] **Cross browser**: works in Chrome
- [X] **Cross browser**: works in Firefox
- [X] **Cross browser**: works in Safari
- [X] **Cross browser**: works in Opera
- [X] **Responsive**: works in extra small, small, medium and large view ports.
