### PR TITLE
build(package): Make bootstrap v3.4.0 requirements consistent

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,9 +22,9 @@
     "patternfly.spec.in"
   ],
   "dependencies": {
-    "bootstrap": "~3.3.7",
+    "bootstrap": "~3.4.0",
     "bootstrap-datepicker": "^1.7.1",
-    "bootstrap-sass": "^3.3.7",
+    "bootstrap-sass": "^3.4.0",
     "bootstrap-select": "~1.12.2",
     "bootstrap-slider": "seiyria-bootstrap-slider#^9.9.0",
     "bootstrap-switch": "<=3.3.3",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "optionalDependencies": {
     "@types/c3": "^0.6.0",
     "bootstrap-datepicker": "^1.7.1",
-    "bootstrap-sass": "^3.3.7",
+    "bootstrap-sass": "^3.4.0",
     "bootstrap-select": "1.12.2",
     "bootstrap-slider": "^9.9.0",
     "bootstrap-switch": "~3.3.4",


### PR DESCRIPTION
Previous commit modified only package.json leaving inconsistencies
in bower.json. Also bump the required version of bootstrap-sass
to match.
