### PR TITLE
Added package.json to list of the file in the gemspec explicitly

### DIFF
--- a/patternfly-sass.gemspec
+++ b/patternfly-sass.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.files = [
     'patternfly-sass.gemspec',
+    'package.json',
     'LICENSE.txt',
     'README.md',
     'CODE_OF_CONDUCT.md',


### PR DESCRIPTION
## Description
add package.json to list of the files in the gemspec explicitly, because it is required by version.rb
