### PR TITLE
Update Navigation Examples to reflect the lastest Masthead styling

### DIFF
--- a/src/less/context-selector.less
+++ b/src/less/context-selector.less
@@ -48,6 +48,7 @@
       }
       .filter-option {
         text-overflow: ellipsis;
+        position: relative;
       }
     }
     .dropdown-menu li a span.text {

--- a/src/less/navbar.less
+++ b/src/less/navbar.less
@@ -301,7 +301,8 @@
           outline: 0!important;
         }
         position: relative;
-        > .fa {
+        > .fa,
+        .pficon {
           line-height: 0;
         }
       }

--- a/src/sass/converted/patternfly/_context-selector.scss
+++ b/src/sass/converted/patternfly/_context-selector.scss
@@ -48,6 +48,7 @@
       }
       .filter-option {
         text-overflow: ellipsis;
+        position: relative;
       }
     }
     .dropdown-menu li a span.text {

--- a/src/sass/converted/patternfly/_navbar.scss
+++ b/src/sass/converted/patternfly/_navbar.scss
@@ -301,7 +301,8 @@
           outline: 0!important;
         }
         position: relative;
-        > .fa {
+        > .fa,
+        .pficon {
           line-height: 0;
         }
       }

--- a/src/sass/converted/rcue/_context-selector.scss
+++ b/src/sass/converted/rcue/_context-selector.scss
@@ -48,6 +48,7 @@
       }
       .filter-option {
         text-overflow: ellipsis;
+        position: relative;
       }
     }
     .dropdown-menu li a span.text {

--- a/src/sass/converted/rcue/_navbar.scss
+++ b/src/sass/converted/rcue/_navbar.scss
@@ -301,7 +301,8 @@
           outline: 0!important;
         }
         position: relative;
-        > .fa {
+        > .fa,
+        .pficon {
           line-height: 0;
         }
       }

--- a/tests/pages/_includes/widgets/layouts/navbar-primary.html
+++ b/tests/pages/_includes/widgets/layouts/navbar-primary.html
@@ -69,11 +69,9 @@
             </ul>
           </li>
         </ul>
+        <ul class="nav navbar-nav navbar-primary">
         {% for node in site.weighted_pages %}
           {% if node.categories contains 'Layouts' and node.weight %}
-            {% if forloop.first %}
-              <ul class="nav navbar-nav navbar-primary">
-            {% endif %}
             {% if page.url == node.url %}
             <li class="active">
               <a href="{{ node.url| remove_first:'/' }}" class="active">{{ node.title }}</a>
@@ -83,10 +81,8 @@
               <a href="{{ node.url | remove_first:'/' }}">{{ node.title }}</a>
             </li>
             {% endif %}
-            {% if forloop.last %}
-              </ul>
-            {% endif %}
           {% endif %}
         {% endfor %}
+        </ul>
       </div>
     </nav>{% endstrip %}

--- a/tests/pages/_includes/widgets/layouts/navbar-primary.html
+++ b/tests/pages/_includes/widgets/layouts/navbar-primary.html
@@ -13,20 +13,21 @@
       <div class="collapse navbar-collapse navbar-collapse-1">
         <ul class="nav navbar-nav navbar-utility">
           <li class="dropdown">
-            <a href="#0" class="nav-item-iconic" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-              <span title="Help" class="fa pficon-help"></span>
-              <span class="caret"></span>
-            </a>
+            <button class="btn btn-link nav-item-iconic" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+              <span title="Help" class="fa pficon-help dropdown-title"></span>
+            </button>
             <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
               <li><a href="#0">Help</a></li>
               <li><a href="#0">About</a></li>
             </ul>
           </li>
           <li class="dropdown">
-            <a href="#0" class="dropdown-toggle" data-toggle="dropdown">
+            <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
               <span class="pficon pficon-user"></span>
-              Brian Johnson <b class="caret"></b>
-            </a>
+              <span class="dropdown-title">
+                Brian Johnson <b class="caret"></b>
+              </span>
+            </button>
             <ul class="dropdown-menu">
               <li>
                 <a href="#0">Link</a>
@@ -68,20 +69,24 @@
             </ul>
           </li>
         </ul>
-        <ul class="nav navbar-nav navbar-primary">
-          {% for node in site.weighted_pages %}
+        {% for node in site.weighted_pages %}
           {% if node.categories contains 'Layouts' and node.weight %}
-          {% if page.url == node.url %}
-          <li class="active">
-            <a href="{{ node.url| remove_first:'/' }}" class="active">{{ node.title }}</a>
-          </li>
-          {% else %}
-          <li>
-            <a href="{{ node.url | remove_first:'/' }}">{{ node.title }}</a>
-          </li>
+            {% if forloop.first %}
+              <ul class="nav navbar-nav navbar-primary">
+            {% endif %}
+            {% if page.url == node.url %}
+            <li class="active">
+              <a href="{{ node.url| remove_first:'/' }}" class="active">{{ node.title }}</a>
+            </li>
+            {% else %}
+            <li>
+              <a href="{{ node.url | remove_first:'/' }}">{{ node.title }}</a>
+            </li>
+            {% endif %}
+            {% if forloop.last %}
+              </ul>
+            {% endif %}
           {% endif %}
-          {% endif %}
-          {% endfor %}
-        </ul>
+        {% endfor %}
       </div>
     </nav>{% endstrip %}

--- a/tests/pages/_includes/widgets/navigation/horizontal-multi-level.html
+++ b/tests/pages/_includes/widgets/navigation/horizontal-multi-level.html
@@ -13,21 +13,22 @@
   <div class="collapse navbar-collapse navbar-collapse-5">
     <ul class="nav navbar-nav navbar-utility">
       <li class="dropdown">
