### PR TITLE
docs(quickstart): Add instructions for less and sass consumption

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -8,20 +8,22 @@ Within the download you'll find the following directories and files, logically g
 
 ```
 patternfly/
-├── dist/
-│   ├── css/
-│   │   │── patternfly.min.css (* need to include)
-│   │   │── patternfly-additions.min.css (* need to include)
-│   └── fonts/
-│   │   │── font and icon libraries (included via above CSS)
-│   └── img/
-│   │   │── branding materials and loading indicators
-│   └── js/
-│   │   │── patternfly.min.js (may need to include if you are using PatternFly jQuery Sidebar, Popovers or Datatables)
-├── less/
-│   ├── variables, mixin, and component Less files (may need to include if you want to customize the already built CSS)
-└── test-src/
-    ├── example markup source files
+└── dist/
+    ├── css/
+    │   │── patternfly.min.css (* need to include)
+    │   └── patternfly-additions.min.css (* need to include)
+    ├── fonts/
+    │   └── font and icon libraries (included via above CSS)
+    ├── img/
+    │   └── branding materials and loading indicators
+    ├── js/
+    │   └── patternfly.min.js (may need to include if you are using PatternFly jQuery Sidebar, Popovers or Datatables)
+    ├── less/
+    │   └── variables, mixin, and component Less files (may need to include if you want to customize the already built CSS)
+    ├── sass/
+    │   └── variables, mixin, and component Sass files (may need to include if you want to customize the already built CSS)
+    └── tests/
+        └── example markup source files
 ```
 
 We provide compiled CSS and JS (`patternfly.*`), as well as compiled and minified CSS and JS (`patternfly.min.*`). CSS [source maps](https://developer.chrome.com/devtools/docs/css-preprocessors) (`patternfly.*.map`) are available for use with certain browsers' developer tools. Fonts from OpenSans, FontAwesome, PatternFly Icons are included, as well as numerous other 3rd party JS components and libraries.
@@ -163,3 +165,46 @@ We provide compiled CSS and JS (`patternfly.*`), as well as compiled and minifie
         <!-- See https://github.com/patternfly/angular-patternfly for more information -->
 
 6. Enjoy!!!
+
+## Consuming PatternFly LESS or SASS
+
+PatternFly includes LESS and SASS files for those that need to add their own customizations. When importing PatternFly LESS or SASS into your application, there are a few configuration steps that need to be made to ensure that paths to all resources are properly resolved.
+
+> If you used bower to install PatternFly, then you will need to replace `node_modules` paths from these instructions with the equivalent `bower_components` path.
+
+### Consuming PatternFly LESS
+1. Import the two main PatternFly LESS files:
+
+        @import 'patternfly/dist/less/patternfly.less';
+        @import 'patternfly/dist/less/patternfly-additions.less';
+
+1. Add `node_modules/` to the LESS compiler's search path options.
+
+1. LESS compiler references for a few common build tools:
+ - [Grunt](https://github.com/gruntjs/grunt-contrib-less)
+ - [Gulp](https://github.com/stevelacy/gulp-less)
+ - [Node](http://lesscss.org/usage/)
+ - [Webpack](https://github.com/webpack-contrib/less-loader)
+
+### Consuming PatternFly SASS
+1. Import the main PatternFly SASS file:
+
+        @import 'patternfly';
+
+1. Add the following paths to the SASS compiler's search path options:
+ - `node_modules/patternfly/dist/sass`
+ - `node_modules/bootstrap-sass/assets/stylesheets`
+        - ** If installed in PatternFly private dependency tree: `node_modules/patternfly/node_modules/bootstrap-sass/assets/stylesheets`
+ - `node_modules/font-awesome-sass/assets/stylesheets`  
+        - ** If installed in PatternFly private dependency tree:``node_modules/patternfly/node_modules/font-awesome-sass/assets/stylesheets`
+
+ > ** In some cases, bootstrap-sass and font-awesome-sass might be installed into a private dependency tree within `node_modules/patternfly`. If this is the case, adjust the path to those dependencies accordingly.
+
+1. SASS compiler references for a few common build tools:
+ - [Grunt](https://github.com/gruntjs/grunt-contrib-sass)
+ - [Gulp](https://github.com/dlmanning/gulp-sass)
+ - [Node](https://github.com/sass/node-sass)
+ - [Webpack](https://github.com/webpack-contrib/sass-loader)
+
+### Resolving Static Files
+PatternFly uses some static font and image files. If you see 404 errors in your browser relating to these files, you may need to make some adjustments to ensure path references in the compiled css are correct. In our LESS and SASS, the `font-path` and `img-path` variables are used to define relative paths to these static files. The default values of these variables are `../fonts` and `../img`, respectively.  These relative paths may not resolve in the context of your application, so you may need to override these variables or copy the PatternFly static files as part of your build.


### PR DESCRIPTION
## Description
Update the Quick Start Guide to include instructions for consuming Less and Sass.

Fixes #944, #847

## Changes
- Add section for consumption of Less and Sass
- Update "What's Included"