### PR TITLE
fix(build): broken npm login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 
 before_install:
   - rvm install 2.4.1
-  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
+  - if [[ `npm -v` != "5.4.0" ]]; then npm i -g npm@5.4.0; fi
   - npm install -g bower grunt-cli
   - npm install patternfly-eng-release
 


### PR DESCRIPTION
In order to publish an npm package, we run `npm publish` along side the `semantic-release pre/post` commands. While `semantic-release pre/post` uses a token, we must first log into npm in order to run `npm publish`. The build does this programmatically, like so:

`printf "$NPM_USER\n$NPM_PWD\n$NPM_USER@redhat.com\n" | npm login`

After updating travis.yml to node 8, I discovered that the programmatic login is broken with npm v5.5.0. As a fix, I'd like to try installing npm v5.4.0 to getting the build releases working again. I was able to confirm on my local machine that npm v5.4.0 works with the above programmatic login command.

Note: if this does not resolve the issue, we can drop back to node 6 in .travis.yml. That will also get the build releases going while we investigate further.