### PR TITLE
fix(notification drawer): bring notification drawer pages inline with masthead design

### DIFF
--- a/src/less/application-launcher.less
+++ b/src/less/application-launcher.less
@@ -173,7 +173,6 @@
               
               @media (min-width: @screen-sm-min) {
                 padding: 0;
-                display: block;
               }
             }
 

--- a/src/less/navbar-vertical.less
+++ b/src/less/navbar-vertical.less
@@ -102,6 +102,7 @@
       &:focus {
         background: @navbar-pf-item-open-bg-color;
         color: @navbar-pf-item-active-color;
+        outline: 0;
 
         .caret,
         .fa,

--- a/src/less/navbar.less
+++ b/src/less/navbar.less
@@ -300,6 +300,9 @@
           outline: 0!important;
         }
         position: relative;
+        > .fa {
+          line-height: 0;
+        }
       }
     }
     @media (max-width: @grid-float-breakpoint-max) {

--- a/src/less/navbar.less
+++ b/src/less/navbar.less
@@ -69,6 +69,7 @@
         &:focus {
           background-color: @navbar-pf-item-open-bg-color;
           color: @navbar-pf-active-color;
+          outline: 0;
         }
       }
     }

--- a/src/less/notifications-drawer.less
+++ b/src/less/notifications-drawer.less
@@ -239,10 +239,11 @@
   .drawer-pf {
     height: ~"calc(100vh - @{drawer-pf-top-horizontal} - 20px)";
     top: @drawer-pf-top-horizontal;
+    border-top: 0;
     @media (max-width: @screen-xs-max) {
       width:100%;
       height: calc(~"100vh - @{drawer-pf-top-horizontal} - 32px");
-      top:calc(~"@{drawer-pf-top-horizontal} + 8px");
+      top:calc(~"@{drawer-pf-top-horizontal} + 10px");
     }
   }
   .drawer-pf-trigger-icon { cursor: pointer; }

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -56,7 +56,7 @@
 @contextselector-pf-list-li-border-width:                           1px 0;
 @donut-font-size-big:                                               30px;
 @drawer-pf-top-vertical:                                            58px;
-@drawer-pf-top-horizontal:                                          26px;
+@drawer-pf-top-horizontal:                                          25px;
 @dropdown-divider-margin:                                           4px 1px;
 @dropdown-link-active-border-color:                                 @color-pf-blue;
 @dropdown-link-hover-border-color:                                  @color-pf-blue-100;

--- a/src/sass/converted/patternfly/_navbar-vertical.scss
+++ b/src/sass/converted/patternfly/_navbar-vertical.scss
@@ -102,6 +102,7 @@
       &:focus {
         background: $navbar-pf-item-open-bg-color;
         color: $navbar-pf-item-active-color;
+        outline: 0;
 
         .caret,
         .fa,

--- a/src/sass/converted/patternfly/_navbar.scss
+++ b/src/sass/converted/patternfly/_navbar.scss
@@ -300,6 +300,9 @@
           outline: 0!important;
         }
         position: relative;
+        > .fa {
+          line-height: 0;
+        }
       }
     }
     @media (max-width: $grid-float-breakpoint-max) {

--- a/src/sass/converted/patternfly/_navbar.scss
+++ b/src/sass/converted/patternfly/_navbar.scss
@@ -69,6 +69,7 @@
         &:focus {
           background-color: $navbar-pf-item-open-bg-color;
           color: $navbar-pf-active-color;
+          outline: 0;
         }
       }
     }

--- a/src/sass/converted/patternfly/_notifications-drawer.scss
+++ b/src/sass/converted/patternfly/_notifications-drawer.scss
@@ -239,10 +239,11 @@
   .drawer-pf {
     height: unquote("calc(100vh - #{$drawer-pf-top-horizontal} - 20px)");
     top: $drawer-pf-top-horizontal;
+    border-top: 0;
     @media (max-width: $screen-xs-max) {
       width:100%;
       height: calc(unquote("100vh - #{$drawer-pf-top-horizontal} - 32px"));
-      top:calc(unquote("#{$drawer-pf-top-horizontal} + 8px"));
+      top:calc(unquote("#{$drawer-pf-top-horizontal} + 10px"));
     }
   }
   .drawer-pf-trigger-icon { cursor: pointer; }

