### PR TITLE
fix(forms): Remove hyphens from inclusion variables

### DIFF
--- a/tests/pages/_includes/widgets/forms/expand-collapse-section.html
+++ b/tests/pages/_includes/widgets/forms/expand-collapse-section.html
@@ -1,52 +1,52 @@
 <form class="form-horizontal">
   <div class="form-group">
-    <label class="col-sm-{{include.col-size-label}} control-label" for="{{include.id-blueprintname}}">Blueprint Name</label>
-    <div class="col-sm-{{include.col-size-field}}">
-      <input type="text" id="{{include.id-blueprintname}}" class="form-control">
+    <label class="col-sm-{{include.col_size_label}} control-label" for="{{include.id_blueprintname}}">Blueprint Name</label>
+    <div class="col-sm-{{include.col_size_field}}">
+      <input type="text" id="{{include.id_blueprintname}}" class="form-control">
     </div>
   </div>
   <div class="form-group">
-    <label class="col-sm-{{include.col-size-label}} control-label" for="{{include.id-catalog}}">Catalog</label>
-    <div class="col-sm-{{include.col-size-field}}">
-      <input type="text" id="{{include.id-catalog}}" class="form-control"></div>
+    <label class="col-sm-{{include.col_size_label}} control-label" for="{{include.id_catalog}}">Catalog</label>
+    <div class="col-sm-{{include.col_size_field}}">
+      <input type="text" id="{{include.id_catalog}}" class="form-control"></div>
   </div>
   <div class="form-group">
-    <label class="col-sm-{{include.col-size-label}} control-label" for="{{include.id-number}}">Number</label>
-    <div class="col-sm-{{include.col-size-field}}">
-      <input type="text" id="{{include.id-number}}" class="form-control"></div>
+    <label class="col-sm-{{include.col_size_label}} control-label" for="{{include.id_number}}">Number</label>
+    <div class="col-sm-{{include.col_size_field}}">
+      <input type="text" id="{{include.id_number}}" class="form-control"></div>
   </div>
 
-  <fieldset class="fields-section-pf" id="{{include.id-fieldsection}}">
+  <fieldset class="fields-section-pf" id="{{include.id_fieldsection}}">
     <legend class="fields-section-header-pf">
       <span class="fa fa-angle-right fa-angle-down field-section-toggle-pf"></span>
-      <a href="#{{include.id-fieldsection}}" class="field-section-toggle-pf">Advanced Options</a>
+      <a href="#{{include.id_fieldsection}}" class="field-section-toggle-pf">Advanced Options</a>
     </legend>
     <div class="form-group">
-      <label class="col-sm-{{include.col-size-label}} control-label" for="{{include.id-entry1}}">Entry Point 1</label>
-      <div class="col-sm-{{include.col-size-field}}">
-        <input type="text" id="{{include.id-entry1}}" class="form-control"></div>
+      <label class="col-sm-{{include.col_size_label}} control-label" for="{{include.id_entry1}}">Entry Point 1</label>
+      <div class="col-sm-{{include.col_size_field}}">
+        <input type="text" id="{{include.id_entry1}}" class="form-control"></div>
     </div>
     <div class="form-group">
-      <label class="col-sm-{{include.col-size-label}} control-label" for="{{include.id-entry2}}">Entry Point 2</label>
-      <div class="col-sm-{{include.col-size-field}}">
-        <input type="text" id="{{include.id-entry2}}" class="form-control"></div>
+      <label class="col-sm-{{include.col_size_label}} control-label" for="{{include.id_entry2}}">Entry Point 2</label>
+      <div class="col-sm-{{include.col_size_field}}">
+        <input type="text" id="{{include.id_entry2}}" class="form-control"></div>
     </div>
     <div class="form-group">
-      <label class="col-sm-{{include.col-size-label}} control-label" for="{{include.id-entry3}}">Entry Point 3</label>
-      <div class="col-sm-{{include.col-size-field}}">
-        <input type="text" id="{{include.id-entry3}}" class="form-control"></div>
+      <label class="col-sm-{{include.col_size_label}} control-label" for="{{include.id_entry3}}">Entry Point 3</label>
+      <div class="col-sm-{{include.col_size_field}}">
+        <input type="text" id="{{include.id_entry3}}" class="form-control"></div>
     </div>
   </fieldset>
 
