### PR TITLE
fix(login): fix login-pf class location

### DIFF
--- a/src/less/login.less
+++ b/src/less/login.less
@@ -4,6 +4,11 @@
 
 .login-pf {
   height: 100%;
+  background: @login-bg-color url("@{img-path}/@{img-bg-login}") repeat-x 50% 0;
+  background-size: auto;
+  @media (min-width: @screen-sm-min) {
+    background-size: 100% auto;
+  }
   #brand {
     position: relative;
     top: -70px;

--- a/src/sass/converted/patternfly/_login.scss
+++ b/src/sass/converted/patternfly/_login.scss
@@ -4,6 +4,11 @@
 
 .login-pf {
   height: 100%;
+  background: $login-bg-color url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$img-path}#{$img-bg-login}"), "#{$img-path}#{$img-bg-login}")) repeat-x 50% 0;
+  background-size: auto;
+  @media (min-width: $screen-sm-min) {
+    background-size: 100% auto;
+  }
   #brand {
     position: relative;
     top: -70px;

--- a/tests/pages/_layouts/login.html
+++ b/tests/pages/_layouts/login.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <!--[if IE 9]><html lang="en-us" class="ie9 login-pf"><![endif]-->
 <!--[if gt IE 9]><!-->
-<html lang="en-us" class="login-pf">
+<html lang="en-us">
 <!--<![endif]-->
 {% include head.html %}
-  <body>
+  <body class="login-pf">
 {{ content }}
   </body>
 </html>


### PR DESCRIPTION
## Description
Fix the `login-pf` class location to be on `<body>` rather than `<html>`. Update styles accordingly.

fixes https://github.com/patternfly/patternfly/issues/1019

## Changes

Write a list of changes the PR introduces

* Move `.login-pf` to `<body>` rather than `<html>`.
* Update the `login.less` file to account for class location change.

## Link to rawgit and/or image
![login basic patternfly](https://user-images.githubusercontent.com/4032718/38880308-5f77a20e-4233-11e8-944b-300000c06615.png)

## PR checklist (if relevant)

- [X] **Cross browser**: works in IE9
- [X] **Cross browser**: works in IE10
- [X] **Cross browser**: works in IE11
- [X] **Cross browser**: works in Edge
- [X] **Cross browser**: works in Chrome
- [X] **Cross browser**: works in Firefox
- [X] **Cross browser**: works in Safari
- [X] **Cross browser**: works in Opera
- [X] **Responsive**: works in extra small, small, medium and large view ports.
- [X] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