--- a/src/sass/converted/patternfly/_variables.scss
+++ b/src/sass/converted/patternfly/_variables.scss
@@ -56,7 +56,7 @@ $contextselector-pf-list-li-padding:                                1px 10px !de
 $contextselector-pf-list-li-border-width:                           1px 0 !default;
 $donut-font-size-big:                                               30px !default;
 $drawer-pf-top-vertical:                                            58px !default;
-$drawer-pf-top-horizontal:                                          26px !default;
+$drawer-pf-top-horizontal:                                          25px !default;
 $dropdown-divider-margin:                                           4px 1px !default;
 $dropdown-link-active-border-color:                                 $color-pf-blue !default;
 $dropdown-link-hover-border-color:                                  $color-pf-blue-100 !default;

--- a/src/sass/converted/rcue/_navbar-vertical.scss
+++ b/src/sass/converted/rcue/_navbar-vertical.scss
@@ -102,6 +102,7 @@
       &:focus {
         background: $navbar-pf-item-open-bg-color;
         color: $navbar-pf-item-active-color;
+        outline: 0;
 
         .caret,
         .fa,

--- a/src/sass/converted/rcue/_navbar.scss
+++ b/src/sass/converted/rcue/_navbar.scss
@@ -300,6 +300,9 @@
           outline: 0!important;
         }
         position: relative;
+        > .fa {
+          line-height: 0;
+        }
       }
     }
     @media (max-width: $grid-float-breakpoint-max) {

--- a/src/sass/converted/rcue/_navbar.scss
+++ b/src/sass/converted/rcue/_navbar.scss
@@ -69,6 +69,7 @@
         &:focus {
           background-color: $navbar-pf-item-open-bg-color;
           color: $navbar-pf-active-color;
+          outline: 0;
         }
       }
     }

--- a/src/sass/converted/rcue/_notifications-drawer.scss
+++ b/src/sass/converted/rcue/_notifications-drawer.scss
@@ -239,10 +239,11 @@
   .drawer-pf {
     height: unquote("calc(100vh - #{$drawer-pf-top-horizontal} - 20px)");
     top: $drawer-pf-top-horizontal;
+    border-top: 0;
     @media (max-width: $screen-xs-max) {
       width:100%;
       height: calc(unquote("100vh - #{$drawer-pf-top-horizontal} - 32px"));
-      top:calc(unquote("#{$drawer-pf-top-horizontal} + 8px"));
+      top:calc(unquote("#{$drawer-pf-top-horizontal} + 10px"));
     }
   }
   .drawer-pf-trigger-icon { cursor: pointer; }

--- a/src/sass/converted/rcue/_variables.scss
+++ b/src/sass/converted/rcue/_variables.scss
@@ -56,7 +56,7 @@ $contextselector-pf-list-li-padding:                                1px 10px !de
 $contextselector-pf-list-li-border-width:                           1px 0 !default;
 $donut-font-size-big:                                               30px !default;
 $drawer-pf-top-vertical:                                            58px !default;
-$drawer-pf-top-horizontal:                                          26px !default;
+$drawer-pf-top-horizontal:                                          25px !default;
 $dropdown-divider-margin:                                           4px 1px !default;
 $dropdown-link-active-border-color:                                 $color-pf-blue !default;
 $dropdown-link-hover-border-color:                                  $color-pf-blue-100 !default;

--- a/tests/pages/_includes/widgets/layouts/nav-horizontal-notification-drawer.html
+++ b/tests/pages/_includes/widgets/layouts/nav-horizontal-notification-drawer.html
@@ -13,26 +13,27 @@
   <div class="collapse navbar-collapse navbar-collapse-1">
     <ul class="nav navbar-nav navbar-utility">
       <li class="drawer-pf-trigger dropdown">
