### PR TITLE
feat(contextswitcher): Change from dropdown to Bootstrap-select

### DIFF
--- a/src/less/context-selector.less
+++ b/src/less/context-selector.less
@@ -1,67 +1,119 @@
 //
 // Context Selector
 // --------------------------------------------------
+
+.contextselector-pf {
+  float: left;
+  .bootstrap-select {
+    width: @contextselector-pf-bootstrap-select-width-mobile !important;
+    @media (min-width: @screen-xs-min) {
+      width: @contextselector-pf-bootstrap-select-width-desktop !important;
+    }
+    &.open {
+      background: @navbar-pf-navbar-primary-active-bg-color-stop;
+      > .dropdown-toggle {
+        color: @navbar-pf-vertical-active-color;
+        &:focus {
+          outline: 0 !important; // don't show restored focus ring when open
+        }
+      }
+    }
+    > .dropdown-toggle {
+      background: none;
+      border: 0;
+      box-shadow: none !important;
+      color: @navbar-pf-vertical-color;
+      font-weight: normal;
+      padding-bottom: @contextselector-pf-dropdown-toggle-padding-bottom;
+      padding-left: @contextselector-pf-dropdown-toggle-padding-left;
+      padding-top: @contextselector-pf-dropdown-toggle-padding-top;
+      &:focus {
+        color: @navbar-pf-vertical-active-color;
+        // restore the focus ring
+        // Default
+        outline: thin dotted !important;
+        // WebKit
+        outline: 5px auto -webkit-focus-ring-color !important;
+        outline-offset: -2px !important;
+      }
+      &:hover {
+        background: @navbar-pf-navbar-primary-active-bg-color-stop;
+        color: @navbar-pf-vertical-active-color;
+        outline: 0 !important; // don't show restored focus ring when open
+      }
+      .filter-option {
+        text-overflow: ellipsis;
+      }
+    }
+    .dropdown-menu li a span.text {
+      display: block;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      width: 100%;
+    }
+  }
+}
 .layout-pf-fixed .navbar-pf-vertical.navbar-pf-contextselector {
   z-index: @zindex-modal-background;
 }
 .navbar-pf-vertical .nav.contextselector-pf {
-    @media (min-width: @screen-sm-min) {
-      margin-left:@contextselector-pf-margin-left;
-    }
-    border-left:1px solid @color-pf-black-700;
-      .nav-item-iconic {
-        padding:@contextselector-pf-nav-item-iconic-padding;
-        display: flex;
-        align-items: center;
-      }
+  @media (min-width: @screen-md-min) {
+    margin-left: @contextselector-pf-margin-left;
   }
+}
 
