### PR TITLE
fix(donut chart): change chart container to div

### DIFF
--- a/tests/pages/_includes/widgets/charts/donut-utilization.html
+++ b/tests/pages/_includes/widgets/charts/donut-utilization.html
@@ -1,9 +1,9 @@
 <div id="{{include.id}}1" class="example-donut-chart-utilization"></div>
 
 <div class="pct-donut-chart-pf example-donut-chart-utilization">
-  <span class="pct-donut-chart-pf-chart">
-    <span id="{{include.id}}2"></span>
-  </span>
+  <div class="pct-donut-chart-pf-chart">
+    <div id="{{include.id}}2"></div>
+  </div>
   <span class="pct-donut-chart-pf-label">
     60 MHz of 100 MHz used
   </span>
@@ -11,9 +11,9 @@
 
 <div class="example-donut-chart-utilization">
   <span class="pct-donut-chart-pf pct-donut-chart-pf-left">
-    <span class="pct-donut-chart-pf-chart">
-      <span id="{{include.id}}3"></span>
-    </span>
+    <div class="pct-donut-chart-pf-chart">
+      <div id="{{include.id}}3"></div>
+    </div>
     <span class="pct-donut-chart-pf-label text-right">
       60 MHz of 100 MHz used
     </span>
@@ -22,9 +22,9 @@
 
 <div class="example-donut-chart-utilization">
   <span class="pct-donut-chart-pf pct-donut-chart-pf-right">
-    <span class="pct-donut-chart-pf-chart">
-      <span id="{{include.id}}4"></span>
-    </span>
+    <div class="pct-donut-chart-pf-chart">
+      <div id="{{include.id}}4"></div>
+    </div>
     <span class="pct-donut-chart-pf-label text-left">
       60 MHz of 100 MHz
     </span>


### PR DESCRIPTION
The chart needs a block element to properly position the tooltip.

Rawgit: [Donut charts](https://rawgit.com/michpetrov/patternfly/donut-chart-fix-dist/dist/tests/donut-charts.html)

close #963 

