### PR TITLE
fix(list view): add ids to limit JS scope

### DIFF
--- a/tests/pages/_includes/widgets/list-view/list-view-default.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-default.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf">
+{% assign id = include.id | default: 'pf-list-default' %}
+<div id="{{id}}" class="list-group list-view-pf">
   <div class="list-group-item">
     <div class="list-view-pf-checkbox">
       <input type="checkbox">
@@ -45,7 +46,7 @@
 <script>
   // Row Checkbox Selection
   $(document).ready(function () {
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {

--- a/tests/pages/_includes/widgets/list-view/list-view-standard-rows-compound-expansion.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-standard-rows-compound-expansion.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf list-view-pf-view">
+{% assign id = include.id | default: "pf-list-compound-expansion" %}
+<div id="{{id}}" class="list-group list-view-pf list-view-pf-view">
   <div class="list-group-item">
     <div class="list-view-pf-checkbox">
       <input type="checkbox">
@@ -1335,7 +1336,7 @@
 <script>
   $(document).ready(function () {
     // Row Checkbox Selection
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {
@@ -1343,14 +1344,14 @@
       }
     });
     // toggle dropdown menu
-    $(".list-view-pf-actions").on("show.bs.dropdown", function () {
+    $("#{{id}} .list-view-pf-actions").on("show.bs.dropdown", function () {
       var $this = $(this);
       var $dropdown = $this.find(".dropdown");
       var space = $(window).height() - $dropdown[0].getBoundingClientRect().top - $this.find(".dropdown-menu").outerHeight(true);
       $dropdown.toggleClass("dropup", space < 10);
     });
     // compound expansion
-    $(".list-view-pf-expand").on("click", function () {
+    $("#{{id}} .list-view-pf-expand").on("click", function () {
       var $this = $(this);
       var $heading = $(this).parents(".list-group-item");
       //var $row = $heading.parent();
@@ -1378,7 +1379,7 @@
     });
 
     // click close button to close the panel
-    $(".list-group-item-container .close").on("click", function (){
+    $("#{{id}} .list-group-item-container .close").on("click", function (){
       var $this = $(this);
       var $panel = $this.parent();
 

--- a/tests/pages/_includes/widgets/list-view/list-view-standard-rows-simple-expansion.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-standard-rows-simple-expansion.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf list-view-pf-view">
+{% assign id = include.id | default: "pf-list-simple-expansion" %}
+<div id="{{id}}" class="list-group list-view-pf list-view-pf-view">
   <div class="list-group-item">
     <div class="list-group-item-header">
       <div class="list-view-pf-expand">
@@ -477,7 +478,7 @@
 <script>
   $(document).ready(function () {
     // Row Checkbox Selection
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {
@@ -485,7 +486,7 @@
       }
     });
     // toggle dropdown menu
-    $('.list-view-pf-actions').on('show.bs.dropdown', function () {
+    $("#{{id}} .list-view-pf-actions").on('show.bs.dropdown', function () {
       var $this = $(this);
       var $dropdown = $this.find('.dropdown');
       var space = $(window).height() - $dropdown[0].getBoundingClientRect().top - $this.find('.dropdown-menu').outerHeight(true);
@@ -493,7 +494,7 @@
     });
 
     // click the list-view heading then expand a row
-    $(".list-group-item-header").click(function(event){
+    $("#{{id}} .list-group-item-header").click(function(event){
       if(!$(event.target).is("button, a, input, .fa-ellipsis-v")){
         $(this).find(".fa-angle-right").toggleClass("fa-angle-down")
           .end().parent().toggleClass("list-view-pf-expand-active")
@@ -503,7 +504,7 @@
     })
 
     // click the close button, hide the expand row and remove the active status
-    $(".list-group-item-container .close").on("click", function (){
+    $("#{{id}} .list-group-item-container .close").on("click", function (){
       $(this).parent().addClass("hidden")
         .parent().removeClass("list-view-pf-expand-active")
           .find(".fa-angle-right").removeClass("fa-angle-down");

--- a/tests/pages/_includes/widgets/list-view/list-view-standard-rows.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-standard-rows.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf list-view-pf-view">
+{% assign id = include.id | default: 'pf-list-standard' %}
+<div id="{{id}}" class="list-group list-view-pf list-view-pf-view">
   <div class="list-group-item">
     <div class="list-view-pf-checkbox">
       <input type="checkbox">
@@ -255,7 +256,7 @@
 <script>
   $(document).ready(function () {
     // Row Checkbox Selection
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {
@@ -263,14 +264,14 @@
       }
     });
     // toggle dropdown menu
-    $('.list-view-pf-actions').on('show.bs.dropdown', function () {
+    $('#{{id}} .list-view-pf-actions').on('show.bs.dropdown', function () {
       var $this = $(this);
       var $dropdown = $this.find('.dropdown');
       var space = $(window).height() - $dropdown[0].getBoundingClientRect().top - $this.find('.dropdown-menu').outerHeight(true);
       $dropdown.toggleClass('dropup', space < 10);
     });
     // allow users to select multiple list items with shift key
-    $('.list-group').on('click', '.list-view-pf-checkbox>input', function(event) {
+    $('#{{id}} .list-group').on('click', '.list-view-pf-checkbox>input', function(event) {
       var $list = $('.list-group');
       var prevIndex = $list.data('preIndex');
       var $listItems = $list.children('.list-group-item');

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-3.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-3.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf">
+{% assign id = include.id | default: 'pf-list-var3' %}
+<div id="{{id}}" class="list-group list-view-pf">
   <div class="list-group-item list-view-pf-stacked list-view-pf-top-align">
     <div class="list-view-pf-checkbox">
       <input type="checkbox">
@@ -36,7 +37,7 @@
 <script>
   // Row Checkbox Selection
   $(document).ready(function () {
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-4.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-4.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf">
+{% assign id = include.id | default: 'pf-list-var4' %}
+<div id="{{id}}" class="list-group list-view-pf">
   <div class="list-group-item">
     <div class="list-view-pf-checkbox">
       <input type="checkbox">
@@ -33,7 +34,7 @@
 <script>
   // Row Checkbox Selection
   $(document).ready(function () {
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-5.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-5.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf list-view-pf-equalized-column">
+{% assign id = include.id | default: 'pf-list-var5' %}
+<div id="{{id}}" class="list-group list-view-pf list-view-pf-equalized-column">
   <div class="list-group-item">
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
@@ -111,9 +112,9 @@
 <script>
   // Equalize column width
   $(document).ready(function () {
-  	var widest = 0;
-  	$('.list-view-pf-equalized-column .list-view-pf-additional-info-item').each( function() {
-  		widest = $(this).width() > widest ? $(this).width() : widest;
-  	}).width(widest);
+    var widest = 0;
+    $('#{{id}} .list-view-pf-equalized-column .list-view-pf-additional-info-item').each( function() {
+      widest = $(this).width() > widest ? $(this).width() : widest;
+    }).width(widest);
   });
 </script>

--- a/tests/pages/_includes/widgets/list-view/list-view-variation-6.html
+++ b/tests/pages/_includes/widgets/list-view/list-view-variation-6.html
@@ -1,4 +1,5 @@
-<div class="list-group list-view-pf">
+{% assign id = include.id | default: 'pf-list-var6' %}
+<div id="{{id}}" class="list-group list-view-pf">
   <div class="list-group-item list-view-pf-stacked list-view-pf-top-align">
     <div class="list-view-pf-checkbox">
       <input type="checkbox">
@@ -41,7 +42,7 @@
 <script>
   // Row Checkbox Selection
   $(document).ready(function () {
-    $("input[type='checkbox']").change(function (e) {
+    $("#{{id}} input[type='checkbox']").change(function (e) {
       if ($(this).is(":checked")) {
         $(this).closest('.list-group-item').addClass("active");
       } else {


### PR DESCRIPTION
add ids to examples to avoid interference between JS scripts in case multiple examples are included
on the same page

re #641
