### PR TITLE
build(package): Replace SASS with SASSC in the patternfly-sass gem

### DIFF
--- a/lib/patternfly-sass.rb
+++ b/lib/patternfly-sass.rb
@@ -55,7 +55,7 @@ module Patternfly
     private
 
     def configure_sass
-      require 'sass'
+      require 'sassc'
 
       ::Sass.load_paths << stylesheets_path
 

--- a/patternfly-sass.gemspec
+++ b/patternfly-sass.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/Patternfly/patternfly'
   s.license  = 'Apache-2.0'
 
-  s.add_runtime_dependency 'sass', '~> 3.4.15'
+  s.add_runtime_dependency 'sassc', '~> 3.6.1'
   s.add_runtime_dependency 'bootstrap-sass', '~> 3.4.0'
   s.add_runtime_dependency 'font-awesome-sass', '~> 4.6.2'
 


### PR DESCRIPTION
SASS became EOL in favor of SASSC http://sass.logdown.com/posts/7081811

cc @simaishi @himdel @epwinchell @jeff-phillips-18 