### PR TITLE
fix(code of conduct): updates code of conduct link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 This project is governed by the [Contributor Covenant version 1.4][1]. All contributors and participants agree to abide by its terms. To report violations, send an email to [patternfly@redhat.com][2].
 
- [1]: http://contributor-covenant.org/version/1/4/code_of_conduct.md
+ [1]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
  [2]: mailto:patternfly@redhat.com


### PR DESCRIPTION
This updates the link in the Code of Conduct raised in this issue #936 

closes #936 