### PR TITLE
Fix deprecated use of :first in unit test

### DIFF
--- a/tests/unit/bootstrap-switch.spec.js
+++ b/tests/unit/bootstrap-switch.spec.js
@@ -30,12 +30,12 @@ describe("bootstrap switch test suite", function () {
 
   it('should toggle the first switch to ON', function (done) {
 
-    var onButton = $('.btn-group:first button[data-switch-value="true"]');
+    var onButton = $('.btn-group').first().find('button[data-switch-value="true"]').first();
 
     onButton.click();
 
     setTimeout(function () {
-      var switch1 = $('.bootstrap-switch:first');
+      var switch1 = $('.bootstrap-switch').first();
       expect(switch1).toHaveClass('bootstrap-switch-on');
       done();
     }, globals.wait);


### PR DESCRIPTION
## Description
Recent pull requests on Patternfly are failing because of the same unit test, and a comment suggests this may be due to a deprecated jQuery selector in one of the tests: https://github.com/patternfly/patternfly/pull/1174#issuecomment-497004617

When I run unit tests locally, they *all* fail, so I'm opening a pull request to see removing the `:first` selector from that test makes it pass in Travis CI.

## Changes

* Replace uses of the deprecated `:first` selector in a specific unit test
