### PR TITLE
chore(resize): Replace deprecated jQuery.fn.resize() with .on('resize', handler)

### DIFF
--- a/src/js/patternfly-functions-fixed-heights.js
+++ b/src/js/patternfly-functions-fixed-heights.js
@@ -81,7 +81,7 @@
     setCollapseHeights();
 
     // Update on window resizing
-    $(window).resize(setCollapseHeights);
+    $(window).on('resize', setCollapseHeights);
 
   };
 }(jQuery));

--- a/src/js/patternfly-functions-sidebar.js
+++ b/src/js/patternfly-functions-sidebar.js
@@ -22,7 +22,7 @@
     }
   });
 
-  $(window).resize(function () {
+  $(window).on('resize', function () {
     // Call sidebar() on resize if .sidebar-pf exists
     if ($('.sidebar-pf').length > 0) {
       $.fn.sidebar();


### PR DESCRIPTION
## Description
This PR is targeted to fix issue #939 .
The followings are associated demos:

- https://rawgit.com/dabeng/patternfly/deprecated-dist/dist/tests/accordions.html
- https://rawgit.com/dabeng/patternfly/deprecated-dist/dist/tests/tab.html

@dgutride @jeff-phillips-18 @amarie401 Could you review this PR when you have time ?

## Changes

Replace `resize(handler)` with `on('resize', handler)`.