### PR TITLE
fix(inline-edit): modify combobox selector for inline edit for form

### DIFF
--- a/tests/pages/_includes/widgets/forms/inline-edit-for-form.html
+++ b/tests/pages/_includes/widgets/forms/inline-edit-for-form.html
@@ -129,7 +129,7 @@
 <script type="text/javascript">
   $(function() {
 
-    $('.combobox').combobox();
+    $('select.combobox').combobox();
 
     $('.bootstrap-datepicker').datepicker({
       autoclose: true,


### PR DESCRIPTION
## Description
This PR is to modify the selector class used in the inline edit for form. When trying to to consume this example for patternfly-org, the department field is broken (images shown in the PR link below). This fixes that issue.

Related to this PR: https://github.com/patternfly/patternfly-org/pull/558

## Changes
* `$('combobox').combobox();` is now `$('select.combobox').combobox();`

## Link to rawgit and/or image

https://rawgit.com/amarie401/patternfly/combobox-dist/dist/tests/inline-edit-for-form.html


