### PR TITLE
Add main field in package.json for easier import

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-semantically-released",
   "author": "Red Hat",
   "license": "MIT",
+  "main": "dist/js/patternfly.js",
   "dependencies": {
     "bootstrap": "~3.4.1",
     "font-awesome": "^4.7.0",


### PR DESCRIPTION
Added the missing "main" field in package.json for easier import/require by other packages.

## Description
When trying to import patternfly in my project using Webpack Encore, the `require('patternfly')` instruction gave me a dependency not found error.
I figured out this is because patternfly's package.json has no "main" field, so I had to dig into the package folders to get the full path and then write `require('patternfly/dist/js/patternfly.js')` instead.

This PR is about fixing this, so that it's possible to import/require patternfly the first and better way.

## Changes

* Added "main" field in package.json, pointing to `dist/js/patternfly.js`
