### PR TITLE
build(package.json): Upgrade jquery to 3.4.0 to address downstream CVE alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bootstrap": "~3.4.0",
     "font-awesome": "^4.7.0",
-    "jquery": "~3.2.1"
+    "jquery": "~3.4.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^3.2.0",


### PR DESCRIPTION
## Description

In ManageIQ, we are seeing an alert in GitHub for a CVE describing a vulnerability in jquery versions below 3.4.0: https://access.redhat.com/security/cve/cve-2019-11358

Because we depend on patternfly-react, which depends on patternfly, we're depending indirectly on jquery@3.2.1 which is causing this alert. This PR upgrades the jquery version in patternfly, so that we can upgrade it in patternfly-react by upgrading patternfly, so that we can upgrade it in ManageIQ repos by upgrading patternfly-react. ⛓ 

According to https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/, this is a safe upgrade:
> There should be no compatibility issues if upgrading from jQuery 3.0+.

## Changes

* Upgrades the `jquery` dependency in package.json from `~3.2.1` to `~3.4.0`.