### PR TITLE
chore(bootstrap-select): update package.json to lock in 1.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "optionalDependencies": {
     "bootstrap-datepicker": "^1.7.1",
     "bootstrap-sass": "^3.3.7",
-    "bootstrap-select": "^1.12.2",
+    "bootstrap-select": "1.12.2",
     "bootstrap-slider": "^9.9.0",
     "bootstrap-switch": "~3.3.4",
     "bootstrap-touchspin": "~3.1.1",


### PR DESCRIPTION
## Description
* This PR is to lock in bootstrap-select to version 1.12.2 in order to prevent components from breaking that are dependent on this package. This was done in pf-org when the build updated this package to version 1.13.1 and broke some of the components.

* Related PR: https://github.com/patternfly/patternfly-org/pull/559

## Changes

Write a list of changes the PR introduces

* package.json


