### PR TITLE
fix(inline edit): remove clear element in internet explorer

### DIFF
--- a/src/less/forms.less
+++ b/src/less/forms.less
@@ -164,6 +164,9 @@ span.required-pf {
     position: relative;
     input {
       padding-right: @input-height-base;
+      &::-ms-clear {
+        display: none;
+      }
     }
     .form-control-pf-empty {
       background: none;

--- a/src/sass/converted/patternfly/_forms.scss
+++ b/src/sass/converted/patternfly/_forms.scss
@@ -164,6 +164,9 @@ span.required-pf {
     position: relative;
     input {
       padding-right: $input-height-base;
+      &::-ms-clear {
+        display: none;
+      }
     }
     .form-control-pf-empty {
       background: none;

--- a/src/sass/converted/rcue/_forms.scss
+++ b/src/sass/converted/rcue/_forms.scss
@@ -164,6 +164,9 @@ span.required-pf {
     position: relative;
     input {
       padding-right: $input-height-base;
+      &::-ms-clear {
+        display: none;
+      }
     }
     .form-control-pf-empty {
       background: none;


### PR DESCRIPTION
fix #1076

## Description
There are 2 "x" (clear) icons when editing a text input in IE/edge, because IE has a native pseudo element to clear an input.

## Changes

Hiding the IE clear element and using the patternfly icon for consistency.

## Link to rawgit and/or image

The build is failing for the tertiary navigation test below, which should have nothing to do with the inline edit pattern.

https://travis-ci.org/michael-coker/patternfly/builds/411338357

> compare | ERROR { requireSameDimensions: false, size: isDifferent, content: 11.61%, threshold: 7% }: navbar-tertiary-menu-submenu-default-selected backstop_default_navbar-tertiary-menu-submenu-default-selected_0_container_0_large-device.png

## PR checklist (if relevant)

- [x] **Cross browser**: works in IE9
- [x] **Cross browser**: works in IE10
- [x] **Cross browser**: works in IE11
- [x] **Cross browser**: works in Edge
- [ ] **Cross browser**: works in Chrome
- [ ] **Cross browser**: works in Firefox
- [ ] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [ ] **Responsive**: works in extra small, small, medium and large view ports.
- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
