### PR TITLE
fix(npm): remove engine requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,10 +126,6 @@
     "type": "git",
     "url": "https://github.com/patternfly/patternfly.git"
   },
-  "engines": {
-    "node": ">=8.9.0",
-    "npm": ">=5.5.1"
-  },
   "bugs": {
     "url": "https://github.com/patternfly/patternfly/issues"
   },


### PR DESCRIPTION
## Description
Remove the requirement for specific version of node.

fixes https://github.com/patternfly/patternfly/issues/1113

Of note:
**PatternFly-React** has the following engine requirements:
```
"engines": {
  "node": ">=8.9.0",
  "npm": ">=5.5.1",
  "yarn": ">=1.6.0"
}
```

**PatternFly-ng** has the following engine requirements:
```
"engines": {
  "node": ">=8.11.1",
  "npm": ">=5.6.0"
}
```

**PatternFly-Next** has the following engine requirements:
```
"engines": {
  "node": ">=8.0.0",
  "npm": ">=5.0.0"
}
```

## Changes

* Remove node engine requirements for node 8 and npm 5