### PR TITLE
fix(kbd-styling): add class for semantic use of kbd element

### DIFF
--- a/src/less/code.less
+++ b/src/less/code.less
@@ -1,0 +1,11 @@
+//
+// Code (inline and block)
+// --------------------------------------------------
+
+
+// Inline and block code styles
+.kbd-semantic {
+  background: inherit;
+  color: inherit;
+  box-shadow: none;
+}

--- a/src/less/patternfly-additions.less
+++ b/src/less/patternfly-additions.less
@@ -43,6 +43,7 @@
 @import "card-view.less";
 @import "charts.less";
 @import "close.less";
+@import "code.less";
 @import "context-selector.less";
 @import "datatables.less";
 @import "date-and-time.less";

--- a/src/sass/converted/patternfly/_code.scss
+++ b/src/sass/converted/patternfly/_code.scss
@@ -1,0 +1,11 @@
+//
+// Code (inline and block)
+// --------------------------------------------------
+
+
+// Inline and block code styles
+.kbd-semantic {
+  background: inherit;
+  color: inherit;
+  box-shadow: none;
+}

--- a/src/sass/converted/rcue/_code.scss
+++ b/src/sass/converted/rcue/_code.scss
@@ -1,0 +1,11 @@
+//
+// Code (inline and block)
+// --------------------------------------------------
+
+
+// Inline and block code styles
+.kbd-semantic {
+  background: inherit;
+  color: inherit;
+  box-shadow: none;
+}

--- a/src/sass/converted/rcue/_patternfly-additions.scss
+++ b/src/sass/converted/rcue/_patternfly-additions.scss
@@ -43,6 +43,7 @@
 @import 'card-view';
 @import 'charts';
 @import 'close';
+@import 'code';
 @import 'context-selector';
 @import 'datatables';
 @import 'date-and-time';


### PR DESCRIPTION
## kbd styling issue #1002

This PR is related to #1134, that I mistakenly rebased onto the wrong branch. This PR only has the relevant changes (sorry :slightly_frowning_face:)

## Changes

* added code.less file
* added kbd-semantic class into code.less
* ran build

![Codepen Demo of Class](https://codepen.io/tmorozco/pen/aazBMQ)