### PR TITLE
fix(wizard): rewrite click event handler that disables default event on wizard nav and progress link

### DIFF
--- a/tests/pages/_includes/widgets/communication/wizard.html
+++ b/tests/pages/_includes/widgets/communication/wizard.html
@@ -420,6 +420,7 @@
       self.backBtnClicked();
       self.nextBtnClicked();
       self.cancelBtnClick();
+      self.disableDefaultClick();
 
       // Listen for required value change
       self.detailsNameChange();
@@ -597,12 +598,14 @@
     };
 
     // Disable click events
-    $('body').on('click', $(self.modal + " .wizard-pf-step > a",
-      self.modal + " .wizard-pf-step-alt > a",
-      self.modal + " .wizard-pf-step-alt .wizard-pf-step-alt-substep > a",
-      self.modal + " .wizard-pf-sidebar .list-group-item > a"), function(e) {
-        e.preventDefault();
-    });
+    this.disableDefaultClick = function() {
+      $(self.modal + " .wizard-pf-step > a")
+        .add(self.modal + " .wizard-pf-step-alt > a")
+        .add(self.modal + " .wizard-pf-step-alt .wizard-pf-step-alt-substep > a")
+        .add(self.modal + " .wizard-pf-sidebar .list-group-item > a").on('click', function(e) {
+          e.preventDefault()
+      });
+    }
 
     this.validateRequired = function($el) {
       var $nextBtn = $(self.modal + " .wizard-pf-next"),


### PR DESCRIPTION
fix #1105

## Description

Refactor click event handler that disables default event in wizard progress/nav links so that it only captures events on those links, and not the entire body.

## Link to rawgit and/or image

will add

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [ ] **Cross browser**: works in Firefox
- [ ] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [ ] **Responsive**: works in extra small, small, medium and large view ports.
- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