-  {% if include.is-modal == false %}
+  {% if include.is_modal == false %}
   <div class="form-group">
-    <div class="col-sm-offset-{{include.col-size-label}} col-sm-{{include.col-size-field}}">
+    <div class="col-sm-offset-{{include.col_size_label}} col-sm-{{include.col_size_field}}">
       <button type="submit" class="btn btn-primary">Save</button>
       <button type="submit" class="btn btn-default">Cancel</button>
     </div>
   </div>
   {% endif %}
-  {% if include.is-modal == true %}
+  {% if include.is_modal == true %}
   <div class="modal-footer">
     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
     <button type="button" class="btn btn-primary">Save</button>
@@ -65,7 +65,8 @@
     $('.fa.field-section-toggle-pf').removeClass('fa-angle-down');
 
     // click the field section heading to expand the section
-    $("#{{include.id-fieldsection}} .field-section-toggle-pf").click(function(event){
+    $("#{{include.id_fieldsection}} .field-section-toggle-pf").click(function(event){
+      event.preventDefault();
       $(this).parents(".fields-section-pf").find(".fa").toggleClass("fa-angle-down");
       $(this).parents(".fields-section-pf").find(".form-group").toggleClass("hidden");
       if ($(this).parent().attr('aria-expanded') == 'false') {

--- a/tests/pages/_includes/widgets/forms/input-validation-form.html
+++ b/tests/pages/_includes/widgets/forms/input-validation-form.html
@@ -1,21 +1,21 @@
-{% if include.has-error == true %}{% include widgets/communication/alert-danger.html %}{% endif %}
+{% if include.has_error == true %}{% include widgets/communication/alert-danger.html %}{% endif %}
 <form class="form-horizontal">
   <div class="form-group">
-    <label class="col-sm-2 control-label" for="{{include.id-default}}">Default</label>
+    <label class="col-sm-2 control-label" for="{{include.id_default}}">Default</label>
     <div class="col-sm-10">
-      <input type="text" id="{{include.id-default}}" class="form-control">
+      <input type="text" id="{{include.id_default}}" class="form-control">
     </div>
   </div>
   <div class="form-group">
-    <label class="col-sm-2 control-label" for="{{include.id-disabled}}">Disabled</label>
+    <label class="col-sm-2 control-label" for="{{include.id_disabled}}">Disabled</label>
     <div class="col-sm-10">
-      <input type="text" id="{{include.id-disabled}}" class="form-control" disabled></div>
+      <input type="text" id="{{include.id_disabled}}" class="form-control" disabled></div>
   </div>
-  <div class="form-group {% if include.has-error == true %}has-error{% endif %}">
-    <label class="col-sm-2 control-label" for="{{include.id-error}}">{% if include.has-error == true %}With{% else %}No{% endif %} error</label>
+  <div class="form-group {% if include.has_error == true %}has-error{% endif %}">
+    <label class="col-sm-2 control-label" for="{{include.id_error}}">{% if include.has_error == true %}With{% else %}No{% endif %} error</label>
     <div class="col-sm-10">
-      <input type="text" id="{{include.id-error}}" class="form-control">
-{% if include.has-error == true %}
+      <input type="text" id="{{include.id_error}}" class="form-control">
+{% if include.has_error == true %}
       <span class="help-block">Please correct the error</span>
 {% endif %}
     </div>

--- a/tests/pages/_includes/widgets/forms/input-validation-modal.html
+++ b/tests/pages/_includes/widgets/forms/input-validation-modal.html
@@ -7,23 +7,23 @@
         <h4 class="modal-title">Modal title</h4>
       </div>
       <div class="modal-body">
-        {% if include.has-error == true %}{% include widgets/communication/alert-danger.html %}{% endif %}
+        {% if include.has_error == true %}{% include widgets/communication/alert-danger.html %}{% endif %}
         <form class="form-horizontal">
           <div class="form-group">
-            <label class="col-sm-2 control-label" for="{{include.id-default}}">Default</label>
+            <label class="col-sm-2 control-label" for="{{include.id_default}}">Default</label>
             <div class="col-sm-10">
-              <input type="text" id="{{include.id-default}}" class="form-control"></div>
+              <input type="text" id="{{include.id_default}}" class="form-control"></div>
           </div>
           <div class="form-group">
-            <label class="col-sm-2 control-label" for="{{include.id-disabled}}">Disabled</label>
+            <label class="col-sm-2 control-label" for="{{include.id_disabled}}">Disabled</label>
             <div class="col-sm-10">
-              <input type="text" id="{{include.id-disabled}}" class="form-control" disabled></div>
+              <input type="text" id="{{include.id_disabled}}" class="form-control" disabled></div>
           </div>
-          <div class="form-group {% if include.has-error == true %}has-error{% endif %}">
-            <label class="col-sm-2 control-label" for="{{include.id-error}}">{% if include.has-error == true %}With{% else %}No{% endif %} error</label>
+          <div class="form-group {% if include.has_error == true %}has-error{% endif %}">
+            <label class="col-sm-2 control-label" for="{{include.id_error}}">{% if include.has_error == true %}With{% else %}No{% endif %} error</label>
             <div class="col-sm-10">
-              <input type="text" id="{{include.id-error}}" class="form-control">
-{% if include.has-error == true %}
+              <input type="text" id="{{include.id_error}}" class="form-control">
+{% if include.has_error == true %}
               <span class="help-block">Please correct the error</span>
 {% endif %}
             </div>

--- a/tests/pages/forms.html
+++ b/tests/pages/forms.html
@@ -182,7 +182,7 @@ resource: true
       </form>
 
       <h3 id="right-aligned_error-feedback">Error Feedback</h3>
-      {% include widgets/forms/input-validation-form.html id-default="exampleInput" id-disabled="exampleInputDisabled" id-error="exampleInputError" has-error=true %}
+      {% include widgets/forms/input-validation-form.html id_default="exampleInput" id_disabled="exampleInputDisabled" id_error="exampleInputError" has_error=true %}
 
       <h2 id="top-aligned">Top-aligned labels</h2>
 
@@ -298,12 +298,12 @@ resource: true
         }
       </style>
       <div class="example-pf">
-        {% include widgets/forms/input-validation-modal.html id-default="modalInput" id-disabled="modalInputDisabled" id-error="modalInputError" has-error=true %}
+        {% include widgets/forms/input-validation-modal.html id_default="modalInput" id_disabled="modalInputDisabled" id_error="modalInputError" has_error=true %}
       </div>
 
       <h2 id="expand-collapse-section">Expand-Collapse Section</h2>
       <div class="example-pf">
-        {% include widgets/forms/expand-collapse-section.html id-blueprintname="AdvOptBlueprintName" id-catalog="AdvOptCatalog" id-number="AdvOptNumber" id-entry1="AdvOptEntry1" id-entry2="AdvOptEntry2" id-entry3="AdvOptEntry3" id-fieldsection="AdvOptSection" is-modal=false col-size-label="2" col-size-field="10" %}
+        {% include widgets/forms/expand-collapse-section.html id_blueprintname="AdvOptBlueprintName" id_catalog="AdvOptCatalog" id_number="AdvOptNumber" id_entry1="AdvOptEntry1" id_entry2="AdvOptEntry2" id_entry3="AdvOptEntry3" id_fieldsection="AdvOptSection" is_modal=false col_size_label="2" col_size_field="10" %}
       </div>
 
       <h2 id="expand-collapse-section-inside-a-modal">Expand-Collapse Section inside a modal</h2>
@@ -320,7 +320,7 @@ resource: true
             </div>
             <div class="modal-body">
               <div class="example-pf">
-                {% include widgets/forms/expand-collapse-section.html id-blueprintname="AdvOptBlueprintNameMod" id-catalog="AdvOptCatalogMod" id-number="AdvOptNumberMod" id-entry1="AdvOptEntry1Mod" id-entry2="AdvOptEntry2Mod" id-entry3="AdvOptEntry3Mod" id-fieldsection="AdvOptSectionMod" is-modal=true col-size-label="3" col-size-field="9" %}
+                {% include widgets/forms/expand-collapse-section.html id_blueprintname="AdvOptBlueprintNameMod" id_catalog="AdvOptCatalogMod" id_number="AdvOptNumberMod" id_entry1="AdvOptEntry1Mod" id_entry2="AdvOptEntry2Mod" id_entry3="AdvOptEntry3Mod" id_fieldsection="AdvOptSectionMod" is_modal=true col_size_label="3" col_size_field="9" %}
               </div>
             </div>
           </div>


### PR DESCRIPTION
Removed hyphens from inclusion variables as they cause build errors when using liquid.

closes #924


