### PR TITLE
fix(build): remove npm install in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
 
 before_install:
   - rvm install 2.4.1
-  - if [[ `npm -v` != "5.4.0" ]]; then npm i -g npm@5.4.0; fi
   - npm install -g bower grunt-cli
   - npm install patternfly-eng-release
 


### PR DESCRIPTION
We don't need to npm login if we have a valid token. Thus, installing npm to v5.4.0 won't be necessary. With this change, and an updated npm token, we will ensure the build releases properly.