-        <a href="#0" class="nav-item-iconic" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-          <span title="Help" class="fa pficon-help"></span>
-          <span class="caret"></span>
-        </a>
+        <button class="btn btn-link nav-item-iconic" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+          <span title="Help" class="fa pficon-help dropdown-title"></span>
+        </button>
         <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
           <li><a href="#0">Help</a></li>
           <li><a href="#0">About</a></li>
         </ul>
       </li>
       <li class="dropdown">
-        <a href="#0" class="dropdown-toggle" data-toggle="dropdown">
+        <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
           <span class="pficon pficon-user"></span>
-          Brian Johnson
-          <b class="caret"></b>
-        </a>
+          <span class="dropdown-title">
+            Brian Johnson
+            <b class="caret"></b>
+          </span>
+        </button>
         <ul class="dropdown-menu">
           <li>
             <a href="#0">Link</a>

--- a/tests/pages/_includes/widgets/navigation/horizontal-persistent-secondary-tertiary.html
+++ b/tests/pages/_includes/widgets/navigation/horizontal-persistent-secondary-tertiary.html
@@ -13,21 +13,22 @@
   <div class="collapse navbar-collapse navbar-collapse-11">
     <ul class="nav navbar-nav navbar-utility">
       <li class="dropdown">
-        <a href="#0" class="nav-item-iconic" id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-          <span title="Help" class="fa pficon-help"></span>
-          <span class="caret"></span>
-        </a>
+        <button class="btn btn-link nav-item-iconic" id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+          <span title="Help" class="fa pficon-help dropdown-title"></span>
+        </button>
         <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
           <li><a href="#0">Help</a></li>
           <li><a href="#0">About</a></li>
         </ul>
       </li>
       <li class="dropdown">
-        <a href="#0" class="dropdown-toggle" data-toggle="dropdown">
+        <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
           <span class="pficon pficon-user"></span>
-          Brian Johnson
-          <b class="caret"></b>
-        </a>
+          <span class="dropdown-title">
+            Brian Johnson
+            <b class="caret"></b>
+          </span>
+         </button>
         <ul class="dropdown-menu">
           <li>
             <a href="#0">Link</a>

--- a/tests/pages/navbar.html
+++ b/tests/pages/navbar.html
@@ -22,20 +22,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-1">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu3" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu3" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu3">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" id="navbar-utility-menu" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" id="navbar-utility-menu" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -115,20 +116,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-1">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu4" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu4" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu4">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -210,21 +212,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-3">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu5" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu5" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu5">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -318,21 +320,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-3">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu6">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -427,21 +429,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-5">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu7" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu7" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu7">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -674,21 +676,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-5">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu8" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu8" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu8">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -922,21 +924,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-8">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu9" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu9" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu9">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -1181,21 +1183,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-8">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu10">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -1440,21 +1442,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-8">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu11" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu11" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu11">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -1702,21 +1704,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-11">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu12" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu12" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu12">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -1867,21 +1869,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-11">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu13" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu13" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu13">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -2034,21 +2036,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-11">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu14">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -2199,21 +2201,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-11">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu15" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu15" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu15">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -2367,21 +2369,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-16">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu16" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu16" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu16">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -2546,21 +2548,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-16">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu17" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu17" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu17">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -2725,21 +2727,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-16">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu18">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -2904,21 +2906,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-16">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu19" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu19" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu19">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -3083,21 +3085,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-16">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu20" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu20" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu20">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -3265,21 +3267,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-21">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu21" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu21" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu21">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -3444,21 +3446,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-21">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu22" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu22" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu22">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -3689,21 +3691,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-21">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu23" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu23" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu23">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -3934,21 +3936,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-21">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu24" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
-              <ul class="dropdown-menu" aria-labelledby="dropdownMen24">
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu24" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
+              <ul class="dropdown-menu" aria-labelledby="dropdownMenu24">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>
@@ -4179,21 +4181,21 @@ url-js-extra: 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js
         <div class="collapse navbar-collapse navbar-collapse-21">
           <ul class="nav navbar-nav navbar-utility">
             <li class="dropdown">
-              <a class="nav-item-iconic" id="dropdownMenu25" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span title="Help" class="fa pficon-help"></span>
-                <span class="caret"></span>
-              </a>
+              <button class="btn btn-link nav-item-iconic" id="dropdownMenu25" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span title="Help" class="fa pficon-help dropdown-title"></span>
+              </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu25">
                 <li><a href="#">Help</a></li>
                 <li><a href="#">About</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                <span class="pficon pficon-user"></span>
-                Brian Johnson
-                <b class="caret"></b>
-              </a>
+              <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                <span class="fa pficon-user"></span>
+                <span class="dropdown-title">
+                  Brian Johnson <span class="caret"></span>
+                </span>
+              </button>
               <ul class="dropdown-menu">
                 <li>
                   <a href="#">Link</a>


### PR DESCRIPTION
## Description
Fixes #1032.

> All navigation examples should be updated to reflect the latest Mastehead styling found here: http://www.patternfly.org/pattern-library/application-framework/masthead/#design

## Changes

* For horizontal navigation -- remove the down caret "v" from the Help menu.
* For vertical navigation -- remove the down caret "v" from the Help menu and also update the styling of all items to display a selected state when the menu is open.

## Link to rawgit and/or image

https://rawgit.com/michael-coker/patternfly/update-navigation-masthead-dist/dist/tests/

## PR checklist (if relevant)

- [x] **Cross browser**: works in IE9
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [x] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [x] **Cross browser**: works in Safari
- [x] **Cross browser**: works in Opera
- [x] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
