### PR TITLE
fix(loading-state): Import sass for loading-state

### DIFF
--- a/src/sass/static/_patternfly.scss
+++ b/src/sass/static/_patternfly.scss
@@ -128,6 +128,7 @@
 @import 'patternfly/list-pf';
 @import 'patternfly/list-view-dnd';
 @import 'patternfly/list-view';
+@import 'patternfly/loading-state';
 @import 'patternfly/login';
 @import 'patternfly/nav-vertical-alt';
 @import 'patternfly/navbar-alt';


### PR DESCRIPTION
Make sure sass files are properly imported

## Description
related to https://github.com/patternfly/patternfly/pull/1152

patternfly-react uses `sassIncludes` from patternfly/dist/sass,
this should ensure that sass files are included in a build and land in the proper place

## Changes

* import the sass file for loading-state

