### PR TITLE
build(package.json): Fix bootstrap-switch version to 3.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "bootstrap-sass": "^3.4.0",
     "bootstrap-select": "1.12.2",
     "bootstrap-slider": "^9.9.0",
-    "bootstrap-switch": "~3.3.4",
+    "bootstrap-switch": "3.3.4",
     "bootstrap-touchspin": "~3.1.1",
     "c3": "~0.4.11",
     "d3": "~3.5.17",


### PR DESCRIPTION
## Description
A bootstrap-switch unit test has been failing in Travis CI because a more recent version of
bootstrap-switch breaks the test. Therefore this commit fixes the bootstrap-switch version to 3.3.4
exactly.

## Changes

* Changes bootstrap-switch version in `package.json`