### PR TITLE
fix(notification drawer): Fixed tidle-escaped strings in calc

### DIFF
--- a/src/less/notifications-drawer.less
+++ b/src/less/notifications-drawer.less
@@ -217,7 +217,7 @@
     top: @drawer-pf-top-vertical; //menu height;
       @media (max-width: @screen-xs-max) {
         width:100%;
-        height: calc(~"100vh - @{drawer-pf-top-vertical}");
+        height: ~"calc(100vh - @{drawer-pf-top-vertical})";
       }
 
   }
@@ -242,8 +242,8 @@
     border-top: 0;
     @media (max-width: @screen-xs-max) {
       width:100%;
-      height: calc(~"100vh - @{drawer-pf-top-horizontal} - 32px");
-      top:calc(~"@{drawer-pf-top-horizontal} + 10px");
+      height: ~"calc(100vh - @{drawer-pf-top-horizontal} - 32px)";
+      top: ~"calc(@{drawer-pf-top-horizontal} + 10px)";
     }
   }
   .drawer-pf-trigger-icon { cursor: pointer; }

--- a/src/sass/converted/patternfly/_notifications-drawer.scss
+++ b/src/sass/converted/patternfly/_notifications-drawer.scss
@@ -217,7 +217,7 @@
     top: $drawer-pf-top-vertical; //menu height;
       @media (max-width: $screen-xs-max) {
         width:100%;
-        height: calc(unquote("100vh - #{$drawer-pf-top-vertical}"));
+        height: unquote("calc(100vh - #{$drawer-pf-top-vertical})");
       }
 
   }
@@ -242,8 +242,8 @@
     border-top: 0;
     @media (max-width: $screen-xs-max) {
       width:100%;
-      height: calc(unquote("100vh - #{$drawer-pf-top-horizontal} - 32px"));
-      top:calc(unquote("#{$drawer-pf-top-horizontal} + 10px"));
+      height: unquote("calc(100vh - #{$drawer-pf-top-horizontal} - 32px)");
+      top: unquote("calc(#{$drawer-pf-top-horizontal} + 10px)");
     }
   }
   .drawer-pf-trigger-icon { cursor: pointer; }

--- a/src/sass/converted/rcue/_notifications-drawer.scss
+++ b/src/sass/converted/rcue/_notifications-drawer.scss
@@ -217,7 +217,7 @@
     top: $drawer-pf-top-vertical; //menu height;
       @media (max-width: $screen-xs-max) {
         width:100%;
-        height: calc(unquote("100vh - #{$drawer-pf-top-vertical}"));
+        height: unquote("calc(100vh - #{$drawer-pf-top-vertical})");
       }
 
   }
@@ -242,8 +242,8 @@
     border-top: 0;
     @media (max-width: $screen-xs-max) {
       width:100%;
-      height: calc(unquote("100vh - #{$drawer-pf-top-horizontal} - 32px"));
-      top:calc(unquote("#{$drawer-pf-top-horizontal} + 10px"));
+      height: unquote("calc(100vh - #{$drawer-pf-top-horizontal} - 32px)");
+      top: unquote("calc(#{$drawer-pf-top-horizontal} + 10px)");
     }
   }
   .drawer-pf-trigger-icon { cursor: pointer; }


### PR DESCRIPTION
Wrong tidle-escaped strings cause a parsing exception when using the postcss-calc nodejs module.
Those are now fixed as specified in the readme.

## Description
Write a few sentences describing the overall goals of the pull request's commits.

## Changes

* Replaced all `calc(~"...")` with `~"calc(...)"` as specified in the [README](https://github.com/patternfly/patternfly/#tilde-escaped-strings) so that scss files are properly generated. 

## Link to rawgit and/or image

No visual changes.

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [ ] **Cross browser**: works in Chrome
- [ ] **Cross browser**: works in Firefox
- [ ] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [ ] **Responsive**: works in extra small, small, medium and large view ports.
- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
