### PR TITLE
fix(notification drawer): hover state

### DIFF
--- a/src/less/notifications-drawer.less
+++ b/src/less/notifications-drawer.less
@@ -160,7 +160,10 @@
     border-bottom: none;
   }
   &:hover { background-color: @color-pf-blue-50; }
-  &.unread .drawer-pf-notification-message { font-weight: bold; }
+  &.unread .drawer-pf-notification-message {
+    font-weight: bold;
+    cursor: pointer;
+  }
   &.expanded-notification {
     .date {
       border-right: none;
@@ -181,10 +184,6 @@
   .expanded-notification & {
     display: inline-block;
   }
-}
-
-.drawer-pf-notifications-non-clickable .drawer-pf-notification:hover {
-  background-color: @color-pf-white;
 }
 
 .drawer-pf-title {

--- a/src/sass/converted/patternfly/_notifications-drawer.scss
+++ b/src/sass/converted/patternfly/_notifications-drawer.scss
@@ -160,7 +160,10 @@
     border-bottom: none;
   }
   &:hover { background-color: $color-pf-blue-50; }
-  &.unread .drawer-pf-notification-message { font-weight: bold; }
+  &.unread .drawer-pf-notification-message {
+    font-weight: bold;
+    cursor: pointer;
+  }
   &.expanded-notification {
     .date {
       border-right: none;
@@ -181,10 +184,6 @@
   .expanded-notification & {
     display: inline-block;
   }
-}
-
-.drawer-pf-notifications-non-clickable .drawer-pf-notification:hover {
-  background-color: $color-pf-white;
 }
 
 .drawer-pf-title {


### PR DESCRIPTION
This updates the notification drawer hover states to always show a light blue bg on hover. The cursor always shows the pointer when the message has a class of unread.

Fixes #942