### PR TITLE
Make donut chart title consistent between Firefox/Chromium

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "bootstrap-sass": "^3.4.0",
     "bootstrap-select": "1.12.2",
     "bootstrap-slider": "^9.9.0",
-    "bootstrap-switch": "~3.3.4",
+    "bootstrap-switch": "3.3.4",
     "bootstrap-touchspin": "~3.1.1",
     "c3": "~0.4.11",
     "d3": "~3.5.17",

--- a/src/js/patternfly-settings-charts.js
+++ b/src/js/patternfly-settings-charts.js
@@ -8,8 +8,8 @@
   patternfly.pfSetDonutChartTitle = function (selector, primary, secondary) {
     var donutChartRightTitle = window.d3.select(selector).select('text.c3-chart-arcs-title');
     donutChartRightTitle.text("");
-    donutChartRightTitle.insert('tspan').text(primary).classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
-    donutChartRightTitle.insert('tspan').text(secondary).classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
+    donutChartRightTitle.insert('tspan').text(primary).classed('donut-title-big-pf', true).attr('y', 0).attr('x', 0);
+    donutChartRightTitle.insert('tspan').text(secondary).classed('donut-title-small-pf', true).attr('y', 20).attr('x', 0);
   };
 
   patternfly.pfDonutTooltipContents = function (d, defaultTitleFormat, defaultValueFormat, color) {

--- a/tests/pages/_includes/widgets/cards/utilization-trend-multiple-metrics.html
+++ b/tests/pages/_includes/widgets/cards/utilization-trend-multiple-metrics.html
@@ -46,8 +46,8 @@
           var chart1 = c3.generate(donutConfig);
           var donutChartTitle = d3.select("#{{include.id3}}").select('text.c3-chart-arcs-title');
           donutChartTitle.text("");
-          donutChartTitle.insert('tspan').text("950").classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
-          donutChartTitle.insert('tspan').text("MHz Used").classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
+          donutChartTitle.insert('tspan').text("950").classed('donut-title-big-pf', true).attr('y', 0).attr('x', 0);
+          donutChartTitle.insert('tspan').text("MHz Used").classed('donut-title-small-pf', true).attr('y', 20).attr('x', 0);
 
           var sparklineConfig = $().c3ChartDefaults().getDefaultSparklineConfig();
           sparklineConfig.bindto = '#{{include.id4}}';
@@ -99,8 +99,8 @@
           var chart3 = c3.generate(donutConfig);
           var donutChartTitle = d3.select("#{{include.id5}}").select('text.c3-chart-arcs-title');
           donutChartTitle.text("");
-          donutChartTitle.insert('tspan').text("176").classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
-          donutChartTitle.insert('tspan').text("GB Used").classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
+          donutChartTitle.insert('tspan').text("176").classed('donut-title-big-pf', true).attr('y', 0).attr('x', 0);
+          donutChartTitle.insert('tspan').text("GB Used").classed('donut-title-small-pf', true).attr('y', 20).attr('x', 0);
 
           var sparklineConfig = $().c3ChartDefaults().getDefaultSparklineConfig();
           sparklineConfig.bindto = '#{{include.id6}}';
@@ -152,8 +152,8 @@
           var chart5 = c3.generate(donutConfig);
           var donutChartTitle = d3.select("#{{include.id7}}").select('text.c3-chart-arcs-title');
           donutChartTitle.text("");
-          donutChartTitle.insert('tspan').text("1100").classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
-          donutChartTitle.insert('tspan').text("Gbps Used").classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
+          donutChartTitle.insert('tspan').text("1100").classed('donut-title-big-pf', true).attr('y', 0).attr('x', 0);
+          donutChartTitle.insert('tspan').text("Gbps Used").classed('donut-title-small-pf', true).attr('y', 20).attr('x', 0);
 
           var sparklineConfig = $().c3ChartDefaults().getDefaultSparklineConfig();
           sparklineConfig.bindto = '#{{include.id8}}';

--- a/tests/pages/_includes/widgets/cards/utilization-trend-single-metric.html
+++ b/tests/pages/_includes/widgets/cards/utilization-trend-single-metric.html
@@ -42,8 +42,8 @@
       var chart1 = c3.generate(donutConfig);
       var donutChartTitle = d3.select("#{{include.id1}}").select('text.c3-chart-arcs-title');
       donutChartTitle.text("");
-      donutChartTitle.insert('tspan').text("1100").classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
-      donutChartTitle.insert('tspan').text("Gbps Used").classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
+      donutChartTitle.insert('tspan').text("1100").classed('donut-title-big-pf', true).attr('y', 0).attr('x', 0);
+      donutChartTitle.insert('tspan').text("Gbps Used").classed('donut-title-small-pf', true).attr('y', 20).attr('x', 0);
 
       var sparklineConfig = c3ChartDefaults.getDefaultSparklineConfig();
       sparklineConfig.bindto = '#{{include.id2}}';


### PR DESCRIPTION
## Description
This PR modifies the SVG styling of Patternfly donut chart titles slightly to use the `y` attribute instead of `dy`, because Firefox treats `dy` on `tspan` elements differently than Chromium.

This PR is intended to address https://github.com/patternfly/patternfly/issues/1168

## Changes

* `<tspan>` elements of the donut chart use the `y` attribute in place of `dy`

## Screenshots

Both screenshots were generated in Firefox 67.

From feature branch, with my fix:
![Patternfly donut charts with space between "big" and "small" title elements](https://user-images.githubusercontent.com/39909293/59435174-055ea400-8dbb-11e9-8df8-799676131f49.png)

From current master branch:
![Patternfly donut charts with no space between "big" and "small" title elements](https://user-images.githubusercontent.com/39909293/59435355-68503b00-8dbb-11e9-84dd-06e0e029bc6f.png)

## PR checklist (if relevant)

- [ ] **Cross browser**: works in IE9
- [ ] **Cross browser**: works in IE10
- [ ] **Cross browser**: works in IE11
- [ ] **Cross browser**: works in Edge
- [x] **Cross browser**: works in Chrome
- [x] **Cross browser**: works in Firefox
- [ ] **Cross browser**: works in Safari
- [ ] **Cross browser**: works in Opera
- [ ] **Responsive**: works in extra small, small, medium and large view ports.
- [ ] **Preview the PR**: An image or a URL for designer to preview this PR is provided.
