### PR TITLE
fix(context selector): styles match dropdowns

### DIFF
--- a/src/less/context-selector.less
+++ b/src/less/context-selector.less
@@ -38,7 +38,7 @@
       width: 100%;
     }
     .form-group {
-      padding:@contextselector-pf-form-group-padding;
+      margin: @contextselector-pf-form-group-margin;
     }
     .contextselector-pf-list {
       @media (min-width: @screen-sm-min) {
@@ -46,17 +46,21 @@
         overflow-y: scroll;
       }
       li {
-        padding-left: @contextselector-pf-list-li-padding-left;
+        padding: @contextselector-pf-list-li-padding;
+        border-width: @contextselector-pf-list-li-border-width;
+        border-style: solid;
+        border-color: transparent;
         &:hover {
-          background: @color-pf-blue-400;
+          background: @color-pf-blue-50;
+          border-color: @dropdown-link-hover-border-color;
           a {
-            color: @color-pf-white;
             text-decoration: none;
           }
         }
       }
       a {
         color: @color-pf-black-800;
+        display: block;
       }
     }
   }

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -45,9 +45,10 @@
 @contextselector-pf-nav-item-iconic-padding:                        23px 20px 18px 10px;
 @contextselector-title-width-mobile:                                170px;
 @contextselector-title-width-desktop:                               210px;
-@contextselector-pf-form-group-padding:                             0 5px;
+@contextselector-pf-form-group-margin:                              0 5px 5px 5px;
 @contextselector-pf-list-max-height:                                200px;
-@contextselector-pf-list-li-padding-left:                           5px;
+@contextselector-pf-list-li-padding:                                1px 10px;
+@contextselector-pf-list-li-border-width:                           1px 0;
 @donut-font-size-big:                                               30px;
 @drawer-pf-top-vertical:                                            58px;
 @drawer-pf-top-horizontal:                                          26px;

--- a/src/sass/converted/patternfly/_context-selector.scss
+++ b/src/sass/converted/patternfly/_context-selector.scss
@@ -38,7 +38,7 @@
       width: 100%;
     }
     .form-group {
-      padding:$contextselector-pf-form-group-padding;
+      margin: $contextselector-pf-form-group-margin;
     }
     .contextselector-pf-list {
       @media (min-width: $screen-sm-min) {
@@ -46,17 +46,21 @@
         overflow-y: scroll;
       }
       li {
-        padding-left: $contextselector-pf-list-li-padding-left;
+        padding: $contextselector-pf-list-li-padding;
+        border-width: $contextselector-pf-list-li-border-width;
+        border-style: solid;
+        border-color: transparent;
         &:hover {
-          background: $color-pf-blue-400;
+          background: $color-pf-blue-50;
+          border-color: $dropdown-link-hover-border-color;
           a {
-            color: $color-pf-white;
             text-decoration: none;
           }
         }
       }
       a {
         color: $color-pf-black-800;
+        display: block;
       }
     }
   }

--- a/src/sass/converted/patternfly/_variables.scss
+++ b/src/sass/converted/patternfly/_variables.scss
@@ -45,9 +45,10 @@ $contextselector-pf-margin-left:                                    10px !defaul
 $contextselector-pf-nav-item-iconic-padding:                        23px 20px 18px 10px !default;
 $contextselector-title-width-mobile:                                170px !default;
 $contextselector-title-width-desktop:                               210px !default;
-$contextselector-pf-form-group-padding:                             0 5px !default;
+$contextselector-pf-form-group-margin:                              0 5px 5px 5px !default;
 $contextselector-pf-list-max-height:                                200px !default;
-$contextselector-pf-list-li-padding-left:                           5px !default;
+$contextselector-pf-list-li-padding:                                1px 10px !default;
+$contextselector-pf-list-li-border-width:                           1px 0 !default;
 $donut-font-size-big:                                               30px !default;
 $drawer-pf-top-vertical:                                            58px !default;
 $drawer-pf-top-horizontal:                                          26px !default;


### PR DESCRIPTION
This updates the style of the context selector to match the dropdown menu as per requested in #981. 
https://rawgit.com/matthewcarleton/patternfly/context-selector-981-dist/dist/tests/context-selector.html