### PR TITLE
fix(stylelint): Remove deprecated rule from stylelint config

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -30,7 +30,6 @@
     "declaration-block-no-duplicate-properties": [true, {
       "ignore": ["consecutive-duplicates-with-different-values"]
     }],
-    "declaration-block-no-ignored-properties": true,
     "declaration-block-trailing-semicolon": "always",
     "declaration-block-semicolon-space-before": "never",
     "declaration-block-semicolon-space-after": "always-single-line",


### PR DESCRIPTION
## Description
Remove deprecated `declaration-block-no-ignored-properties` rule from stylelint config to squelch deprecation warning and fix ide/text-editor warnings.

Fixes https://github.com/patternfly/patternfly/issues/729