### PR TITLE
fix(popovers): Fix color issue with bottom popover

### DIFF
--- a/src/less/popovers.less
+++ b/src/less/popovers.less
@@ -5,6 +5,20 @@
 .popover {
   .box-shadow(0 2px 2px fade(@color-pf-black, 8%));
   padding: 0;
+  &.bottom {
+    .popover-title:before {
+      content:"";
+      position: absolute;
+      top: @popover-position-top;
+      left: 50%;
+      transform: translateX(-50%);
+      border-top-width: @popover-border-top-width;
+      border-width: @popover-border-width;
+      border-color: transparent;
+      border-bottom-color: @popover-border-bottom-color;
+      border-style: solid;
+    }
+  }
 }
 
 .popover-content {

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -487,7 +487,11 @@
 @popover-arrow-color:                                               @color-pf-white;
 @popover-arrow-outer-color:                                         @color-pf-black-400;
 @popover-border-color:                                              @color-pf-black-400;
+@popover-border-bottom-color:                                       @color-pf-black-150;
+@popover-border-width:                                              10px;
+@popover-border-top-width:                                          0;
 @popover-max-width:                                                 220px;
+@popover-position-top:                                              -20px;
 @popover-title-bg:                                                  @color-pf-black-150;
 @pre-bg:                                                            @color-pf-black-100;
 @progress-bg:                                                       @color-pf-black-200;

--- a/src/sass/converted/patternfly/_popovers.scss
+++ b/src/sass/converted/patternfly/_popovers.scss
@@ -5,6 +5,20 @@
 .popover {
   @include box-shadow(0 2px 2px rgba($color-pf-black, (8/100)));
   padding: 0;
+  &.bottom {
+    .popover-title:before {
+      content:"";
+      position: absolute;
+      top: $popover-position-top;
+      left: 50%;
+      transform: translateX(-50%);
+      border-top-width: $popover-border-top-width;
+      border-width: $popover-border-width;
+      border-color: transparent;
+      border-bottom-color: $popover-border-bottom-color;
+      border-style: solid;
+    }
+  }
 }
 
 .popover-content {

--- a/src/sass/converted/patternfly/_variables.scss
+++ b/src/sass/converted/patternfly/_variables.scss
@@ -487,7 +487,11 @@ $panel-inner-border:                                                $color-pf-bl
 $popover-arrow-color:                                               $color-pf-white !default;
 $popover-arrow-outer-color:                                         $color-pf-black-400 !default;
 $popover-border-color:                                              $color-pf-black-400 !default;
+$popover-border-bottom-color:                                       $color-pf-black-150 !default;
+$popover-border-width:                                              10px !default;
+$popover-border-top-width:                                          0 !default;
 $popover-max-width:                                                 220px !default;
+$popover-position-top:                                              -20px !default;
 $popover-title-bg:                                                  $color-pf-black-150 !default;
 $pre-bg:                                                            $color-pf-black-100 !default;
 $progress-bg:                                                       $color-pf-black-200 !default;


### PR DESCRIPTION
## Description
Fix the bottom popover styling issue where the triangle is white, rather than grey to match the title background.

fixes https://github.com/patternfly/patternfly/issues/1014

## Changes

Write a list of changes the PR introduces

* Update the triangle on the top of popovers to be grey, in order to match the title background.

Rawgit: https://rawgit.com/mindreeper2420/patternfly/issue-1014-dist/dist/tests/popovers.html

![screen shot 2018-04-18 at 10 54 11 am](https://user-images.githubusercontent.com/4032718/38940430-1cedf29c-42f8-11e8-8199-63ecda25e45d.png)
![screen shot 2018-04-18 at 10 54 16 am](https://user-images.githubusercontent.com/4032718/38940431-1d050680-42f8-11e8-806e-4dd5cc3d5a14.png)
![screen shot 2018-04-18 at 10 54 23 am](https://user-images.githubusercontent.com/4032718/38940432-1d19d380-42f8-11e8-9709-b43831554fb2.png)
![screen shot 2018-04-18 at 10 54 28 am](https://user-images.githubusercontent.com/4032718/38940433-1d2ba29a-42f8-11e8-8cff-e9557964fc2e.png)

## PR checklist (if relevant)

- [X] **Cross browser**: works in IE9
- [X] **Cross browser**: works in IE10
- [X] **Cross browser**: works in IE11
- [X] **Cross browser**: works in Edge
- [X] **Cross browser**: works in Chrome
- [X] **Cross browser**: works in Firefox
- [X] **Cross browser**: works in Safari
- [X] **Cross browser**: works in Opera
- [X] **Responsive**: works in extra small, small, medium and large view ports.
- [X] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
