### PR TITLE
fix(popover): Close (X) icon should toggle button for popovers

### DIFF
--- a/tests/pages/_includes/widgets/forms/field-level-help.html
+++ b/tests/pages/_includes/widgets/forms/field-level-help.html
@@ -10,5 +10,8 @@
   // Initialize Popovers
   $(document).ready(function() {
     $('[data-toggle=popover]').popovers()
+      .on('hidden.bs.popover', function (e) {
+        $(e.target).data('bs.popover').inState.click = false;
+      });
   });
 </script>


### PR DESCRIPTION
## Description
This PR is targeted to fix issue https://github.com/patternfly/patternfly/issues/846

## Changes

Users can reopen popover without double clicks.

## Link to rawgit and/or image

Here's the **[Demo](https://rawgit.com/dabeng/patternfly/popover-close-dist/dist/tests/popovers.html)** page.

@jeff-phillips-18 @cliffpyles @matthewcarleton please review :)

Fixes #846 