### PR TITLE
feat(doc): provide basic example for scss with webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ exclude: [
 Sass is included in the `dist/sass` directory. Just add `node_modules` to your build tool's Sass include paths then `@import 'patternfly/dist/sass/patternfly';` in your Sass to get started!
 
 #### Using Webpack?
-There are two touch points for integratign patternfly sass, one in your webpack conrfig, and another in your sass. Below is an example module rule for loading patternfly .scss files using webpack
+There are two touch points for integrating patternfly sass: one in your webpack config, and another in your sass. Below is an example module rule for loading patternfly .scss files using webpack.
 
 ```javascript
 module: {

--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ module: {
     {
       test: /\.scss$/,
       use: [
-        {loader: 'style-loader'},
-        {loader: 'css-loader'},
         {
           loader: 'sass-loader',
           options: {

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you wish to contribute to PatternFly, please follow the instructions under "C
 
 PatternFly can be installed and managed through [NPM](https://www.npmjs.com/). To do so, either add `patternfly` as a dependency in your `package.json` or run the following:
 
-```
+```sh
 npm install patternfly --save
 ```
 
@@ -30,7 +30,7 @@ PatternFly stays up to date with the Node LTS [Release Schedule](https://github.
 
 PatternFly can be installed and managed through [Bower](http://bower.io/). To do so, either add `patternfly` as a dependency in your `bower.json` or run the following:
 
-```
+```sh
 bower install patternfly --save
 ```
 
@@ -38,7 +38,7 @@ bower install patternfly --save
 
 Are you using [Wiredep](https://github.com/taptapship/wiredep)?  PatternFly's CSS includes the CSS of its dependencies.  As a result, you'll want to add the following to your [Wiredep configuration](https://github.com/taptapship/wiredep#configuration) so you don't end up with duplicate CSS.
 
-```
+```javascript
 exclude: [
   "node_modules/patternfly/node_modules/patternfly-bootstrap-combobox/css/bootstrap-combobox.css",
   "node_modules/patternfly/node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker.css",
@@ -60,6 +60,43 @@ exclude: [
 
 **Patternfly now supports Sass natively!**
 Sass is included in the `dist/sass` directory. Just add `node_modules` to your build tool's Sass include paths then `@import 'patternfly/dist/sass/patternfly';` in your Sass to get started!
+
+#### Using Webpack?
+There are two touch points for integratign patternfly sass, one in your webpack conrfig, and another in your sass. Below is an example module rule for loading patternfly .scss files using webpack
+
+```javascript
+module: {
+  rules: [
+    {
+      test: /\.scss$/,
+      use: [
+        {loader: 'style-loader'},
+        {loader: 'css-loader'},
+        {
+          loader: 'sass-loader',
+          options: {
+            includePaths: [
+              // teach webpack to resolve these references
+              path.resolve(__dirname, 'node_modules', 'patternfly', 'dist', 'sass'),
+              path.resolve(__dirname, 'node_modules', 'bootstrap-sass', 'assets', 'stylesheets'),
+              path.resolve(__dirname, 'node_modules', 'font-awesome-sass', 'assets', 'stylesheets')
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+With webpack configured, just set the asset-path related variables and you're off!
+
+```scss
+$img-path: '~patternfly/dist/img/';
+$font-path: '~patternfly/dist/fonts/';
+$icon-font-path: '~patternfly/dist/fonts/';
+@import '~patternfly/dist/sass/patternfly';
+```
 
 Please note that the [patternfly-sass](https://github.com/patternfly/patternfly-sass) is no longer supported and will not include any features or fixes introduced after Patternfly 3.23.2. However, the [patternfly-sass](https://rubygems.org/gems/patternfly-sass) Rubygem is maintained further and built from this repository.
 
@@ -93,13 +130,13 @@ The development includes the use of a number of helpful tasks. In order to setup
 
 To do this clone, and change directories into PatternFly:
 
-```
+```sh
 cd [PathToYourRepository]
 ```
 
 then
 
-```
+```sh
 npm install
 ```
 
@@ -115,13 +152,13 @@ Additionally you may need to install the grunt command line utility.  To do this
 
 Test pages are optionally generated using [Jekyll](http://jekyllrb.com/). To use jekyll to build the test pages, ensure Ruby is installed and available then run:
 
-```
+```sh
 npm run jekyll
 ```
 
 or
 
-```
+```sh
 gem install bundle
 bundle install
 ```
@@ -135,7 +172,7 @@ Next, set the environment variable PF_PAGE_BUILDER=jekyll.  eg.:
 
 Anytime you pull a new version of PatternFly, make sure you also run
 
-```
+```sh
 npm update
 ```
 
@@ -145,13 +182,13 @@ so you get the latest version of the dependencies specified in package.json.
 
 A local development server can be quickly fired up by using the Gruntjs serve task:
 
-```
+```sh
 npm start
 ```
 
 or
 
-```
+```sh
 grunt serve                 # will build first by default
 grunt serve --skipRebuild   # flag would allow you to skip the rebuild to save some time
 ```
@@ -168,7 +205,7 @@ PatternFly uses the [semantic-release tool](https://github.com/semantic-release/
 
 We have configured the [commitizen tool](https://github.com/commitizen/cz-cli) to assist you in formatting your commit messages corrctly.  To use this tool run the following command instead of `git commit`:
 
-```
+```sh
 npm run commit
 ```
 
@@ -212,13 +249,13 @@ The tool will prompt you with several questions that it will use to correctly fo
 
 In development, styling is written and managed through multiple Less files. In order to generate a CSS file of all styling, run the build Gruntjs task:
 
-```
+```sh
 npm run build
 ```
 
 or
 
-```
+```sh
 grunt build
 ```
 
@@ -227,14 +264,14 @@ This task will compile and minify the Less files into CSS files located at `dist
 ### Less to Sass Conversion
 Any time style changes are introduced, the Sass code will need to be updated to reflect those changes. The conversion is accomplished as part of the build, but in order to test the CSS you will need to build it from Sass:
 
-```
+```sh
 npm start -- --sass
 ```
 *Note the extra ` -- ` between `npm start` and the `--sass` flag. This syntax passes the flag on to the underlying grunt process instead of the npm command itself.*
 
 or
 
-```
+```sh
 grunt build --sass
 ```
 
@@ -249,7 +286,7 @@ Sass and Less do not have perfect feature parity, which can sometimes throw a wr
 #### Non-parametric Mixins
 Sass does not support non-parametric mixins in the same way that Less does. Mixins must be explictly declared in Sass, whereas any class definition in Less can be used as a non-parametric mixin. Sass does not have a feature that perfectly parallels this behavior, so we have to use the closest thing which is the `@extend` statement. However, an edge case exists where `@extend` statements are not allowed within media queries in Sass. This creates a scenario where uncompilable Sass code can be generated from perfectly acceptable Less. For example:
 **Less:**
-```
+```less
   .applauncher-pf {
     .applauncher-pf-title {
         .sr-only();
@@ -262,7 +299,7 @@ Sass does not support non-parametric mixins in the same way that Less does. Mixi
 ```
 
 **Converts to Sass:**
-```
+```scss
   .applauncher-pf {
     .applauncher-pf-title {
       @extend .sr-only;
@@ -277,7 +314,7 @@ Sass does not support non-parametric mixins in the same way that Less does. Mixi
 This breaks for two reasons. We cannot use the `@extend` statement directly inside a media query, and even if we are able to work around that by making applauncher-pf into a mixin and using the `@include` directive, `.applauncher-pf .applauncher-pf-title` uses the `@extend` directive, which would still fall within the media query via the mixin invocation. To fix this, the Less would need to be adjusted like this:
 
 **Less**
-```
+```less
   // Explicitly define a non-parametric sr-only mixin.
   .sr-only() {
     // sr-only rules;
@@ -304,7 +341,7 @@ This breaks for two reasons. We cannot use the `@extend` statement directly insi
 ```
 
 **Converts to Sass:**
-```
+```scss
   @mixin sr-only() {
     // sr-only rules
   }
@@ -327,42 +364,42 @@ This breaks for two reasons. We cannot use the `@extend` statement directly insi
 #### Tilde-Escaped Strings
 Strings that are escaped using the tilde in Less get converted to the Sass `unquote()` function. This causes Sass compilation issues when using escaped strings inside native CSS functions like `calc()`. Here is what happens:
 Less:
-```
+```less
 height: calc(~"100vh - 20px");
 ```
 Converts to Sass:
-```
+```scss
 height: calc(unqoute("100vh - 20px")):
 ```
 Which compiles directly to CSS and does not work as expected:
-```
+```css
 height: calc(unqoute("100vh - 20px")):
 ```
 
 To fix this, move the tilde operator outside of the `calc()` statement:
 
 Less:
-```
+```less
 height: ~"calc(100vh - 20px)";
 ```
 Converts to Sass:
-```
+```scss
 height: unqoute("calc(100vh - 20px)");
 ```
 Compiles to CSS:
-```
+```css
 height: calc(100vh - 20px);
 ```
 
 #### Comma Separated CSS Rules
 Using complex, comma separated rules in things like box shadows or backgrounds will cause conversion problems if they are not properly escaped. These rules should be escaped, and mixins and variables should not be used inline. For example, this statement should not be used in Less:
-```
+```css
 box-shadow: inset 0 1px 1px fade(@color-pf-black, 7.5%), 0 0 6px lighten(@state-danger-text, 20%);
 ```
 
 Instead, mixins should be assigned to variables, and variables should be interpolated in an escaped string like this:
 
-```
+```scss
 @color1: fade(@color-pf-black, 7.5%);
 @color2: lighten(@state-danger-text, 20%);
 box-shadow: ~"inset 0 1px 1px @{color1}, 0 0 6px @{color2}";
@@ -386,13 +423,13 @@ The HTML pages in `dist/tests` are generated using Jekyll.  Do *not* edit these 
 ### Unit Testing
 Unit tests are written for [Karma test server] (https://karma-runner.github.io/1.0/index.html) with [Jasmine](http://jasmine.github.io/)
 
-```
+```sh
 npm test
 ```
 
 or
 
-```
+```sh
 grunt karma
 ```
 ### Visual Regression Testing


### PR DESCRIPTION
## Description
This PR makes a few small enhancements to the main readme, namely adding an example of how to configure a webpack build to be able to consume patternfly sass. It ended up being very simple after I figured out how to make it work, but it became obvious that a simple mention in our documentation for how to do this was badly missing.

It's kinda related to https://github.com/patternfly/patternfly-next/issues/720, not directly - but treating the same problem anyway. There just wasn't a good example of how to do this using webpack, a widely adopted module bundler. Instead of making developers painfully figure this out on their own, let's give them a simple example of how to do it.

Also, I added the language type onto various code snippets in the readme so that, as a developer, I get syntax highlighting. Without this, all of the text in the readme is white, which isn't so easy on the eyes.

## Changes

* Include example of webpack configuration
* Include example of how to set required scss vars
* Specify language for various code snippets in the readme

## Link to rawgit and/or image

https://github.com/seanforyou23/patternfly/tree/readme-update-sass-dist#using-webpack

<img width="943" alt="screen shot 2018-10-10 at 5 08 25 pm" src="https://user-images.githubusercontent.com/5942899/46766414-ed74d480-ccaf-11e8-9c49-c9d4cb1be239.png">

![screen shot 2018-10-10 at 5 09 22 pm](https://user-images.githubusercontent.com/5942899/46766519-3a58ab00-ccb0-11e8-9476-578e377f9f71.png)

## PR checklist

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [ ] **Cross browser**: works in Chrome
- [ ] **Cross browser**: works in Firefox
- [ ] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [ ] **Responsive**: works in extra small, small, medium and large view ports.
- [x] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
