### PR TITLE
fix(deps): sass -> sassc switch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
 install: true
 
 script:
+  - gem install bundler:1.15.4
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -p
 
 after_success:

--- a/lib/patternfly-sass.rb
+++ b/lib/patternfly-sass.rb
@@ -55,12 +55,12 @@ module Patternfly
     private
 
     def configure_sass
-      require 'sass'
+      require 'sassc'
 
-      ::Sass.load_paths << stylesheets_path
+      ::SassC.load_paths << stylesheets_path
 
       # bootstrap requires minimum precision of 8, see https://github.com/twbs/bootstrap-sass/issues/409
-      ::Sass::Script::Number.precision = [8, ::Sass::Script::Number.precision].max
+      ::SassC::Script::Value::Number.precision = [8, ::SassC::Script::Value::Number.precision].max
     end
 
     def register_compass_extension

--- a/patternfly-sass.gemspec
+++ b/patternfly-sass.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/Patternfly/patternfly'
   s.license  = 'Apache-2.0'
 
-  s.add_runtime_dependency 'sass', '~> 3.4.15'
+  s.add_runtime_dependency 'sassc', "> 2.0.1", "< 3.0"
   s.add_runtime_dependency 'bootstrap-sass', '~> 3.4.0'
   s.add_runtime_dependency 'font-awesome-sass', '~> 4.6.2'
 


### PR DESCRIPTION
## Description
The `sass` gem is now deprecated and it's highly encouraged to move to the `sassc`.

As bootstrap already moved in https://github.com/twbs/bootstrap-sass/commit/dcdef9bfd81a9821d775417dbdab4c5df3553ba2#diff-3dabc815e5a509f3166ca40cd58772da, the precision fixes probably don't even work now.

Once we move to font-awesome-sass 5, we would be the only one depending on `sass`, what is not situation we want I believe :)

## Changes
* Switch from `sass` to `sassc`
