### PR TITLE
fix(wizard): better align wizard ui to design spec

### DIFF
--- a/src/less/wizard.less
+++ b/src/less/wizard.less
@@ -6,6 +6,7 @@
   margin: 0 auto;
   max-height: 900px;
   width: auto;
+
   .modal-content {
     min-height:100%;
   }
@@ -19,100 +20,115 @@
     padding: 0;
     position: static;
 }
+
 /* styles the sidebard containing the sub-steps */
 .wizard-pf-sidebar {
-    background: @color-pf-black-100;
-    border-right: 1px solid @color-pf-black-300;
-    display:none;
+  background: @color-pf-black-100;
+  border-right: 1px solid @color-pf-black-300;
+  display:none;
+
   @media (min-width: @screen-sm-min) {
     display:inherit;
     flex:0 0 auto;
     overflow-x: hidden;
     overflow-y: auto;
+
     .list-group {
       border-top: 0;
       margin-bottom: 0;
     }
-      .list-group-item {
-        background-color: transparent;
-        border-color: @color-pf-black-200;
-        padding: 0;
-        > a {
-          color: @color-pf-black;
-          cursor: pointer;
-          display: block;
-          font-size: 14px;
-          font-weight: 700;
-          height: 50px;
-          outline: 0;
-          padding-top: 11px;
-          padding-left: 20px;
-          position: relative;
-          white-space: nowrap;
-          width: 14em;
-          &:hover {
-            text-decoration: none;
-            background-color: @color-pf-black-200;
-          }
-          &:focus {
-            //corrects odd behavior when hover and focus are combined.
-            text-decoration: none;
-            span {
-              text-decoration: underline;
-            }
-          }
-        }
-        &.active {
-          background-color: @color-pf-black-200;
 
-          //override default behavior
-          &:hover {
-            border-color: @color-pf-black-200;
-          }
-          > a {
-            color: @color-pf-blue-300;
-            cursor: default;
-          }
-          // line to left side showing active substep
-          > a:before {
-            content: " ";
-            background: @color-pf-blue-300;
-            height: 100%;
-            left: 0;
-            position: absolute;
-            top: 0;
-            width: 3px;
-          }
-          // caret to right showing active substep
-          > a:after {
-            color: @color-pf-blue-300;
-            content: "\f105"; // right caret
-            display: block;
-            font-family: FontAwesome;
-            font-size: 24px;
-            font-weight: 500;
-            line-height: 30px;
-            padding-top: 10px;
-            position: absolute;
-            right: 23px;
-            top: 0;
+    .list-group-item {
+      background-color: transparent;
+      border-color: @color-pf-black-200;
+      padding: 0;
+
+      > a {
+        color: @color-pf-black;
+        cursor: pointer;
+        display: block;
+        font-size: 14px;
+        font-weight: 700;
+        height: 50px;
+        outline: 0;
+        padding-top: 11px;
+        padding-left: 20px;
+        position: relative;
+        white-space: nowrap;
+        width: 14em;
+
+        &:hover {
+          text-decoration: none;
+          background-color: @color-pf-black-200;
+        }
+
+        &:focus {
+          //corrects odd behavior when hover and focus are combined.
+          text-decoration: none;
+
+          span {
+            text-decoration: underline;
           }
         }
       }
+
+      &.active {
+        background-color: @color-pf-black-200;
+
+        //override default behavior
+        &:hover {
+          border-color: @color-pf-black-200;
+        }
+
+        > a {
+          color: @color-pf-blue-300;
+          cursor: default;
+        }
+
+        // line to left side showing active substep
+        > a:before {
+          content: " ";
+          background: @color-pf-blue-300;
+          height: 100%;
+          left: 0;
+          position: absolute;
+          top: 0;
+          width: 3px;
+        }
+
+        // caret to right showing active substep
+        > a:after {
+          color: @color-pf-blue-300;
+          content: "\f105"; // right caret
+          display: block;
+          font-family: FontAwesome;
+          font-size: 24px;
+          font-weight: 500;
+          line-height: 30px;
+          padding-top: 10px;
+          position: absolute;
+          right: 23px;
+          top: 0;
+        }
+      }
     }
+  }
 }
+
 .wizard-pf-substep-number {
   display:inline-block;
   margin-right: 5px;
   vertical-align: middle;
   width: 25px;
 }
+
 .wizard-pf-substep-title {
   display:inline-block;
   margin-right: 5px;
   text-align: left;
   vertical-align: middle;
 }
+
 /* styles the steps indicator across the top of the wizard */
 .wizard-pf-steps {
   border-bottom: solid 1px @color-pf-black-300;
@@ -130,14 +146,15 @@
   list-style: none;
   margin-bottom: 0;
   padding: 15px 0;
-    @media (min-width: @screen-sm-min) {
-      background: @color-pf-white;
-      height: 120px;
-      padding: 38px 0 0;
-      justify-content: space-around;
-    }
 
-  li {
+  @media (min-width: @screen-sm-min) {
+    background: @color-pf-white;
+    height: 120px;
+    padding: 38px 0 0;
+    justify-content: space-around;
+  }
+
+  .wizard-pf-step {
     counter-increment: section;
     float:left; /* float for IE9 since it doesn't support flex. If items wrap, they overlap */
     flex-grow: 1;
@@ -147,47 +164,57 @@
     padding: 0;
     position: relative;
     text-align: center;
+
     &:not(.active) {
       display: none;
+
       @media (min-width: @screen-sm-min) {
         display: block;
       }
     }
-    a {
-        align-items: center;
-        display: flex;
-        flex-wrap:wrap;
-        font-weight: 700;
-        @media (min-width: @screen-sm-min) {
-          font-weight: normal;
-          justify-content: center;
-        }
-          .wizard-pf-step-title {
-            margin-left: 10px;
-            @media(min-width: @screen-sm-min) {
-              margin-left: 0;
-            }
 
-            &-substep {
-              font-weight: normal;
-              margin-left: 10px;
-              text-transform: capitalize;
-              &:before {
-                content:"\00BB";
-                font-size: 20px;
-                margin-right: 10px;
-              }
-              &:not(.active) {
-                display: none;
-              }
-            }
+    a {
+      align-items: center;
+      display: flex;
+      flex-wrap:wrap;
+      font-weight: 700;
+
+      @media (min-width: @screen-sm-min) {
+        font-weight: normal;
+        justify-content: center;
+      }
+
+      .wizard-pf-step-title {
+        margin-left: 10px;
+
+        @media(min-width: @screen-sm-min) {
+          margin-left: 0;
+        }
+
+        &-substep {
+          font-weight: normal;
+          margin-left: 10px;
+          text-transform: capitalize;
+
+          &:before {
+            content:"\00BB";
+            font-size: 20px;
+            margin-right: 10px;
           }
+
+          &:not(.active) {
+            display: none;
+          }
+        }
+      }
     }
+
     /* draw the line between the circles */
     @media (min-width: @screen-sm-min) {
       .wizard-pf-step-title-substep {
         display: none;
       }
+
       &:before {
         background-color: @color-pf-black-400;
         content: "";
@@ -198,19 +225,23 @@
         top: 40px; // needed for IE9/10 calculate 50% of just the li, others calc 50% of the entire thing including the a:before
         //otherwise, use top: calc(50% - 1px);
       }
+
       /* don't draw the line between the circles on the ends */
       &:first-child:before {
         left: 50%;
         right: 0;
       }
+
       &:last-child:before {
         left: 0;
         right: 50%;
       }
+
       &:only-of-type:before {
         background-color: transparent;
       }
     }
+
     a {
       color: @color-pf-black;
       cursor: pointer;
@@ -218,7 +249,10 @@
       margin-left:1em;
       margin-right:1em;
       text-decoration: none;
-      &:hover {
+    }
+
+    &:not(.active) {
+      a:hover {
         .wizard-pf-step-number {
           background-color: @color-pf-black-400;
           border-color: @color-pf-black-400;
@@ -226,38 +260,41 @@
         }
       }
     }
-}
-  /* draw the step number in the circle */
 
-  .wizard-pf-step-number {
-    background-color: @color-pf-white;
-    border-radius: 50%;
-    border: solid 2px @color-pf-black-400;
-    color: @color-pf-black-400;
-    font-size: @font-size-base;
-    font-weight: 700;
-    height: 25px;
-    line-height: 22px;
+    .wizard-pf-step-number {
+      border-radius: 50%;
+      border: solid 2px @color-pf-blue-300;
+      background: @color-pf-white;
+      color: @color-pf-black-400;
+      font-size: @font-size-base;
+      font-weight: 700;
+      height: 25px;
+      line-height: 22px;
+      width: 25px;
+  
       @media (min-width: @screen-sm-min) {
         left: ~"calc(50% - 13px)";
         position: absolute;
         top: 27px;
       }
-    width: 25px;
-  }
-  .active .wizard-pf-step-number {
-    background-color: @color-pf-blue-300;
-    border-color: @color-pf-blue-300;
-    cursor: default;
-    color: @color-pf-white;
-  }
+    }
 
-  .viewed-pf .wizard-pf-step-number {
-    color: @color-pf-black;
-    background-color: @color-pf-white;
-    border-color: @color-pf-blue-300;
-  }
+    & ~ .wizard-pf-step {
+      .wizard-pf-step-number {
+        border-color: @color-pf-black-400;
+        background: @color-pf-white;
+      }
+    }
 
+    &.active {
+      .wizard-pf-step-number {
+        background-color: @color-pf-blue-300;
+        border-color: @color-pf-blue-300;
+        cursor: default;
+        color: @color-pf-white;
+      }
+    }
+  }
 }
 
 /* styles the main content portion of the wizard */
@@ -266,11 +303,13 @@
   padding:1em;
   vertical-align: top;
   width:100%;
+
   @media (min-width: @screen-sm-min) {
     overflow: auto;
     padding:3em;
     flex:1 1 auto;
   }
+
   .blank-slate-pf {
     background-color: transparent;
     border: none;
@@ -286,11 +325,14 @@
 /* styles the content of a review page */
 .wizard-pf-review-steps {
   list-style: none;
+
   .list-group, .list-group-item {
     border: none;
     margin-bottom: 0;
   }
+
   > ul {
+
     > li {
       float: left;
       line-height: 15px;
@@ -298,6 +340,7 @@
       padding-top: 0;
       position: relative;
       width: 100%;
+
       > a {
         color: #030303;
         cursor: pointer;
@@ -306,6 +349,7 @@
         padding-right: 5px;
         text-decoration: none;
         transition: 250ms;
+
         &:before {
           content: "\f107";
           display: block;
@@ -316,6 +360,7 @@
           position: absolute;
           top: 0;
         }
+
         &.collapsed {
           &:before {
             content: "\f105";
@@ -328,13 +373,16 @@
 
 .wizard-pf-review-substeps {
   padding-left: 22px;
+
   > ul {
+
     > li {
       float: left;
       line-height: 15px;
       margin: 0;
       position: relative;
       width: 100%;
+
       a {
         color: #030303;
         cursor: pointer;
@@ -343,6 +391,7 @@
         padding-right: 5px;
         text-decoration: none;
         transition: 250ms;
+
         &:before {
           content: "\f107";
           display: block;
@@ -353,6 +402,7 @@
           position: absolute;
           top: 10px;
         }
+
         &.collapsed {
           &:before {
             content: "\f105";
@@ -366,25 +416,32 @@
 .wizard-pf-review-content {
   padding-top: 10px;
   padding-left: 40px;
+
   .wizard-pf-review-item {
     padding: 5px 0;
+
     &.sub-item {
       margin-left: 10px;
     }
+
     .wizard-pf-review-item-label {
       font-weight: 700;
       padding-right: 10px;
     }
+
     .wizard-pf-review-item-field {
       font-weight: 700;
       margin: 5px 0;
       padding-right: 10px;
+
       &:first-of-type {
         margin-top: 0;
       }
+
       &:last-of-type {
         margin-bottom: 0;
       }
+
       &.sub-field {
         margin-left: 10px;
       }
@@ -425,6 +482,7 @@
     padding: 30px 0;
     width: 900px;
   }
+
   // increasing width of sidebar for larger viewports
   .wizard-pf-sidebar .list-group-item > a {
     width: 18em;
@@ -443,14 +501,15 @@
 }
 
 .wizard-pf-steps-alt {
-  margin-left: 15px;
-  margin-top: 15px;
-  background-image: linear-gradient(to right, transparent 11px, @color-pf-black-300 11px, @color-pf-black-300 13px, transparent 13px);
+  margin: 15px 0 15px 15px;
+  
   @media (min-width: @screen-sm-min) {
     display:none;
   }
+
   &-indicator {
     position: relative;
+
     // caret to top showing active substep
     &:after {
       color: @color-pf-black-700;
@@ -463,10 +522,12 @@
       right: 17px;
       top: 50%;
       transform:translateY(-50%);
+
       @media (min-width: @screen-sm-min) {
         display:none;
       }
     }
+
     &.active {
       &:after {
         content: "\f106";
@@ -476,26 +537,50 @@
 }//.wizard-pf-steps-alt
 
 .wizard-pf-step-alt {
-  margin-bottom: 10px;
+  position: relative;
+  z-index: 1;
+
+  &:not(:last-child) {
+    padding-bottom: 10px;
+  }
+
   a {
     display:flex;
     flex:1;
+
     &:hover {
       text-decoration: none;
+
       .wizard-pf-step-alt-title {
         color: @color-pf-blue-300;
       }
     }
   }
+
   ul {
     margin-left: 11px;
   }
+
+  .wizard-pf-step-alt-number {
+    border-radius: 50%;
+    font-size: @font-size-base;
+    font-weight: 700;
+    height: 24px;
+    width: 24px;
+    display: inline-block;
+    text-align: center;
+    flex:0 0 auto;
+    border: 2px solid @color-pf-blue-300;
+    background-color: @color-pf-white;
+  }
+  
   .wizard-pf-step-alt-title {
+    color: @color-pf-black;
+    font-weight: 700;
+    text-transform: capitalize;
+    display:inline-block;
     margin-left: 5px;
     align-self:center;
-  }
-  .wizard-pf-step-alt-number {
-    flex:0 0 auto;
   }
 
   &.active {
@@ -505,70 +590,69 @@
       cursor: default;
       color: @color-pf-white;
     }
+
     .wizard-pf-step-alt-title {
       color: @color-pf-blue-300;
     }
-    .wizard-pf-step-alt-substep:first-of-type {
-      margin-top: 2px; // gives proper spacing below number in circle active state
-    }
 
-
-  }
-  &.viewed {
-    .wizard-pf-step-alt-number {
-      color: @color-pf-black;
-      background-color: @color-pf-white;
-      border-color: @color-pf-blue-300;
+    & ~ .wizard-pf-step-alt {
+      .wizard-pf-step-alt-number {
+        color: @color-pf-black-400;
+        border-color: @color-pf-black-400;
+      }
     }
   }
 
+  &:not(.active) {
+    a:hover {
+      .wizard-pf-step-alt-number {
+        border-color: @color-pf-black-400;
+        background: @color-pf-black-400;
+        color: @color-pf-white;
+      }
+    }
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 11px;
+    height: 100%;
+    border-left: 2px solid @color-pf-black-400;
+    z-index: -1;
+  }
 }//.wizard-pf-step-alt
 
-.wizard-pf-step-alt-number {
-  background-color: @color-pf-white;
-  border-radius: 50%;
-  border: solid 2px @color-pf-black-400;
-  color: @color-pf-black-400;
-  font-size: @font-size-base;
-  font-weight: 700;
-  height: 24px;
-  width: 24px;
-  display: inline-block;
-  text-align: center;
-}
-
-
-.wizard-pf-step-alt-title {
-  color: @color-pf-black;
-  font-weight: 700;
-  text-transform: capitalize;
-  display:inline-block;
-
-}//.wizard-pf-steps-alt-title
-
 .wizard-pf-step-alt-substep {
-    display:flex;
+  display: flex;
+  border-left: 2px solid transparent;
+
   a {
     padding:5px 0 5px 18px;
     color: @color-pf-black-800;
   }
 
-&:not(.disabled) {
-  &.active, &:hover {
-    background-color: @color-pf-black-200;
-    background-image: linear-gradient(to right, @color-pf-blue-300 2px, transparent 2px);
-    a {
-      color:@color-pf-blue-300;
+  &:not(.disabled) {
+    &.active,
+    &:hover {
+      background-color: @color-pf-black-200;
+      border-color: @color-pf-blue-300;
+      
+      a {
+        color:@color-pf-blue-300;
+      }
     }
   }
-}
+
   &.active {
     a {
       font-weight:700;
     }
   }
+
   &.disabled {
     cursor: not-allowed;
+    
     a {
       pointer-events: none;
     }

--- a/src/less/wizard.less
+++ b/src/less/wizard.less
@@ -613,8 +613,8 @@
     }
   }
 
-  &::before {
-    content: '';
+  &:before {
+    content: "";
     position: absolute;
     left: 11px;
     height: 100%;

--- a/src/sass/converted/patternfly/_wizard.scss
+++ b/src/sass/converted/patternfly/_wizard.scss
@@ -6,6 +6,7 @@
   margin: 0 auto;
   max-height: 900px;
   width: auto;
+
   .modal-content {
     min-height:100%;
   }
@@ -19,100 +20,115 @@
     padding: 0;
     position: static;
 }
+
 /* styles the sidebard containing the sub-steps */
 .wizard-pf-sidebar {
-    background: $color-pf-black-100;
-    border-right: 1px solid $color-pf-black-300;
-    display:none;
+  background: $color-pf-black-100;
+  border-right: 1px solid $color-pf-black-300;
+  display:none;
+
   @media (min-width: $screen-sm-min) {
     display:inherit;
     flex:0 0 auto;
     overflow-x: hidden;
     overflow-y: auto;
+
     .list-group {
       border-top: 0;
       margin-bottom: 0;
     }
-      .list-group-item {
-        background-color: transparent;
-        border-color: $color-pf-black-200;
-        padding: 0;
-        > a {
-          color: $color-pf-black;
-          cursor: pointer;
-          display: block;
-          font-size: 14px;
-          font-weight: 700;
-          height: 50px;
-          outline: 0;
-          padding-top: 11px;
-          padding-left: 20px;
-          position: relative;
-          white-space: nowrap;
-          width: 14em;
-          &:hover {
-            text-decoration: none;
-            background-color: $color-pf-black-200;
-          }
-          &:focus {
-            //corrects odd behavior when hover and focus are combined.
-            text-decoration: none;
-            span {
-              text-decoration: underline;
-            }
-          }
-        }
-        &.active {
-          background-color: $color-pf-black-200;
 
-          //override default behavior
-          &:hover {
-            border-color: $color-pf-black-200;
-          }
-          > a {
-            color: $color-pf-blue-300;
-            cursor: default;
-          }
-          // line to left side showing active substep
-          > a:before {
-            content: " ";
-            background: $color-pf-blue-300;
-            height: 100%;
-            left: 0;
-            position: absolute;
-            top: 0;
-            width: 3px;
-          }
-          // caret to right showing active substep
-          > a:after {
-            color: $color-pf-blue-300;
-            content: "\f105"; // right caret
-            display: block;
-            font-family: FontAwesome;
-            font-size: 24px;
-            font-weight: 500;
-            line-height: 30px;
-            padding-top: 10px;
-            position: absolute;
-            right: 23px;
-            top: 0;
+    .list-group-item {
+      background-color: transparent;
+      border-color: $color-pf-black-200;
+      padding: 0;
+
+      > a {
+        color: $color-pf-black;
+        cursor: pointer;
+        display: block;
+        font-size: 14px;
+        font-weight: 700;
+        height: 50px;
+        outline: 0;
+        padding-top: 11px;
+        padding-left: 20px;
+        position: relative;
+        white-space: nowrap;
+        width: 14em;
+
+        &:hover {
+          text-decoration: none;
+          background-color: $color-pf-black-200;
+        }
+
+        &:focus {
+          //corrects odd behavior when hover and focus are combined.
+          text-decoration: none;
+
+          span {
+            text-decoration: underline;
           }
         }
       }
+
+      &.active {
+        background-color: $color-pf-black-200;
+
+        //override default behavior
+        &:hover {
+          border-color: $color-pf-black-200;
+        }
+
+        > a {
+          color: $color-pf-blue-300;
+          cursor: default;
+        }
+
+        // line to left side showing active substep
+        > a:before {
+          content: " ";
+          background: $color-pf-blue-300;
+          height: 100%;
+          left: 0;
+          position: absolute;
+          top: 0;
+          width: 3px;
+        }
+
+        // caret to right showing active substep
+        > a:after {
+          color: $color-pf-blue-300;
+          content: "\f105"; // right caret
+          display: block;
+          font-family: FontAwesome;
+          font-size: 24px;
+          font-weight: 500;
+          line-height: 30px;
+          padding-top: 10px;
+          position: absolute;
+          right: 23px;
+          top: 0;
+        }
+      }
     }
+  }
 }
+
 .wizard-pf-substep-number {
   display:inline-block;
   margin-right: 5px;
   vertical-align: middle;
   width: 25px;
 }
+
 .wizard-pf-substep-title {
   display:inline-block;
   margin-right: 5px;
   text-align: left;
   vertical-align: middle;
 }
+
 /* styles the steps indicator across the top of the wizard */
 .wizard-pf-steps {
   border-bottom: solid 1px $color-pf-black-300;
@@ -130,14 +146,15 @@
   list-style: none;
   margin-bottom: 0;
   padding: 15px 0;
-    @media (min-width: $screen-sm-min) {
-      background: $color-pf-white;
-      height: 120px;
-      padding: 38px 0 0;
-      justify-content: space-around;
-    }
 
-  li {
+  @media (min-width: $screen-sm-min) {
+    background: $color-pf-white;
+    height: 120px;
+    padding: 38px 0 0;
+    justify-content: space-around;
+  }
+
+  .wizard-pf-step {
     counter-increment: section;
     float:left; /* float for IE9 since it doesn't support flex. If items wrap, they overlap */
     flex-grow: 1;
@@ -147,47 +164,57 @@
     padding: 0;
     position: relative;
     text-align: center;
+
     &:not(.active) {
       display: none;
+
       @media (min-width: $screen-sm-min) {
         display: block;
       }
     }
-    a {
-        align-items: center;
-        display: flex;
-        flex-wrap:wrap;
-        font-weight: 700;
-        @media (min-width: $screen-sm-min) {
-          font-weight: normal;
-          justify-content: center;
-        }
-          .wizard-pf-step-title {
-            margin-left: 10px;
-            @media(min-width: $screen-sm-min) {
-              margin-left: 0;
-            }
 
-            &-substep {
-              font-weight: normal;
-              margin-left: 10px;
-              text-transform: capitalize;
-              &:before {
-                content:"\00BB";
-                font-size: 20px;
-                margin-right: 10px;
-              }
-              &:not(.active) {
-                display: none;
-              }
-            }
+    a {
+      align-items: center;
+      display: flex;
+      flex-wrap:wrap;
+      font-weight: 700;
+
+      @media (min-width: $screen-sm-min) {
+        font-weight: normal;
+        justify-content: center;
+      }
+
+      .wizard-pf-step-title {
+        margin-left: 10px;
+
+        @media(min-width: $screen-sm-min) {
+          margin-left: 0;
+        }
+
+        &-substep {
+          font-weight: normal;
+          margin-left: 10px;
+          text-transform: capitalize;
+
+          &:before {
+            content:"\00BB";
+            font-size: 20px;
+            margin-right: 10px;
           }
+
+          &:not(.active) {
+            display: none;
+          }
+        }
+      }
     }
+
     /* draw the line between the circles */
     @media (min-width: $screen-sm-min) {
       .wizard-pf-step-title-substep {
         display: none;
       }
+
       &:before {
         background-color: $color-pf-black-400;
         content: "";
@@ -198,19 +225,23 @@
         top: 40px; // needed for IE9/10 calculate 50% of just the li, others calc 50% of the entire thing including the a:before
         //otherwise, use top: calc(50% - 1px);
       }
+
       /* don't draw the line between the circles on the ends */
       &:first-child:before {
         left: 50%;
         right: 0;
       }
+
       &:last-child:before {
         left: 0;
         right: 50%;
       }
+
       &:only-of-type:before {
         background-color: transparent;
       }
     }
+
     a {
       color: $color-pf-black;
       cursor: pointer;
@@ -218,7 +249,10 @@
       margin-left:1em;
       margin-right:1em;
       text-decoration: none;
-      &:hover {
+    }
+
+    &:not(.active) {
+      a:hover {
         .wizard-pf-step-number {
           background-color: $color-pf-black-400;
           border-color: $color-pf-black-400;
@@ -226,38 +260,41 @@
         }
       }
     }
-}
-  /* draw the step number in the circle */
 
-  .wizard-pf-step-number {
-    background-color: $color-pf-white;
-    border-radius: 50%;
-    border: solid 2px $color-pf-black-400;
-    color: $color-pf-black-400;
-    font-size: $font-size-base;
-    font-weight: 700;
-    height: 25px;
-    line-height: 22px;
+    .wizard-pf-step-number {
+      border-radius: 50%;
+      border: solid 2px $color-pf-blue-300;
+      background: $color-pf-white;
+      color: $color-pf-black-400;
+      font-size: $font-size-base;
+      font-weight: 700;
+      height: 25px;
+      line-height: 22px;
+      width: 25px;
+  
       @media (min-width: $screen-sm-min) {
         left: unquote("calc(50% - 13px)");
         position: absolute;
         top: 27px;
       }
-    width: 25px;
-  }
-  .active .wizard-pf-step-number {
-    background-color: $color-pf-blue-300;
-    border-color: $color-pf-blue-300;
-    cursor: default;
-    color: $color-pf-white;
-  }
+    }
 
-  .viewed-pf .wizard-pf-step-number {
-    color: $color-pf-black;
-    background-color: $color-pf-white;
-    border-color: $color-pf-blue-300;
-  }
+    & ~ .wizard-pf-step {
+      .wizard-pf-step-number {
+        border-color: $color-pf-black-400;
+        background: $color-pf-white;
+      }
+    }
 
+    &.active {
+      .wizard-pf-step-number {
+        background-color: $color-pf-blue-300;
+        border-color: $color-pf-blue-300;
+        cursor: default;
+        color: $color-pf-white;
+      }
+    }
+  }
 }
 
 /* styles the main content portion of the wizard */
@@ -266,11 +303,13 @@
   padding:1em;
   vertical-align: top;
   width:100%;
+
   @media (min-width: $screen-sm-min) {
     overflow: auto;
     padding:3em;
     flex:1 1 auto;
   }
+
   .blank-slate-pf {
     background-color: transparent;
     border: none;
@@ -286,11 +325,14 @@
 /* styles the content of a review page */
 .wizard-pf-review-steps {
   list-style: none;
+
   .list-group, .list-group-item {
     border: none;
     margin-bottom: 0;
   }
+
   > ul {
+
     > li {
       float: left;
       line-height: 15px;
@@ -298,6 +340,7 @@
       padding-top: 0;
       position: relative;
       width: 100%;
+
       > a {
         color: #030303;
         cursor: pointer;
@@ -306,6 +349,7 @@
         padding-right: 5px;
         text-decoration: none;
         transition: 250ms;
+
         &:before {
           content: "\f107";
           display: block;
@@ -316,6 +360,7 @@
           position: absolute;
           top: 0;
         }
+
         &.collapsed {
           &:before {
             content: "\f105";
@@ -328,13 +373,16 @@
 
 .wizard-pf-review-substeps {
   padding-left: 22px;
+
   > ul {
+
     > li {
       float: left;
       line-height: 15px;
       margin: 0;
       position: relative;
       width: 100%;
+
       a {
         color: #030303;
         cursor: pointer;
@@ -343,6 +391,7 @@
         padding-right: 5px;
         text-decoration: none;
         transition: 250ms;
+
         &:before {
           content: "\f107";
           display: block;
@@ -353,6 +402,7 @@
           position: absolute;
           top: 10px;
         }
+
         &.collapsed {
           &:before {
             content: "\f105";
@@ -366,25 +416,32 @@
 .wizard-pf-review-content {
   padding-top: 10px;
   padding-left: 40px;
+
   .wizard-pf-review-item {
     padding: 5px 0;
+
     &.sub-item {
       margin-left: 10px;
     }
+
     .wizard-pf-review-item-label {
       font-weight: 700;
       padding-right: 10px;
     }
+
     .wizard-pf-review-item-field {
       font-weight: 700;
       margin: 5px 0;
       padding-right: 10px;
+
       &:first-of-type {
         margin-top: 0;
       }
+
       &:last-of-type {
         margin-bottom: 0;
       }
+
       &.sub-field {
         margin-left: 10px;
       }
@@ -425,6 +482,7 @@
     padding: 30px 0;
     width: 900px;
   }
+
   // increasing width of sidebar for larger viewports
   .wizard-pf-sidebar .list-group-item > a {
     width: 18em;
@@ -443,14 +501,15 @@
 }
 
 .wizard-pf-steps-alt {
-  margin-left: 15px;
-  margin-top: 15px;
-  background-image: linear-gradient(to right, transparent 11px, $color-pf-black-300 11px, $color-pf-black-300 13px, transparent 13px);
+  margin: 15px 0 15px 15px;
+  
   @media (min-width: $screen-sm-min) {
     display:none;
   }
+
   &-indicator {
     position: relative;
+
     // caret to top showing active substep
     &:after {
       color: $color-pf-black-700;
@@ -463,10 +522,12 @@
       right: 17px;
       top: 50%;
       transform:translateY(-50%);
+
       @media (min-width: $screen-sm-min) {
         display:none;
       }
     }
+
     &.active {
       &:after {
         content: "\f106";
@@ -476,26 +537,50 @@
 }//.wizard-pf-steps-alt
 
 .wizard-pf-step-alt {
-  margin-bottom: 10px;
+  position: relative;
+  z-index: 1;
+
+  &:not(:last-child) {
+    padding-bottom: 10px;
+  }
+
   a {
     display:flex;
     flex:1;
+
     &:hover {
       text-decoration: none;
+
       .wizard-pf-step-alt-title {
         color: $color-pf-blue-300;
       }
     }
   }
+
   ul {
     margin-left: 11px;
   }
+
+  .wizard-pf-step-alt-number {
+    border-radius: 50%;
+    font-size: $font-size-base;
+    font-weight: 700;
+    height: 24px;
+    width: 24px;
+    display: inline-block;
+    text-align: center;
+    flex:0 0 auto;
+    border: 2px solid $color-pf-blue-300;
+    background-color: $color-pf-white;
+  }
+  
   .wizard-pf-step-alt-title {
+    color: $color-pf-black;
+    font-weight: 700;
+    text-transform: capitalize;
+    display:inline-block;
     margin-left: 5px;
     align-self:center;
-  }
-  .wizard-pf-step-alt-number {
-    flex:0 0 auto;
   }
 
   &.active {
@@ -505,70 +590,69 @@
       cursor: default;
       color: $color-pf-white;
     }
+
     .wizard-pf-step-alt-title {
       color: $color-pf-blue-300;
     }
-    .wizard-pf-step-alt-substep:first-of-type {
-      margin-top: 2px; // gives proper spacing below number in circle active state
-    }
 
-
-  }
-  &.viewed {
-    .wizard-pf-step-alt-number {
-      color: $color-pf-black;
-      background-color: $color-pf-white;
-      border-color: $color-pf-blue-300;
+    & ~ .wizard-pf-step-alt {
+      .wizard-pf-step-alt-number {
+        color: $color-pf-black-400;
+        border-color: $color-pf-black-400;
+      }
     }
   }
 
+  &:not(.active) {
+    a:hover {
+      .wizard-pf-step-alt-number {
+        border-color: $color-pf-black-400;
+        background: $color-pf-black-400;
+        color: $color-pf-white;
+      }
+    }
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 11px;
+    height: 100%;
+    border-left: 2px solid $color-pf-black-400;
+    z-index: -1;
+  }
 }//.wizard-pf-step-alt
 
-.wizard-pf-step-alt-number {
-  background-color: $color-pf-white;
-  border-radius: 50%;
-  border: solid 2px $color-pf-black-400;
-  color: $color-pf-black-400;
-  font-size: $font-size-base;
-  font-weight: 700;
-  height: 24px;
-  width: 24px;
-  display: inline-block;
-  text-align: center;
-}
-
-
-.wizard-pf-step-alt-title {
-  color: $color-pf-black;
-  font-weight: 700;
-  text-transform: capitalize;
-  display:inline-block;
-
-}//.wizard-pf-steps-alt-title
-
 .wizard-pf-step-alt-substep {
-    display:flex;
+  display: flex;
+  border-left: 2px solid transparent;
+
   a {
     padding:5px 0 5px 18px;
     color: $color-pf-black-800;
   }
 
-&:not(.disabled) {
-  &.active, &:hover {
-    background-color: $color-pf-black-200;
-    background-image: linear-gradient(to right, $color-pf-blue-300 2px, transparent 2px);
-    a {
-      color:$color-pf-blue-300;
+  &:not(.disabled) {
+    &.active,
+    &:hover {
+      background-color: $color-pf-black-200;
+      border-color: $color-pf-blue-300;
+      
+      a {
+        color:$color-pf-blue-300;
+      }
     }
   }
-}
+
   &.active {
     a {
       font-weight:700;
     }
   }
+
   &.disabled {
     cursor: not-allowed;
+    
     a {
       pointer-events: none;
     }

--- a/tests/pages/_includes/widgets/communication/wizard.html
+++ b/tests/pages/_includes/widgets/communication/wizard.html
@@ -39,7 +39,7 @@
           </ul>
 
           <ul class="wizard-pf-steps-alt">
-            <li class="wizard-pf-step-alt viewed">
+            <li class="wizard-pf-step-alt">
               <a href="#">
                 <span class="wizard-pf-step-alt-number">1</span>
                 <span class="wizard-pf-step-alt-title">First Step</span>
@@ -435,7 +435,9 @@
       $(self.modal + " .wizard-pf-step[data-tabgroup='" + self.currentGroup + "']").addClass("active");
       $(self.modal + " .wizard-pf-sidebar .list-group").addClass("hidden");
       $(self.modal + " .list-group[data-tabgroup='" + self.currentGroup + "']").removeClass("hidden");
-      $(self.modal + " .wizard-pf-step-alt[data-tabgroup='" + self.currentGroup + "']").addClass("viewed");
+      $(self.modal + " .wizard-pf-step-alt")
+        .not("[data-tabgroup='" + self.currentGroup + "']").removeClass("active").end()
+        .filter("[data-tabgroup='" + self.currentGroup + "']").addClass("active");
       $(self.modal + " .wizard-pf-step-alt > ul").addClass("hidden");
       $(self.modal + " .wizard-pf-step-alt[data-tabgroup='" + self.currentGroup + "'] > ul").removeClass("hidden");
     };
@@ -590,7 +592,7 @@
     };
 
     this.detailsNameChange = function() {
-      $(self.modal + " #detailsName").on('change', function() {
+      $(self.modal + " #detailsName").on('keyup change', function() {
         if ($(self.modal + " #detailsName").val()) {
           $(self.modal + " .wizard-pf-step-alt-substep").removeClass('disabled');
           $(self.modal + " .wizard-pf-next").removeClass("disabled");


### PR DESCRIPTION
fix #1044

## Description
better align wizard ui to design spec.

## Changes
1. add completed step css
1. disable active hover state
1. fix mobile active step css
1. align grey and blue lines between steps in mobile
1. fix disappearing grey line between steps on mobile
1. add `keyup` event listener for required fields instead of relying on `change`

## Link to rawgit and/or image
[will add]

--------

For some reason, I couldn't add this long description to the commit, and got a `footer must have leading blank line` error from commitizen

```
? Select the type of change that you're committing: fix:      A bug fix
? What is the scope of this change (e.g. component or file name)? (press enter to skip)
 wizard
? Write a short, imperative tense description of the change:
 better align ui to design spec
? Provide a longer description of the change: (press enter to skip)
 add completed step css, disable active hover state, fix mobile active step css, align grey and blue lines between steps in mobile, fix disappearing grey line between steps on mobile
? Are there any breaking changes? No
? Does this change affect any open issues? Yes
? Add issue references (e.g. "fix #123", "re #123".):
 fix #1044
husky > npm run -s commitmsg (node v10.0.0)

⧗   input: fix(wizard): better align ui to design spec
✖   footer must have leading blank line [footer-leading-blank]
⚠   tense of body must be present-imperative. Verbs in other tenses: disappearing - present-participle [body-tense]
⚠   commit must be in language "eng", was one of: nob, dan, por, nds, glg [lang]
✖   found 1 problems, 2 warnings
```