### PR TITLE
fix(wizard): updates focus state for sub items

### DIFF
--- a/src/less/wizard.less
+++ b/src/less/wizard.less
@@ -52,6 +52,14 @@
           width: 14em;
           &:hover {
             text-decoration: none;
+            background-color: @color-pf-black-200;
+          }
+          &:focus {
+            //corrects odd behavior when hover and focus are combined.
+            text-decoration: none;
+            span {
+              text-decoration: underline;
+            }
           }
         }
         &.active {

--- a/src/sass/converted/patternfly/_wizard.scss
+++ b/src/sass/converted/patternfly/_wizard.scss
@@ -52,6 +52,14 @@
           width: 14em;
           &:hover {
             text-decoration: none;
+            background-color: $color-pf-black-200;
+          }
+          &:focus {
+            //corrects odd behavior when hover and focus are combined.
+            text-decoration: none;
+            span {
+              text-decoration: underline;
+            }
           }
         }
         &.active {


### PR DESCRIPTION
## Description
Added styling for focus and hover on sub nav text for better accessibility. 

I discussed this with @jgiardino and we concluded it made more sense to include just the underlined text for focus rather than reinstating the outline. In order to reinstate the currently disabled outline the css would have to be refactored and this seems beyond scope at this point. 

closes #869 

https://rawgit.com/matthewcarleton/patternfly/wizard-sub-nav-focus-dist/dist/tests/wizard.html