### PR TITLE
feat(icon): Add support for fontawesome v5

### DIFF
--- a/src/less/card-view.less
+++ b/src/less/card-view.less
@@ -31,7 +31,7 @@
     &:last-child { padding-right: 0; }
     + .card-pf-item { border-left: 1px solid @card-pf-border-color; }
     .fa-check { color: @brand-success; }
-    .fa,
+    .fa, .fas, .far, .fab, .fal,
     .pficon {
       + .card-pf-item-text { margin-left: 10px; }
     }
@@ -42,7 +42,7 @@
     font-weight: 300;
     margin-bottom: 0;
     margin-top: 15px;
-    .fa,
+    .fa, .fas, .far, .fab, .fal,
     .pficon {
       font-size: ceil((@font-size-base * 1.5));
       margin-right: 2px;
@@ -95,7 +95,7 @@
       font-size: 16px;
       font-weight: normal;
       margin-bottom: 10px;
-      .fa,
+      .fa, .fas, .far, .fab, .fal,
       .pficon {
         font-size: 14px;
         margin-right: 5px;

--- a/src/less/cards.less
+++ b/src/less/cards.less
@@ -58,7 +58,7 @@
     margin-left: (@grid-gutter-width / 8 - 2);
     padding-left: (@grid-gutter-width / 4);
   }
-  .fa, .pficon {
+  .fa, .fas, .far, .fab, .fal, .pficon {
     font-size: (@font-size-base * 1.5); // 18px
     margin-right: 7px;
   }
@@ -93,7 +93,7 @@
   margin: 0 (-(@grid-gutter-width / 2)) !important;
   padding: (@grid-gutter-width / 2) (@grid-gutter-width / 2) (@grid-gutter-width / 4);
   a > {
-    .fa,
+    .fa, .fas, .far, .fab, .fal,
     .pficon {
       margin-right: 5px;
     }
@@ -106,7 +106,7 @@
 .card-pf-link-with-icon {
   padding-left: 21px;
   position: relative;
-  .fa,
+  .fa, .fas, .far, .fab, .fal,
   .pficon {
     font-size: 16px;
     left: 0;
@@ -159,7 +159,7 @@
   .card-pf-aggregate-status & {
     font-size: @font-size-large;
     margin: (@grid-gutter-width / 4) 0 0;
-    .fa,
+    .fa, .fas, .far, .fab, .fal,
     .pficon {
       color: @card-pf-aggregate-status-title-icon-color;
       font-size: @font-size-h3;
@@ -181,7 +181,7 @@
     a {
       display: inline-block;
     }
-    .fa,
+    .fa, .fas, .far, .fab, .fal,
     .pficon {
       font-size: (@font-size-base * 2 + 2); // 26px
       margin-right: 0;

--- a/src/less/date-and-time.less
+++ b/src/less/date-and-time.less
@@ -2,7 +2,7 @@
 // Date and Time
 // --------------------------------------------------
 .date-time-picker-pf .input-group-addon {
-  .fa,
+  .fa, .fas, .far, .fab, .fal,
   .pficon {
     width: 12px;
   }

--- a/src/less/list-pf.less
+++ b/src/less/list-pf.less
@@ -56,7 +56,7 @@
     border-left: 1px solid @color-pf-black-300;
     padding-left: (@grid-gutter-width/2);
   }
-  .fa {
+  .fa, .fas, .far, .fab, .fal {
     font-size: 22px;
   }
 }

--- a/src/less/list-view.less
+++ b/src/less/list-view.less
@@ -119,7 +119,7 @@
       line-height: 1em;
     }
   }
-  .pficon, .fa {
+  .pficon, .fa, .fas, .far, .fab, .fal {
     font-size: @font-size-h3;
     margin-right: (@grid-gutter-width/4);
   }
@@ -185,7 +185,7 @@
       line-height: 1em;
     }
   }
-  .pficon, .fa {
+  .pficon, .fa, .fas, .far, .fab, .fal {
     border-radius: 50%;
     font-size: 2em;
     // -md is out of alpha order to get correct bg on -danger

--- a/src/less/modals.less
+++ b/src/less/modals.less
@@ -41,7 +41,7 @@
 .message-dialog-pf .modal-body {
   display: flex;
 
-  .fa,
+  .fa, .fas, .far, .fab, .fal,
   .pficon {
     font-size: 30px;
     margin-right: 15px;

--- a/src/less/nav-vertical-alt.less
+++ b/src/less/nav-vertical-alt.less
@@ -135,7 +135,7 @@
       }
     }
 
-    .fa,
+    .fa, .fas, .far, .fab, .fal,
     .glyphicon,
     .pficon {
       float: left;

--- a/src/less/navbar-alt.less
+++ b/src/less/navbar-alt.less
@@ -41,7 +41,7 @@
         background-color: transparent;
 
         .caret,
-        .fa,
+        .fa, .fas, .far, .fab, .fal,
         .glyphicon,
         .pficon {
           color: @navbar-pf-alt-active-color;
@@ -61,7 +61,7 @@
       }
 
       .caret,
-      .fa,
+      .fa, .fas, .far, .fab, .fal,
       .pficon {
         color: @navbar-pf-alt-color;
         font-size: (@font-size-base + 4);
@@ -81,7 +81,7 @@
         background: transparent;
 
         .caret,
-        .fa,
+        .fa, .fas, .far, .fab, .fal,
         .pficon {
           color: @navbar-pf-alt-active-color;
         }

--- a/src/less/navbar-vertical.less
+++ b/src/less/navbar-vertical.less
@@ -72,7 +72,7 @@
       }
 
       .caret,
-      .fa,
+      .fa, .fas, .far, .fab, .fal,
       .pficon {
         color: @navbar-pf-vertical-color;
         font-size: (@font-size-base + 4);
@@ -105,7 +105,7 @@
         outline: 0;
 
         .caret,
-        .fa,
+        .fa, .fas, .far, .fab, .fal,
         .pficon {
           color: @navbar-pf-item-active-color;
         }

--- a/src/less/navbar.less
+++ b/src/less/navbar.less
@@ -301,7 +301,7 @@
           outline: 0!important;
         }
         position: relative;
-        > .fa,
+        > .fa, .fas, .far, .fab, .fal,
         .pficon {
           line-height: 0;
         }

--- a/src/less/notifications-drawer.less
+++ b/src/less/notifications-drawer.less
@@ -105,7 +105,7 @@
   .btn-link {
     color: @link-color;
     padding: 10px 0;
-    .pficon, .fa {
+    .pficon, .fa, .fas, .far, .fab, .fal, {
       margin-right: 3px;
     }
     .pficon-close {

--- a/src/less/progress-bars.less
+++ b/src/less/progress-bars.less
@@ -103,7 +103,7 @@
     line-height: 1;
     margin-right: 5px;
   }
-  .fa,
+  .fa, .fas, .far, .fab, .fal,
   .pficon {
     font-size: 14px;
     margin-right: 3px;

--- a/src/less/sidebar.less
+++ b/src/less/sidebar.less
@@ -52,7 +52,7 @@
           top: 1px;
         }
       }
-      .fa {
+      .fa, .fas, .far, .fab, .fal {
         color: @color-pf-white;
       }
     }
@@ -68,7 +68,7 @@
         background: @dropdown-link-hover-bg;
         border-color: @dropdown-link-hover-border-color;
       }
-      .fa {
+      .fa, .fas, .far, .fab, .fal {
         color: lighten(@gray-pf, 12%);
         font-size: (@font-size-base + 3);
         margin-right: (@grid-gutter-width / 4);

--- a/src/less/time-picker.less
+++ b/src/less/time-picker.less
@@ -62,7 +62,7 @@
 }
 .time-picker-pf {
   .input-group-addon {
-    .fa,
+    .fa, .fas, .far, .fab, .fal,
     .pficon { width: 12px; }
     &:not(.active) { box-shadow: none; }
   }

--- a/src/less/vertical-nav.less
+++ b/src/less/vertical-nav.less
@@ -81,7 +81,7 @@
         display: flex;
         padding-right: 0;
       }
-      .fa,
+      .fa, .fas, .far, .fab, .fal,
       .glyphicon,
       .pficon {
         color: @nav-pf-vertical-icon-color;
@@ -103,7 +103,7 @@
       background-color: @nav-pf-vertical-active-bg-color;
       color: @nav-pf-vertical-active-color;
       font-weight: @nav-pf-vertical-active-font-weight;
-      .fa,
+      .fa, .fas, .far, .fab, .fal,
       .glyphicon,
       .pficon {
         color: @nav-pf-vertical-active-icon-color;
@@ -160,7 +160,7 @@
   &.hidden-icons-pf {
     > .list-group > .list-group-item { // only the primary menu hides icons
       > a {
-        .fa,
+        .fa, .fas, .far, .fab, .fal,
         .glyphicon,
         .pficon {
           display: none;
@@ -196,7 +196,7 @@
       padding: 0 7px;
       text-align: center;
       .pficon,
-      .fa {
+      .fa, .fas, .far, .fab, .fal {
         font-size: (@font-size-base + 2);
         height: 20px;
         line-height: @line-height-base;


### PR DESCRIPTION
## Description
Allow the usage of fontawesome 5 icons in PF3.

## Changes
Added the new FA prefixes into the codebase.
https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4