### PR TITLE
feat(vertical-navigation): Support custom hoverDelay and hideDelay

### DIFF
--- a/src/js/patternfly-functions-vertical-nav.js
+++ b/src/js/patternfly-functions-vertical-nav.js
@@ -3,16 +3,19 @@
 (function ($) {
   'use strict';
 
-  $.fn.setupVerticalNavigation = function (handleItemSelections, ignoreDrawer) {
+  $.fn.setupVerticalNavigation = function (handleItemSelections, ignoreDrawer, userOptions) {
 
-    var navElement = $('.nav-pf-vertical'),
+    var options = $.extend({
+        hoverDelay: 500,
+        hideDelay: 700,
+      }, userOptions || {}),
+
+      navElement = $('.nav-pf-vertical'),
       bodyContentElement = $('.container-pf-nav-pf-vertical'),
       toggleNavBarButton = $('.navbar-toggle'),
       handleResize = true,
       explicitCollapse = false,
       subDesktop = false,
-      hoverDelay = 500,
-      hideDelay = hoverDelay + 200,
 
       inMobileState = function () {
         return bodyContentElement.hasClass('hidden-nav');
@@ -447,7 +450,7 @@
                 navElement.addClass('hover-secondary-nav-pf');
                 $this.addClass('is-hover');
                 $this[0].navHoverTimeout = undefined;
-              }, hoverDelay);
+              }, options.hoverDelay);
             }
           }
         });
@@ -465,7 +468,7 @@
               }
               $this.removeClass('is-hover');
               $this[0].navUnHoverTimeout = undefined;
-            }, hideDelay);
+            }, options.hideDelay);
           }
         });
 
@@ -481,7 +484,7 @@
                 navElement.addClass('hover-tertiary-nav-pf');
                 $this.addClass('is-hover');
                 $this[0].navHoverTimeout = undefined;
-              }, hoverDelay);
+              }, options.hoverDelay);
             }
           }
         });
@@ -497,7 +500,7 @@
               }
               $this.removeClass('is-hover');
               $this[0].navUnHoverTimeout = undefined;
-            }, hideDelay);
+            }, options.hideDelay);
           }
         });
       },


### PR DESCRIPTION
fix #744

## Description
The delay when hovering over vertical navigation items should be configurable. This change allows users to pass in the `hoverDelay` and `hideDelay`, while maintaining sensible defaults.

## Changes

- Allow `setupVerticalNavigation()` to take an arbitrary options object

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [ ] **Cross browser**: works in Chrome
- [ ] **Cross browser**: works in Firefox
- [ ] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [ ] **Responsive**: works in extra small, small, medium and large view ports.
- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