-  .contextselector-pf {
-    float:left;
-    &-title {
-      width: @contextselector-title-width-mobile;
-      @media (min-width: @screen-xs-min) {
-        width: @contextselector-title-width-desktop;
-      }
-      white-space: nowrap;
-      display:inline-block;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      line-height: normal;
+// the following rules are deprecated
+.contextselector-pf {
+  float:left;
+  &-title {
+    display: inline-block;
+    line-height: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: @contextselector-title-width-mobile;
+    @media (min-width: @screen-xs-min) {
+      width: @contextselector-title-width-desktop;
     }
-    .dropdown {
-      &.open, &:hover {
-        background-color: @navbar-pf-navbar-primary-active-bg-color-stop;
-      }
+  }
+  .contextselector-pf-list {
+    @media (min-width: @screen-sm-min) {
+      max-height: @contextselector-pf-list-max-height;
+      overflow-y: auto;
     }
-    .dropdown-menu {
-      width: 100%;
-      margin-top:0;
+    a {
+      color: @color-pf-black-800;
+      display: block;
     }
-    .form-group {
-      margin: @contextselector-pf-form-group-margin;
-    }
-    .contextselector-pf-list {
-      @media (min-width: @screen-sm-min) {
-        max-height: @contextselector-pf-list-max-height;
-        overflow-y: auto;
-      }
-      li {
-        padding: @contextselector-pf-list-li-padding;
-        border-width: @contextselector-pf-list-li-border-width;
-        border-style: solid;
-        border-color: transparent;
-        &:hover {
-          background: @color-pf-blue-50;
-          border-color: @dropdown-link-hover-border-color;
-          a {
-            text-decoration: none;
-          }
+    li {
+      border-color: transparent;
+      border-style: solid;
+      border-width: @contextselector-pf-list-li-border-width;
+      padding: @contextselector-pf-list-li-padding;
+      &:hover {
+        background: @color-pf-blue-50;
+        border-color: @dropdown-link-hover-border-color;
+        a {
+          text-decoration: none;
         }
       }
-      a {
-        color: @color-pf-black-800;
-        display: block;
-      }
     }
   }
+  .dropdown {
+    &.open, &:hover {
+      background-color: @navbar-pf-navbar-primary-active-bg-color-stop;
+    }
+  }
+  .dropdown-menu {
+    margin-top: 0;
+    width: 100%;
+  }
+  .form-group {
+    margin: @contextselector-pf-form-group-margin;
+  }
+}
+.navbar-pf-vertical .nav.contextselector-pf .nav-item-iconic {
+  align-items: center;
+  display: flex;
+  padding: @contextselector-pf-nav-item-iconic-padding;
+}

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -41,10 +41,15 @@
 @card-pf-container-bg-color:                                        @color-pf-black-150;
 @card-pf-footer-bg-color:                                           @color-pf-black-100;
 @card-pf-selected-border-color:                                     @color-pf-blue-300;
+@contextselector-title-width-desktop:                               210px;
+@contextselector-title-width-mobile:                                170px;
+@contextselector-pf-bootstrap-select-width-desktop:                 (@contextselector-title-width-desktop + 32);
+@contextselector-pf-bootstrap-select-width-mobile:                  (@contextselector-title-width-mobile + 32);
+@contextselector-pf-dropdown-toggle-padding-bottom:                 19px;
+@contextselector-pf-dropdown-toggle-padding-left:                   10px;
+@contextselector-pf-dropdown-toggle-padding-top:                    19px;
 @contextselector-pf-margin-left:                                    10px;
 @contextselector-pf-nav-item-iconic-padding:                        23px 20px 18px 10px;
-@contextselector-title-width-mobile:                                170px;
-@contextselector-title-width-desktop:                               210px;
 @contextselector-pf-form-group-margin:                              0 5px 5px 5px;
 @contextselector-pf-list-max-height:                                200px;
 @contextselector-pf-list-li-padding:                                1px 10px;

--- a/src/sass/converted/patternfly/_context-selector.scss
+++ b/src/sass/converted/patternfly/_context-selector.scss
@@ -1,67 +1,119 @@
 //
 // Context Selector
 // --------------------------------------------------
+
+.contextselector-pf {
+  float: left;
+  .bootstrap-select {
+    width: $contextselector-pf-bootstrap-select-width-mobile !important;
+    @media (min-width: $screen-xs-min) {
+      width: $contextselector-pf-bootstrap-select-width-desktop !important;
+    }
+    &.open {
+      background: $navbar-pf-navbar-primary-active-bg-color-stop;
+      > .dropdown-toggle {
+        color: $navbar-pf-vertical-active-color;
+        &:focus {
+          outline: 0 !important; // don't show restored focus ring when open
+        }
+      }
+    }
+    > .dropdown-toggle {
+      background: none;
+      border: 0;
+      box-shadow: none !important;
+      color: $navbar-pf-vertical-color;
+      font-weight: normal;
+      padding-bottom: $contextselector-pf-dropdown-toggle-padding-bottom;
+      padding-left: $contextselector-pf-dropdown-toggle-padding-left;
+      padding-top: $contextselector-pf-dropdown-toggle-padding-top;
+      &:focus {
+        color: $navbar-pf-vertical-active-color;
+        // restore the focus ring
+        // Default
+        outline: thin dotted !important;
+        // WebKit
+        outline: 5px auto -webkit-focus-ring-color !important;
+        outline-offset: -2px !important;
+      }
+      &:hover {
+        background: $navbar-pf-navbar-primary-active-bg-color-stop;
+        color: $navbar-pf-vertical-active-color;
+        outline: 0 !important; // don't show restored focus ring when open
+      }
+      .filter-option {
+        text-overflow: ellipsis;
+      }
+    }
+    .dropdown-menu li a span.text {
+      display: block;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      width: 100%;
+    }
+  }
+}
 .layout-pf-fixed .navbar-pf-vertical.navbar-pf-contextselector {
   z-index: $zindex-modal-background;
 }
 .navbar-pf-vertical .nav.contextselector-pf {
-    @media (min-width: $screen-sm-min) {
-      margin-left:$contextselector-pf-margin-left;
-    }
-    border-left:1px solid $color-pf-black-700;
-      .nav-item-iconic {
-        padding:$contextselector-pf-nav-item-iconic-padding;
-        display: flex;
-        align-items: center;
-      }
+  @media (min-width: $screen-md-min) {
+    margin-left: $contextselector-pf-margin-left;
   }
+}
 
-  .contextselector-pf {
-    float:left;
-    &-title {
-      width: $contextselector-title-width-mobile;
-      @media (min-width: $screen-xs-min) {
-        width: $contextselector-title-width-desktop;
-      }
-      white-space: nowrap;
-      display:inline-block;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      line-height: normal;
+// the following rules are deprecated
+.contextselector-pf {
+  float:left;
+  &-title {
+    display: inline-block;
+    line-height: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: $contextselector-title-width-mobile;
+    @media (min-width: $screen-xs-min) {
+      width: $contextselector-title-width-desktop;
     }
-    .dropdown {
-      &.open, &:hover {
-        background-color: $navbar-pf-navbar-primary-active-bg-color-stop;
-      }
+  }
+  .contextselector-pf-list {
+    @media (min-width: $screen-sm-min) {
+      max-height: $contextselector-pf-list-max-height;
+      overflow-y: auto;
     }
-    .dropdown-menu {
-      width: 100%;
-      margin-top:0;
+    a {
+      color: $color-pf-black-800;
+      display: block;
     }
-    .form-group {
-      margin: $contextselector-pf-form-group-margin;
-    }
-    .contextselector-pf-list {
-      @media (min-width: $screen-sm-min) {
-        max-height: $contextselector-pf-list-max-height;
-        overflow-y: auto;
-      }
-      li {
-        padding: $contextselector-pf-list-li-padding;
-        border-width: $contextselector-pf-list-li-border-width;
-        border-style: solid;
-        border-color: transparent;
-        &:hover {
-          background: $color-pf-blue-50;
-          border-color: $dropdown-link-hover-border-color;
-          a {
-            text-decoration: none;
-          }
+    li {
+      border-color: transparent;
+      border-style: solid;
+      border-width: $contextselector-pf-list-li-border-width;
+      padding: $contextselector-pf-list-li-padding;
+      &:hover {
+        background: $color-pf-blue-50;
+        border-color: $dropdown-link-hover-border-color;
+        a {
+          text-decoration: none;
         }
       }
-      a {
-        color: $color-pf-black-800;
-        display: block;
-      }
     }
   }
+  .dropdown {
+    &.open, &:hover {
+      background-color: $navbar-pf-navbar-primary-active-bg-color-stop;
+    }
+  }
+  .dropdown-menu {
+    margin-top: 0;
+    width: 100%;
+  }
+  .form-group {
+    margin: $contextselector-pf-form-group-margin;
+  }
+}
+.navbar-pf-vertical .nav.contextselector-pf .nav-item-iconic {
+  align-items: center;
+  display: flex;
+  padding: $contextselector-pf-nav-item-iconic-padding;
+}

--- a/src/sass/converted/patternfly/_variables.scss
+++ b/src/sass/converted/patternfly/_variables.scss
@@ -41,10 +41,15 @@ $card-pf-border-top-color:                                          transparent 
 $card-pf-container-bg-color:                                        $color-pf-black-150 !default;
 $card-pf-footer-bg-color:                                           $color-pf-black-100 !default;
 $card-pf-selected-border-color:                                     $color-pf-blue-300 !default;
+$contextselector-title-width-desktop:                               210px !default;
+$contextselector-title-width-mobile:                                170px !default;
+$contextselector-pf-bootstrap-select-width-desktop:                 ($contextselector-title-width-desktop + 32) !default;
+$contextselector-pf-bootstrap-select-width-mobile:                  ($contextselector-title-width-mobile + 32) !default;
+$contextselector-pf-dropdown-toggle-padding-bottom:                 19px !default;
+$contextselector-pf-dropdown-toggle-padding-left:                   10px !default;
+$contextselector-pf-dropdown-toggle-padding-top:                    19px !default;
 $contextselector-pf-margin-left:                                    10px !default;
 $contextselector-pf-nav-item-iconic-padding:                        23px 20px 18px 10px !default;
-$contextselector-title-width-mobile:                                170px !default;
-$contextselector-title-width-desktop:                               210px !default;
 $contextselector-pf-form-group-margin:                              0 5px 5px 5px !default;
 $contextselector-pf-list-max-height:                                200px !default;
 $contextselector-pf-list-li-padding:                                1px 10px !default;

--- a/tests/pages/_includes/widgets/framework/context-selector.html
+++ b/tests/pages/_includes/widgets/framework/context-selector.html
@@ -1,30 +1,18 @@
-<ul class="nav contextselector-pf">
-  <li class="dropdown">
-    <a href="#0" class="dropdown-toggle nav-item-iconic" id="dropdownMenu3{{include.navindex}}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-      <span class="contextselector-pf-title">Really long server name server name</span>
-      <span class="caret"></span>
-    </a>
-    <div class="dropdown-menu" aria-labelledby="dropdownMenu3{{include.navindex}}">
-    <div class="form-group">
-    <label class="sr-only" for="searchinput">search</label>
-    <input type="text" class="form-control" id="searchinput" placeholder="Search">
-  </div>
-    <ul class="contextselector-pf-list list-unstyled">
-      <li><a href="#0">A Different Context</a></li>
-      <li><a href="#0">A Second Context</a></li>
-      <li><a href="#0">Current</a></li>
-      <li><a href="#0">Dolor Sit Amet</a></li>
-      <li><a href="#0">Dolor Sit Amet</a></li>
-      <li><a href="#0">Dolor Sit Amet</a></li>
-      <li><a href="#0">Dolor Sit Amet</a></li>
-      <li><a href="#0">Dolor Sit Amet</a></li>
-      <li><a href="#0">Dolor Sit Amet</a></li>
-      <li><a href="#0">Dolor Sit Amet</a></li>
-      <li><a href="#0">Dolor Sit Amet</a></li>
-      <li><a href="#0">Dolor Sit Amet</a></li>
-      <li><a href="#0">Dolor Sit Amet</a></li>
-      <li><a href="#0">Dolor Sit Amet</a></li>
-    </ul>
-  </div>
-  </li>
-</ul>
+<div class="nav contextselector-pf">
+  <select class="selectpicker" data-live-search="true">
+    <option>Really long server name server name</option>
+    <option>A Different Context</option>
+    <option>A Second Context</option>
+    <option>Current</option>
+    <option>Superlongstringwithoutanyspacesthatkeepsgoingandgoingandgoing</option>
+    <option>Dolor Sit Amet</option>
+    <option>Dolor Sit Amet</option>
+    <option>Dolor Sit Amet</option>
+    <option>Dolor Sit Amet</option>
+    <option>Dolor Sit Amet</option>
+    <option>Dolor Sit Amet</option>
+    <option>Dolor Sit Amet</option>
+    <option>Dolor Sit Amet</option>
+    <option>Dolor Sit Amet</option>
+  </select>
+</div>

--- a/tests/pages/context-selector-vertical-nav.html
+++ b/tests/pages/context-selector-vertical-nav.html
@@ -7,6 +7,6 @@ full-page: true
 contextselector: true
 submenus: true
 title: Context Selector for Vertical Navigation
-url-js-extra: ['https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.2/jquery.matchHeight-min.js', 'https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.js', 'https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js']
+url-js-extra: ['https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.2/jquery.matchHeight-min.js', 'https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.js', 'https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js', 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js/bootstrap-select.min.js']
 ---
 {% include widgets/navigation/vertical-navigation.html icons=true %}

--- a/tests/pages/context-selector.html
+++ b/tests/pages/context-selector.html
@@ -6,5 +6,6 @@ resource: true
 contextselector: true
 navindex: 1
 title: Context Selector
+url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js/bootstrap-select.min.js'
 ---
 {% include widgets/layouts/navbar-vertical.html navindex=5 %}


### PR DESCRIPTION
Fixes #1006

The contextswitcher was originally written using a dropdown, which doesn't provide the correct
functionality.  This PR preserves the existing styles for the dropdown for backward compatibility.

## Changes

Write a list of changes the PR introduces

* Replace dropdown with Bootstrap-select

## Link to rawgit and/or image

https://rawgit.com/rhamilto/patternfly/contextselector-selectpicker-dist/dist/tests/context-selector.html
https://rawgit.com/rhamilto/patternfly/contextselector-selectpicker-dist/dist/tests/context-selector-vertical-nav.html

## PR checklist (if relevant)
Note:  I am not currently able to cross-browser test IE as I don't have full access to BrowserStack at the moment.

- [x] **Cross browser**: works in IE9
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [x] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
- [X] **Responsive**: works in extra small, small, medium and large view ports.
- [X] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
