### PR TITLE
fix(listview): update List View active state per design specs

### DIFF
--- a/src/less/list-view.less
+++ b/src/less/list-view.less
@@ -22,7 +22,7 @@
     }
     &.active {
       color: @list-group-link-color;
-      background-color: @list-view-active-bg;
+      background-color: transparent;
       background-clip: border-box;
       border-color: @list-view-active-border transparent transparent;
       z-index:auto;
@@ -258,7 +258,7 @@
   }
 }
 .list-view-pf-view {
-  background: @list-group-top-border;
+  background: transparent;
   border: none;
   margin-top: 30px;
 }

--- a/src/sass/converted/patternfly/_list-view.scss
+++ b/src/sass/converted/patternfly/_list-view.scss
@@ -22,7 +22,7 @@
     }
     &.active {
       color: $list-group-link-color;
-      background-color: $list-view-active-bg;
+      background-color: transparent;
       background-clip: border-box;
       border-color: $list-view-active-border transparent transparent;
       z-index:auto;
@@ -258,7 +258,7 @@
   }
 }
 .list-view-pf-view {
-  background: $list-group-top-border;
+  background: transparent;
   border: none;
   margin-top: 30px;
 }


### PR DESCRIPTION
## Description
Update the List View active state to match the updated designs specs.

fixes https://github.com/patternfly/patternfly/issues/1020

## Changes

Set the active state of the `list-group-item` to have a transparent background, rather than the blue highlight.

* Remove `background-color: @list-view-active-bg;` from `.list-view-pf:active` and replace with `background-color: transparent;`
* Remove `background: @list-group-top-border;` from `.list-view-pf-view` and replace with `background-color: transparent;`

**Old**
<img width="1204" alt="screen shot 2018-04-22 at 1 51 52 pm" src="https://user-images.githubusercontent.com/4032718/39098184-03e28c28-4635-11e8-9eb8-fb870797595a.png">
<img width="1440" alt="screen shot 2018-04-22 at 1 52 10 pm" src="https://user-images.githubusercontent.com/4032718/39098185-03f234f2-4635-11e8-8829-867089da90cf.png">

**New**
<img width="1210" alt="screen shot 2018-04-22 at 1 51 28 pm" src="https://user-images.githubusercontent.com/4032718/39098187-09b487dc-4635-11e8-81d3-a3ae6c74915d.png">
<img width="1434" alt="screen shot 2018-04-22 at 1 51 04 pm" src="https://user-images.githubusercontent.com/4032718/39098188-0bade966-4635-11e8-9179-88b7bf5d6dca.png">

https://rawgit.com/mindreeper2420/patternfly/issue-1020-dist/dist/tests/list-view-rows.html

## PR checklist (if relevant)

- [X] **Cross browser**: works in IE9
- [X] **Cross browser**: works in IE10
- [X] **Cross browser**: works in IE11
- [X] **Cross browser**: works in Edge
- [X] **Cross browser**: works in Chrome
- [X] **Cross browser**: works in Firefox
- [X] **Cross browser**: works in Safari
- [X] **Cross browser**: works in Opera
- [X] **Responsive**: works in extra small, small, medium and large view ports.
- [X] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
