### PR TITLE
fix(patternfly-settings.js): Make compatible with NodeJS environment

### DIFF
--- a/src/js/patternfly-settings-base.js
+++ b/src/js/patternfly-settings-base.js
@@ -13,4 +13,4 @@
 
   window.patternfly = patternfly;
 
-})(window);
+})(typeof window !== 'undefined' ? window : global);

--- a/src/js/patternfly-settings-charts.js
+++ b/src/js/patternfly-settings-charts.js
@@ -1,6 +1,9 @@
 (function (window) {
   'use strict';
 
+  // Ensure we are assigning these to the patternfly property of the window argument, and not the implicit global patternfly
+  var patternfly = window.patternfly;
+
   // Util: PatternFly C3 Chart Defaults
   patternfly.pfSetDonutChartTitle = function (selector, primary, secondary) {
     var donutChartRightTitle = window.d3.select(selector).select('text.c3-chart-arcs-title');
@@ -443,4 +446,4 @@
       getDefaultSingleAreaConfig: getDefaultSingleAreaConfig
     };
   };
-})(window);
+})(typeof window !== 'undefined' ? window : global);

--- a/src/js/patternfly-settings-colors.js
+++ b/src/js/patternfly-settings-colors.js
@@ -1,6 +1,9 @@
 (function (window) {
   'use strict';
 
+  // Ensure we are assigning these to the patternfly property of the window argument, and not the implicit global patternfly
+  var patternfly = window.patternfly;
+
   // Util: PatternFly Palette colors
   patternfly.pfPaletteColors = {
     black:         '#030303',
@@ -84,5 +87,5 @@
     red400:        '#470000',
     red500:        '#2c0000'
   };
-})(window);
+})(typeof window !== 'undefined' ? window : global);
 


### PR DESCRIPTION
## Description
Don't reference `window` when it isn't present, use `global` instead. This change makes this repo
compatible with being imported in a NodeJS script, which I want to use for some snapshot testing
experiments.

## Changes

Write a list of changes the PR introduces

* In the three files which compile down to patternfly-settings.js, I used a ternary expression in the self-executing function expressions, where there was `(window)` it now passes `(typeof window !== 'undefined' ? window : global).
* In the top of each of those same closures, I added `const patternfly = window.patternfly` to make sure the passed-in window argument was actually being used, in all the following `patternfly.*` assignments (so far this just happens to work because in a browser `patternfly` is an alias for `window.patternfly`).

## Link to rawgit and/or image

I don't really have a link, but I can show that my build is still passing.