### PR TITLE
Bump bootstrap-sass gem to 3.4.0

### DIFF
--- a/patternfly-sass.gemspec
+++ b/patternfly-sass.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license  = 'Apache-2.0'
 
   s.add_runtime_dependency 'sass', '~> 3.4.15'
-  s.add_runtime_dependency 'bootstrap-sass', '~> 3.3.7'
+  s.add_runtime_dependency 'bootstrap-sass', '~> 3.4.0'
   s.add_runtime_dependency 'font-awesome-sass', '~> 4.6.2'
 
   s.files = [


### PR DESCRIPTION
Resolves XSS vulnerability

## Description
Resolves XSS vulnerability for patternfly-sass gem.

(optional) Include related PRs, Issues and or Jira stories.
https://github.com/patternfly/patternfly/pull/1157/

## Changes

Write a list of changes the PR introduces

Updates bootstrap-sass

## Link to rawgit and/or image

N/A

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [ ] **Cross browser**: works in Chrome
- [ ] **Cross browser**: works in Firefox
- [ ] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [ ] **Responsive**: works in extra small, small, medium and large view ports.
- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
