### PR TITLE
Fix rubygems.org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ exclude: [
 **Patternfly now supports Sass natively!**
 Sass is included in the `dist/sass` directory. Just add `node_modules` to your build tool's Sass include paths then `@import 'patternfly/dist/sass/patternfly';` in your Sass to get started!
 
-Please note that the [patternfly-sass](https://github.com/patternfly/patternfly-sass) is no longer supported and will not include any features or fixes introduced after Patternfly 3.23.2. However, the [patternfly-sass](https://rubygems.org/patternfly-sass) Rubygem is maintained further and built from this repository.
+Please note that the [patternfly-sass](https://github.com/patternfly/patternfly-sass) is no longer supported and will not include any features or fixes introduced after Patternfly 3.23.2. However, the [patternfly-sass](https://rubygems.org/gems/patternfly-sass) Rubygem is maintained further and built from this repository.
 
 ### AngularJS
 


### PR DESCRIPTION
The link structure changed:

https://rubygems.org/patternfly-sass (broken)
https://rubygems.org/gems/patternfly-sass (correct)

This is just a README fix.