### PR TITLE
fix(list view): Adjust bg colors of list view

### DIFF
--- a/src/less/list-group.less
+++ b/src/less/list-group.less
@@ -11,6 +11,11 @@
 .list-group-item {
   border-left: 0;
   border-right: 0;
+  &.disabled,
+  &.disabled:hover,
+  &.disabled:focus {
+    background-color: @list-group-disabled-bg;
+  }
 }
 
 .list-group-item-heading {

--- a/src/less/list-view.less
+++ b/src/less/list-view.less
@@ -16,7 +16,7 @@
     padding-bottom: 0;
     padding-top: 0;
     &.list-view-pf-expand-active {
-      background-color: @list-view-hover-bg;
+      background-color: @list-view-active-bg;
       box-shadow: 0 2px 6px rgba(3, 3, 3, .2);
       z-index: 1;
     }

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -97,6 +97,7 @@
 @list-view-active-border:                                           @color-pf-black-400;
 @list-view-divider:                                                 @color-pf-black-300;
 @list-view-hover-bg:                                                @color-pf-blue-25;
+@list-group-disabled-bg:                                            @color-pf-black-100;
 @list-group-top-border:                                             @color-pf-black-200;
 @login-bg-color:                                                    @color-pf-black;
 @login-container-bg-color-rgba:                                     fade(@color-pf-white, 5.5%);

--- a/src/sass/converted/patternfly/_list-group.scss
+++ b/src/sass/converted/patternfly/_list-group.scss
@@ -11,6 +11,11 @@
 .list-group-item {
   border-left: 0;
   border-right: 0;
+  &.disabled,
+  &.disabled:hover,
+  &.disabled:focus {
+    background-color: $list-group-disabled-bg;
+  }
 }
 
 .list-group-item-heading {

--- a/src/sass/converted/patternfly/_list-view.scss
+++ b/src/sass/converted/patternfly/_list-view.scss
@@ -16,7 +16,7 @@
     padding-bottom: 0;
     padding-top: 0;
     &.list-view-pf-expand-active {
-      background-color: $list-view-hover-bg;
+      background-color: $list-view-active-bg;
       box-shadow: 0 2px 6px rgba(3, 3, 3, .2);
       z-index: 1;
     }

--- a/src/sass/converted/patternfly/_variables.scss
+++ b/src/sass/converted/patternfly/_variables.scss
@@ -97,6 +97,7 @@ $list-view-active-bg:                                               $color-pf-bl
 $list-view-active-border:                                           $color-pf-black-400 !default;
 $list-view-divider:                                                 $color-pf-black-300 !default;
 $list-view-hover-bg:                                                $color-pf-blue-25 !default;
+$list-group-disabled-bg:                                            $color-pf-black-100 !default;
 $list-group-top-border:                                             $color-pf-black-200 !default;
 $login-bg-color:                                                    $color-pf-black !default;
 $login-container-bg-color-rgba:                                     rgba($color-pf-white, (5.5/100)) !default;

--- a/src/sass/converted/rcue/_list-group.scss
+++ b/src/sass/converted/rcue/_list-group.scss
@@ -11,6 +11,11 @@
 .list-group-item {
   border-left: 0;
   border-right: 0;
+  &.disabled,
+  &.disabled:hover,
+  &.disabled:focus {
+    background-color: $list-group-disabled-bg;
+  }
 }
 
 .list-group-item-heading {

--- a/src/sass/converted/rcue/_list-view.scss
+++ b/src/sass/converted/rcue/_list-view.scss
@@ -16,7 +16,7 @@
     padding-bottom: 0;
     padding-top: 0;
     &.list-view-pf-expand-active {
-      background-color: $list-view-hover-bg;
+      background-color: $list-view-active-bg;
       box-shadow: 0 2px 6px rgba(3, 3, 3, .2);
       z-index: 1;
     }

--- a/src/sass/converted/rcue/_variables.scss
+++ b/src/sass/converted/rcue/_variables.scss
@@ -97,6 +97,7 @@ $list-view-active-bg:                                               $color-pf-bl
 $list-view-active-border:                                           $color-pf-black-400 !default;
 $list-view-divider:                                                 $color-pf-black-300 !default;
 $list-view-hover-bg:                                                $color-pf-blue-25 !default;
+$list-group-disabled-bg:                                            $color-pf-black-100 !default;
 $list-group-top-border:                                             $color-pf-black-200 !default;
 $login-bg-color:                                                    $color-pf-black !default;
 $login-container-bg-color-rgba:                                     rgba($color-pf-white, (5.5/100)) !default;


### PR DESCRIPTION
## Description
This PR is targeted to fix issue #1082.

## Changes

The final background color solution of list view is shown below:

- Hover - when the user hovers over a row (#edf8ff)
- Selected - when the user selects a row via single click or selecting the checkbox (pf-blue-50, #def3ff)
- Open - when a row is expanded (pf-blue-50, #def3ff)
- Edit - when a row is in edit mode via inline edit (pf-blue-50, #def3ff)
- Disabled - when a row is disabled (pf-black-100, #fafafa)

## Link to rawgit and/or image

You can find the expected colors on the [demo](https://rawgit.com/dabeng/patternfly/list-view-colors-dist/dist/tests/index.html) pages with keyword "list view"