### PR TITLE
fix(app launcher): update role attributes for list items and links

### DIFF
--- a/tests/pages/_includes/widgets/framework/application-launcher.html
+++ b/tests/pages/_includes/widgets/framework/application-launcher.html
@@ -9,24 +9,24 @@
     </span>
   </button>
   <ul class="dropdown-menu" role="menu">
-    <li class="applauncher-pf-item" role="menuitem">
-      <a class="applauncher-pf-link" href="#">
+    <li class="applauncher-pf-item" role="presentation">
+      <a class="applauncher-pf-link" href="#" role="menuitem">
         {% if include.icons %}
         <i class="applauncher-pf-link-icon pficon pficon-storage-domain" aria-hidden="true"></i>
         {% endif %}
         <span class="applauncher-pf-link-title">Recteque</span>
       </a>
     </li>
-    <li class="applauncher-pf-item" role="menuitem">
-      <a class="applauncher-pf-link" href="#">
+    <li class="applauncher-pf-item" role="presentation">
+      <a class="applauncher-pf-link" href="#" role="menuitem">
         {% if include.icons %}
         <i class="applauncher-pf-link-icon pficon pficon-virtual-machine" aria-hidden="true"></i>
         {% endif %}
         <span class="applauncher-pf-link-title">Ipsum</span>
       </a>
     </li>
-    <li class="applauncher-pf-item" role="menuitem">
-      <a class="applauncher-pf-link" href="#">
+    <li class="applauncher-pf-item" role="presentation">
+      <a class="applauncher-pf-link" href="#" role="menuitem">
         {% if include.icons %}
         <!-- Placeholder left to maintain spacing -->
         <i class="applauncher-pf-link-icon" aria-hidden="true"></i>
@@ -34,16 +34,16 @@
         <span class="applauncher-pf-link-title">Suavitate</span>
       </a>
     </li>
-    <li class="applauncher-pf-item" role="menuitem">
-      <a class="applauncher-pf-link" href="#">
+    <li class="applauncher-pf-item" role="presentation">
+      <a class="applauncher-pf-link" href="#" role="menuitem">
         {% if include.icons %}
         <i class="applauncher-pf-link-icon pficon pficon-domain" aria-hidden="true"></i>
         {% endif %}
         <span class="applauncher-pf-link-title">Lorem</span>
       </a>
     </li>
-    <li class="applauncher-pf-item" role="menuitem">
-      <a class="applauncher-pf-link" href="#">
+    <li class="applauncher-pf-item" role="presentation">
+      <a class="applauncher-pf-link" href="#" role="menuitem">
         {% if include.icons %}
         <i class="applauncher-pf-link-icon pficon pficon-home" aria-hidden="true"></i>
         {% endif %}


### PR DESCRIPTION
fix #1063

## Description

The roles currently applied to the menu in the [app launcher](https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/application-launcher.html) are incorrect. 

## Changes

* `<li>` now has `role=“presentation”` 
* `<a>` now has `role=“menuitem”`

## Link to rawgit and/or image

https://rawgit.com/michael-coker/patternfly/app-launcher-role-attrs-dist/dist/tests/

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [ ] **Cross browser**: works in Firefox
- [ ] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [ ] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