-        <a href="#0" class="nav-item-iconic drawer-pf-trigger-icon">
-          <span class="fa fa-bell" title="Notifications"></span>
+        <button class="btn btn-link nav-item-iconic drawer-pf-trigger-icon">
+          <span class="fa fa-bell dropdown-title" title="Notifications"></span>
           <span class="badge badge-pf-bordered"> </span><!-- in order to show the empty badge this requires a space, otherwise add a value -->
-        </a>
+        </button>
       </li>
       <li class="dropdown">
-        <a href="#0" class="nav-item-iconic" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-          <span title="Help" class="fa pficon-help"></span>
-          <span class="caret"></span>
-        </a>
+        <button class="btn btn-link nav-item-iconic" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+          <span title="Help" class="fa pficon-help dropdown-title"></span>
+        </button>
         <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
           <li><a href="#0">Help</a></li>
           <li><a href="#0">About</a></li>
         </ul>
       </li>
       <li class="dropdown">
-        <a href="#0" class="dropdown-toggle" data-toggle="dropdown">
-          <span class="pficon pficon-user"></span>
-          Brian Johnson <b class="caret"></b>
-        </a>
+        <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+          <span title="Username" class="fa pficon-user"></span>
+          <span class="dropdown-title">
+            Brian Johnson <span class="caret"></span>
+          </span>
+        </button>
         <ul class="dropdown-menu">
           <li>
             <a href="#0">Link</a>

--- a/tests/pages/_includes/widgets/layouts/nav-vertical-notification-drawer.html
+++ b/tests/pages/_includes/widgets/layouts/nav-vertical-notification-drawer.html
@@ -11,10 +11,10 @@
     </a>
     <ul class="nav pull-right visible-xs-block navbar-iconic">
       <li class="drawer-pf-trigger">
-        <a href="#0" class="nav-item-iconic">
+        <button class="btn btn-link nav-item-iconic">
           <span class="fa fa-bell" title="Notifications"></span>
           <span class="badge badge-pf-bordered"> </span><!-- in order to show the empty badge this requires a space, otherwise add a value -->
-        </a>
+        </button>
       </li>
     </ul>
     {% if page.contextselector %}
@@ -27,26 +27,27 @@
     </ul>
     <ul class="nav navbar-nav navbar-right navbar-iconic">
       <li class="drawer-pf-trigger">
-        <a href="#0" class="nav-item-iconic">
+        <button class="btn btn-link nav-item-iconic">
           <span class="fa fa-bell" title="Notifications"></span>
           <span class="badge badge-pf-bordered"> </span><!-- in order to show the empty badge this requires a space, otherwise add a value -->
-        </a>
+        </button>
       </li>
       <li class="dropdown">
-        <a href="#0" class="dropdown-toggle nav-item-iconic" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+        <button class="btn btn-link dropdown-toggle nav-item-iconic" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
           <span title="Help" class="fa pficon-help"></span>
-          <span class="caret"></span>
-        </a>
+        </button>
         <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
           <li><a href="#0">Help</a></li>
           <li><a href="#0">About</a></li>
         </ul>
       </li>
       <li class="dropdown">
-        <a href="#0" class="dropdown-toggle nav-item-iconic" id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+        <button class="btn btn-link dropdown-toggle nav-item-iconic" id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
           <span title="Username" class="fa pficon-user"></span>
-          Brian Johnson <span class="caret"></span>
-        </a>
+          <span class="dropdown-title">
+            Brian Johnson <span class="caret"></span>
+          </span>
+        </button>
         <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
           <li><a href="#0">Preferences</a></li>
           <li><a href="#0">Logout</a></li>


### PR DESCRIPTION
fix #1030

## Description
Update notification examples with new masthead design

## Changes

From #1030 

* For Horizontal Nav -- remove the down caret "v" from the Help menu
* For Vertical Nav -- remove the down caret from the Help menu and update styling of all utility items to display a selected state when the menu is open.

## Link to rawgit and/or image

https://rawgit.com/michael-coker/patternfly/update-notification-masthead-dist/dist/tests/notification-drawer-horizontal-nav.html

https://rawgit.com/michael-coker/patternfly/update-notification-masthead-dist/dist/tests/notification-drawer-vertical-nav.html

## PR checklist (if relevant)

- [x] **Cross browser**: works in IE9
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [x] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.